### PR TITLE
feat: Vaults 一覧 & 詳細ページ + LP Deposit / Withdraw UI (Issue #162)

### DIFF
--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -29,10 +29,12 @@ import Referrals from "pages/Referrals/Referrals";
 import ReferralsTier from "pages/ReferralsTier/ReferralsTier";
 import { SyntheticsPage } from "pages/SyntheticsPage/SyntheticsPage";
 import { SyntheticsStats } from "pages/SyntheticsStats/SyntheticsStats";
+import VantageLPPage from "pages/VantageLP/VantageLPPage";
+import VaultDetailPage from "pages/VaultDetail/VaultDetailPage";
+import VaultsPage from "pages/Vaults/VaultsPage";
 
 import { EarnRedirect } from "components/Earn/EarnRedirect";
 import { RedirectWithQuery } from "components/RedirectWithQuery/RedirectWithQuery";
-import VantageLPPage from "pages/VantageLP/VantageLPPage";
 
 const LazyUiPage = lazy(() => import("pages/UiPage/UiPage"));
 const UiPage = () => (
@@ -162,6 +164,12 @@ export function MainRoutes({ openSettings }: { openSettings: () => void }) {
       </Route>
       <Route exact path="/vantage-lp">
         <VantageLPPage />
+      </Route>
+      <Route exact path="/vaults">
+        <VaultsPage />
+      </Route>
+      <Route exact path="/vaults/:address">
+        <VaultDetailPage />
       </Route>
       <Route exact path="/jobs">
         <Jobs />

--- a/src/domain/vantage/vaults/useVaultActions.ts
+++ b/src/domain/vantage/vaults/useVaultActions.ts
@@ -1,0 +1,217 @@
+/**
+ * useVaultActions.ts
+ *
+ * Transaction hooks for Vault LP deposit and withdraw.
+ * Mirrors useVantageLPActions but works with any VaultConfig (all 4 vaults).
+ *
+ *   deposit(amount)
+ *     approve token to LPManager (if needed) → LPManager.addLiquidity
+ *
+ *   withdraw(shares)
+ *     LPManager.removeLiquidity  (no approve needed — LPManager burns VLP)
+ */
+
+import { t } from "@lingui/macro";
+import { Contract, ethers } from "ethers";
+import { useCallback, useMemo, useState } from "react";
+import { maxUint256 } from "viem";
+
+import { DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
+import { usePendingTxns } from "context/PendingTxnsContext/PendingTxnsContext";
+import { useTokensAllowanceData } from "domain/synthetics/tokens/useTokenAllowanceData";
+import { pushSuccessNotification } from "lib/contracts/notifications";
+import { helperToast } from "lib/helperToast";
+import useWallet from "lib/wallets/useWallet";
+import TokenAbi from "sdk/abis/Token";
+import type { AnyChainId } from "sdk/configs/chains";
+import LPManagerAbi from "vantage/abis/LPManager.json";
+
+import type { VaultConfig } from "./vaultConfig";
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETTLEMENT_CHAIN_ID) {
+  const { account, signer } = useWallet();
+  const { setPendingTxns } = usePendingTxns();
+
+  const lpManager = useMemo(
+    () => (signer ? new Contract(cfg.lpManagerAddress, LPManagerAbi, signer) : null),
+    [signer, cfg.lpManagerAddress]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Approval state
+  // ---------------------------------------------------------------------------
+
+  const [approvingToken, setApprovingToken] = useState<string | undefined>();
+
+  const { tokensAllowanceData, isLoading: isAllowanceLoading } = useTokensAllowanceData(chainId as AnyChainId, {
+    spenderAddress: cfg.lpManagerAddress,
+    tokenAddresses: cfg.tokenAddress ? [cfg.tokenAddress] : [],
+  });
+
+  const isApprovalNeeded = useCallback(
+    (amount: bigint): boolean => {
+      if (!tokensAllowanceData) return true;
+      const allowance = tokensAllowanceData[cfg.tokenAddress];
+      if (allowance === undefined) return true;
+      return allowance < amount;
+    },
+    [tokensAllowanceData, cfg.tokenAddress]
+  );
+
+  const approve = useCallback(async (): Promise<void> => {
+    if (!signer) return;
+    setApprovingToken(cfg.tokenAddress);
+    try {
+      const contract = new Contract(cfg.tokenAddress, TokenAbi, signer);
+      const tx = await contract.approve(cfg.lpManagerAddress, maxUint256);
+      helperToast.info(t`Approval submitted — waiting for confirmation…`);
+      await tx.wait();
+    } finally {
+      setApprovingToken(undefined);
+    }
+  }, [signer, cfg.tokenAddress, cfg.lpManagerAddress]);
+
+  // ---------------------------------------------------------------------------
+  // Deposit
+  // ---------------------------------------------------------------------------
+
+  const deposit = useCallback(
+    async (amount: bigint): Promise<void> => {
+      if (!account || !signer || !lpManager) {
+        helperToast.error(t`Wallet not connected`);
+        return;
+      }
+
+      if (isApprovalNeeded(amount)) {
+        await approve();
+      }
+
+      try {
+        const tx = await lpManager.addLiquidity(cfg.tokenAddress, amount);
+        helperToast.info(t`Transaction submitted`);
+        setPendingTxns((prev) => [...prev, { hash: tx.hash, message: t`Adding liquidity...` }]);
+        const receipt = await tx.wait();
+        if (receipt) {
+          pushSuccessNotification(chainId, t`Liquidity added`, { transactionHash: receipt.hash });
+        }
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [account, signer, lpManager, cfg.tokenAddress, isApprovalNeeded, approve, chainId, setPendingTxns]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Withdraw
+  // ---------------------------------------------------------------------------
+
+  const withdraw = useCallback(
+    async (shares: bigint): Promise<void> => {
+      if (!account || !signer || !lpManager) {
+        helperToast.error(t`Wallet not connected`);
+        return;
+      }
+
+      try {
+        const tx = await lpManager.removeLiquidity(shares, cfg.tokenAddress, 0n);
+        helperToast.info(t`Transaction submitted`);
+        setPendingTxns((prev) => [...prev, { hash: tx.hash, message: t`Removing liquidity...` }]);
+        const receipt = await tx.wait();
+        if (receipt) {
+          pushSuccessNotification(chainId, t`Liquidity removed`, { transactionHash: receipt.hash });
+        }
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [account, signer, lpManager, cfg.tokenAddress, chainId, setPendingTxns]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Debug: Rebase (Rebasing vault only)
+  // ---------------------------------------------------------------------------
+
+  const debugRebase = useCallback(
+    async (basisPoints: number): Promise<void> => {
+      if (!signer) return;
+      try {
+        const MockRebasingRWAAbi = (await import("vantage/abis/MockRebasingRWA.json")).default;
+        const token = new Contract(cfg.tokenAddress, MockRebasingRWAAbi, signer);
+        const tx = await (
+          token as ethers.Contract & { rebaseByUI: (bp: number) => Promise<{ wait: () => Promise<unknown> }> }
+        ).rebaseByUI(basisPoints);
+        await tx.wait();
+        helperToast.success(t`Rebase +${basisPoints / 100}% applied`);
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [signer, cfg.tokenAddress]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Debug: Set price (PriceShare / Direct vault)
+  // ---------------------------------------------------------------------------
+
+  const debugSetPrice = useCallback(
+    async (newPrice: bigint): Promise<void> => {
+      if (!signer) return;
+      try {
+        const MockPriceFeedAbi = (await import("vantage/abis/MockPriceFeed.json")).default;
+        const localhostDeploy = (await import("vantage/deployments/frontend-localhost.json")).default;
+        const feedAddr = (localhostDeploy.addresses as { MockPriceFeed?: string }).MockPriceFeed ?? "";
+        if (!feedAddr) return;
+        const feed = new Contract(feedAddr, MockPriceFeedAbi, signer);
+        const tx = await (
+          feed as ethers.Contract & {
+            setPrice: (token: string, price: bigint) => Promise<{ wait: () => Promise<unknown> }>;
+          }
+        ).setPrice(cfg.tokenAddress, newPrice);
+        await tx.wait();
+        helperToast.success(t`Price updated`);
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [signer, cfg.tokenAddress]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Debug: Mint tokens to user (testnet only)
+  // ---------------------------------------------------------------------------
+
+  const debugMint = useCallback(
+    async (amount: bigint): Promise<void> => {
+      if (!signer || !account) return;
+      try {
+        const MockERC20Abi = (await import("vantage/abis/MockERC20.json")).default;
+        const token = new Contract(cfg.tokenAddress, MockERC20Abi, signer);
+        const tx = await (
+          token as ethers.Contract & { mint: (to: string, amount: bigint) => Promise<{ wait: () => Promise<unknown> }> }
+        ).mint(account, amount);
+        await tx.wait();
+        helperToast.success(t`Minted tokens to your wallet`);
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [signer, account, cfg.tokenAddress]
+  );
+
+  return {
+    deposit,
+    withdraw,
+    approve,
+    debugRebase,
+    debugSetPrice,
+    debugMint,
+    isApprovalNeeded,
+    isAllowanceLoading,
+    isApproving: Boolean(approvingToken),
+    isReady: Boolean(account && signer),
+  };
+}

--- a/src/domain/vantage/vaults/useVaultDetail.ts
+++ b/src/domain/vantage/vaults/useVaultDetail.ts
@@ -1,0 +1,142 @@
+/**
+ * useVaultDetail.ts
+ *
+ * Fetches on-chain state for a single vault detail page:
+ *   - AUM, share price
+ *   - Token price from MockPriceFeed (for PriceShare / Direct)
+ *   - User's VLP balance and USD value
+ *   - User's shortfall debt (Issue #124 solvency framework)
+ *   - User's token balance (for Rebasing: polls every 5s for real-time update)
+ *   - Historical AUM data points (stored in-memory, reset on mount)
+ *
+ * For Rebasing vaults, token balance is polled every 5 s to show live updates.
+ * For all other vaults, the shared 15 s poll is used.
+ */
+
+import { Contract } from "ethers";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+import LPManagerAbi from "vantage/abis/LPManager.json";
+import LPTokenAbi from "vantage/abis/LPToken.json";
+import MockERC20Abi from "vantage/abis/MockERC20.json";
+import MockPriceFeedAbi from "vantage/abis/MockPriceFeed.json";
+import VaultAbi from "vantage/abis/Vault.json";
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
+
+import type { VaultConfig } from "./vaultConfig";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AumDataPoint {
+  timestamp: number; // ms epoch
+  aum: bigint;
+}
+
+export interface VaultDetailData {
+  aum: bigint;
+  sharePrice: bigint;
+  tokenPrice: bigint; // 1e18 — current price from MockPriceFeed
+  vlpBalance: bigint; // user's LP token balance
+  usdValue: bigint; // user's position in USD WAD
+  tokenBalance: bigint; // user's underlying token balance
+  shortfall: bigint; // user's shortfall debt for this token
+  aumHistory: AumDataPoint[];
+  isLoading: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const WAD = BigInt("1000000000000000000");
+const POLL_INTERVAL_MS = 15_000;
+const REBASING_POLL_MS = 5_000;
+const MAX_HISTORY_POINTS = 50;
+
+const d = localhostDeployment.addresses as { MockPriceFeed?: string };
+const MOCK_PRICE_FEED = d.MockPriceFeed ?? "";
+
+export function useVaultDetail(cfg: VaultConfig): VaultDetailData {
+  const { account } = useWallet();
+  const provider = getProvider(undefined, DEFAULT_SETTLEMENT_CHAIN_ID);
+
+  const [data, setData] = useState<VaultDetailData>({
+    aum: 0n,
+    sharePrice: WAD,
+    tokenPrice: WAD,
+    vlpBalance: 0n,
+    usdValue: 0n,
+    tokenBalance: 0n,
+    shortfall: 0n,
+    aumHistory: [],
+    isLoading: true,
+  });
+
+  const aumHistoryRef = useRef<AumDataPoint[]>([]);
+
+  const fetch = useCallback(async () => {
+    try {
+      const vault = new Contract(cfg.vaultAddress, VaultAbi, provider);
+      const lpManager = new Contract(cfg.lpManagerAddress, LPManagerAbi, provider);
+      const lpToken = new Contract(cfg.lpTokenAddress, LPTokenAbi, provider);
+      const token = new Contract(cfg.tokenAddress, MockERC20Abi, provider);
+
+      const fetchPromises: Promise<unknown>[] = [
+        vault.getAUM(),
+        lpManager.getSharePrice(),
+        account ? lpToken.balanceOf(account) : Promise.resolve(0n),
+        account ? token.balanceOf(account) : Promise.resolve(0n),
+        account ? vault.userShortfallDebt(account, cfg.tokenAddress) : Promise.resolve(0n),
+      ];
+
+      // Fetch token price from MockPriceFeed for PriceShare / Direct vaults
+      let tokenPrice: bigint = WAD;
+      if (MOCK_PRICE_FEED && (cfg.assetType === 0 || cfg.assetType === 2)) {
+        const feed = new Contract(MOCK_PRICE_FEED, MockPriceFeedAbi, provider);
+        try {
+          tokenPrice = (await feed.prices(cfg.tokenAddress)) as bigint;
+          if (tokenPrice === 0n) tokenPrice = WAD;
+        } catch {
+          tokenPrice = WAD;
+        }
+      }
+
+      const [aum, sharePrice, vlpBalance, tokenBalance, shortfall] = (await Promise.all(fetchPromises)) as bigint[];
+
+      const usdValue = (vlpBalance * sharePrice) / WAD;
+
+      // Append AUM to history
+      const point: AumDataPoint = { timestamp: Date.now(), aum };
+      aumHistoryRef.current = [...aumHistoryRef.current.slice(-MAX_HISTORY_POINTS + 1), point];
+
+      setData({
+        aum,
+        sharePrice,
+        tokenPrice,
+        vlpBalance,
+        usdValue,
+        tokenBalance,
+        shortfall,
+        aumHistory: [...aumHistoryRef.current],
+        isLoading: false,
+      });
+    } catch {
+      setData((prev) => ({ ...prev, isLoading: false }));
+    }
+  }, [cfg, account, provider]);
+
+  useEffect(() => {
+    aumHistoryRef.current = [];
+    fetch();
+    const interval = cfg.assetType === 1 ? REBASING_POLL_MS : POLL_INTERVAL_MS;
+    const timer = setInterval(fetch, interval);
+    return () => clearInterval(timer);
+  }, [fetch, cfg.assetType]);
+
+  return data;
+}

--- a/src/domain/vantage/vaults/useVaultList.ts
+++ b/src/domain/vantage/vaults/useVaultList.ts
@@ -1,0 +1,89 @@
+/**
+ * useVaultList.ts
+ *
+ * Fetches on-chain state for all 4 vaults (AUM, LP share price, user deposit)
+ * and returns a list ready for the Vaults list page.
+ *
+ * Polling interval: 15 seconds.
+ */
+
+import { Contract } from "ethers";
+import { useCallback, useEffect, useState } from "react";
+
+import { DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+import LPManagerAbi from "vantage/abis/LPManager.json";
+import LPTokenAbi from "vantage/abis/LPToken.json";
+import VaultAbi from "vantage/abis/Vault.json";
+
+import { VAULT_CONFIGS, type VaultConfig } from "./vaultConfig";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VaultListItem extends VaultConfig {
+  aum: bigint;
+  sharePrice: bigint;
+  vlpBalance: bigint; // user's VLP shares (0 if wallet not connected)
+  usdValue: bigint; // user's position in USD WAD
+  isLoading: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const WAD = BigInt("1000000000000000000");
+const POLL_INTERVAL_MS = 15_000;
+
+export function useVaultList(): VaultListItem[] {
+  const { account } = useWallet();
+  const provider = getProvider(undefined, DEFAULT_SETTLEMENT_CHAIN_ID);
+
+  const buildInitial = (): VaultListItem[] =>
+    VAULT_CONFIGS.map((cfg) => ({
+      ...cfg,
+      aum: 0n,
+      sharePrice: WAD,
+      vlpBalance: 0n,
+      usdValue: 0n,
+      isLoading: true,
+    }));
+
+  const [items, setItems] = useState<VaultListItem[]>(buildInitial);
+
+  const fetchAll = useCallback(async () => {
+    const results = await Promise.all(
+      VAULT_CONFIGS.map(async (cfg): Promise<VaultListItem> => {
+        try {
+          const vault = new Contract(cfg.vaultAddress, VaultAbi, provider);
+          const lpManager = new Contract(cfg.lpManagerAddress, LPManagerAbi, provider);
+          const lpToken = new Contract(cfg.lpTokenAddress, LPTokenAbi, provider);
+
+          const [aum, sharePrice, vlpBalance] = await Promise.all([
+            vault.getAUM() as Promise<bigint>,
+            lpManager.getSharePrice() as Promise<bigint>,
+            account ? (lpToken.balanceOf(account) as Promise<bigint>) : Promise.resolve(0n),
+          ]);
+
+          const usdValue = (vlpBalance * sharePrice) / WAD;
+
+          return { ...cfg, aum, sharePrice, vlpBalance, usdValue, isLoading: false };
+        } catch {
+          return { ...cfg, aum: 0n, sharePrice: WAD, vlpBalance: 0n, usdValue: 0n, isLoading: false };
+        }
+      })
+    );
+    setItems(results);
+  }, [account, provider]);
+
+  useEffect(() => {
+    fetchAll();
+    const timer = setInterval(fetchAll, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [fetchAll]);
+
+  return items;
+}

--- a/src/domain/vantage/vaults/vaultConfig.ts
+++ b/src/domain/vantage/vaults/vaultConfig.ts
@@ -1,0 +1,133 @@
+/**
+ * vaultConfig.ts
+ *
+ * Static configuration for the 4 supported Vaults:
+ *   USDC (stable), mBUIDL (Rebasing), mUSDY (PriceShare), mRWA (Direct)
+ *
+ * Addresses are resolved from the deployment JSON at runtime so this file
+ * remains network-agnostic. For localhost these come from frontend-localhost.json.
+ */
+
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
+
+// ---------------------------------------------------------------------------
+// Asset type IDs (mirrors Solidity assetType())
+// ---------------------------------------------------------------------------
+
+export type AssetTypeId = 0 | 1 | 2 | "stable";
+
+export interface VaultConfig {
+  /** Unique key used in URLs and as React key */
+  key: string;
+  /** Display name */
+  name: string;
+  /** Token symbol shown in the UI */
+  symbol: string;
+  /** Asset type: 1=Rebasing, 2=PriceShare, 0=Direct, "stable"=USDC */
+  assetType: AssetTypeId;
+  /** Vault contract address */
+  vaultAddress: string;
+  /** Underlying token address */
+  tokenAddress: string;
+  /** LPManager address for this vault */
+  lpManagerAddress: string;
+  /** LPToken (VLP) address for this vault */
+  lpTokenAddress: string;
+  /** Token decimals (18 for Mock RWAs, 6 for USDC) */
+  tokenDecimals: number;
+  /** Whether this vault is a mock (testnet only) */
+  isMock: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Build vault list from deployment JSON
+// ---------------------------------------------------------------------------
+
+const d = localhostDeployment.addresses as {
+  Vault?: string;
+  LPManager?: string;
+  LPToken?: string;
+  tokens?: Record<string, string>;
+  mockRWA?: Record<string, string>;
+  mockRWAVaults?: Record<string, string>;
+  mockRWALPManagers?: Record<string, string>;
+  mockRWALPTokens?: Record<string, string>;
+};
+
+export const VAULT_CONFIGS: VaultConfig[] = [
+  // ── USDC (stable) ────────────────────────────────────────────────────────
+  {
+    key: "usdc",
+    name: "USDC Vault",
+    symbol: "USDC",
+    assetType: "stable",
+    vaultAddress: d.Vault ?? "",
+    tokenAddress: d.tokens?.USDC ?? "",
+    lpManagerAddress: d.LPManager ?? "",
+    lpTokenAddress: d.LPToken ?? "",
+    tokenDecimals: 6,
+    isMock: false,
+  },
+  // ── mBUIDL (Rebasing) ────────────────────────────────────────────────────
+  {
+    key: "mBUIDL",
+    name: "mBUIDL Vault",
+    symbol: "mBUIDL",
+    assetType: 1,
+    vaultAddress: d.mockRWAVaults?.Rebasing ?? "",
+    tokenAddress: d.mockRWA?.Rebasing ?? "",
+    lpManagerAddress: d.mockRWALPManagers?.Rebasing ?? "",
+    lpTokenAddress: d.mockRWALPTokens?.Rebasing ?? "",
+    tokenDecimals: 18,
+    isMock: true,
+  },
+  // ── mUSDY (PriceShare) ───────────────────────────────────────────────────
+  {
+    key: "mUSDY",
+    name: "mUSDY Vault",
+    symbol: "mUSDY",
+    assetType: 2,
+    vaultAddress: d.mockRWAVaults?.PriceShare ?? "",
+    tokenAddress: d.mockRWA?.PriceShare ?? "",
+    lpManagerAddress: d.mockRWALPManagers?.PriceShare ?? "",
+    lpTokenAddress: d.mockRWALPTokens?.PriceShare ?? "",
+    tokenDecimals: 18,
+    isMock: true,
+  },
+  // ── mRWA (Direct) ────────────────────────────────────────────────────────
+  {
+    key: "mRWA",
+    name: "mRWA Vault",
+    symbol: "mRWA",
+    assetType: 0,
+    vaultAddress: d.mockRWAVaults?.Direct ?? "",
+    tokenAddress: d.mockRWA?.Direct ?? "",
+    lpManagerAddress: d.mockRWALPManagers?.Direct ?? "",
+    lpTokenAddress: d.mockRWALPTokens?.Direct ?? "",
+    tokenDecimals: 18,
+    isMock: true,
+  },
+];
+
+/** Returns the VaultConfig for a given vault address (case-insensitive). */
+export function getVaultConfigByAddress(address: string): VaultConfig | undefined {
+  return VAULT_CONFIGS.find((v) => v.vaultAddress.toLowerCase() === address.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Type badge colors
+// ---------------------------------------------------------------------------
+
+export const ASSET_TYPE_LABEL: Record<AssetTypeId, string> = {
+  1: "Rebasing",
+  2: "PriceShare",
+  0: "Direct",
+  stable: "Stable",
+};
+
+export const ASSET_TYPE_COLOR: Record<AssetTypeId, string> = {
+  1: "bg-emerald-900/60 text-emerald-300 border border-emerald-700",
+  2: "bg-blue-900/60 text-blue-300 border border-blue-700",
+  0: "bg-orange-900/60 text-orange-300 border border-orange-700",
+  stable: "bg-slate-700/60 text-slate-300 border border-slate-600",
+};

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -25,6 +25,8 @@ msgstr "Slippage überschritten"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "Preiseinfluss beim Schließen. Positive Werte kommen Ihnen zugute. <0>Me
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "Typ"
 
@@ -442,6 +445,10 @@ msgstr "GMX Account Guthaben"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "Bester Swap-Pfad"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "{nativeTokenSymbol} von anderen Netzwerken auf {chainName} übertragen"
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "Statistiken"
 
@@ -831,6 +839,10 @@ msgstr "STIP.b retroaktiver Bonus"
 msgid "in liquidity"
 msgstr "In Liquidität"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "Dezentraler Geldmarkt"
@@ -868,6 +880,10 @@ msgstr "Telegram-Kontakt (optional)"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "Konvertierungserstellung fehlgeschlagen"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "Tokens"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "Ausführungspreis der Order"
 msgid "Market temporarily disabled"
 msgstr "Markt vorübergehend deaktiviert"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "Shift-Fehler"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Layer 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0}-Order für"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "Max"
 
@@ -2628,6 +2651,10 @@ msgstr "Tokenkategorien"
 msgid "You have not traded during the selected period"
 msgstr "Sie haben im ausgewählten Zeitraum nicht gehandelt"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Standardanzahl der Teile für TWAP-Orders"
@@ -2715,6 +2742,10 @@ msgstr "Täglicher Gewinn"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "Eingezahlt {0} in {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "Wir schätzen Ihr Feedback"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>Einzahlen</0> oder <1>kaufen</1> {wrappedNativeTokenSymbol}."
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "Ordertyp"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "Ändern zu {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "Es ist nur ein Unwrap"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "Handelsbestätigungen"
 msgid "Insufficient GLV liquidity"
 msgstr "Unzureichende GLV-Liquidität"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "Bei Auslösung kann für Teile dieser Order unzureichende Liquidität vorhanden sein"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "Order storniert"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "Ann. Performance"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "GMX abheben und freigeben"
@@ -3668,6 +3719,10 @@ msgstr "Keine Einzahlungen erforderlich"
 msgid "Trading airdrop"
 msgstr "Handels-Airdrop"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "{0} Ereignisse in den letzten {DAYS_BACK} Tagen gefunden"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "in {0}"
 msgid "{positionName} fees settled"
 msgstr "{positionName}-Gebühren beglichen"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Preiseinflussrückvergütungen aufgelaufen. Nach 5 Tagen beanspruchbar. <0>Mehr erfahren</0>."
@@ -4584,6 +4648,8 @@ msgstr "Externe Swaps fehlschlagen lassen"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "Abheben"
 
@@ -4625,6 +4691,10 @@ msgstr "Positionsgröße zu klein"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "Bonus-APR"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "Open Interest {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "Empfehlungscode hinzugefügt"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Kaufen Sie GMX-Bonds auf Bond Protocol mit einem Rabatt und einer kurzen Sperrfrist"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "Einlösen von Mitteln fehlgeschlagen"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "Kauf fehlgeschlagen"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "Benutzer"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "Keine Trades entsprechen den ausgewählten Filtern"
 msgid "Decreased"
 msgstr "Verringert"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "Erzielt Gebühren aus der Liquiditätsbereitstellung über GMX V2 Märkte"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "{balanceFormatted} verbleibend im alten 1CT-Unterkonto"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "Short Liq."
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Liquidationsgebühr"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "Akzeptabler Preis der Order"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "Aktualisierung von {updateOrdersCount} TP/SL Orders..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "Ausführungspreis hat den akzeptablen Preis nicht erreicht"
@@ -6487,6 +6581,10 @@ msgstr "Warnung: Ausführung möglicherweise nicht möglich aufgrund geringer Li
 msgid "Cancel TWAP Swap"
 msgstr "TWAP-Swap stornieren"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "Transaktion"
@@ -6574,6 +6672,7 @@ msgstr "Orderfehler. Die Preise in diesem Markt sind volatil, versuchen Sie es e
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Asset"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} abgebrochen"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "PnL nach Gebühren anzeigen"
 msgid "Share position"
 msgstr "Position teilen"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "Wechseln Sie zu <0><1/><2>Arbitrum</2></0> oder <3><4/><5>Avalanche</5></3> für diese Funktionen"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>Zurück zu </0><1>Homepage</1> <2>oder </2> <3>Trade</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "Einzahlungsbetrag eingeben"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "{0} genehmigen"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Balance"
 
@@ -7407,6 +7514,10 @@ msgstr "Kauforder ausgeführt"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "Keine Ergebnisse für Ihre Suche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "Gleich wie der derzeit aktive Code"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "Handeln Sie über Wallet oder GMX Account"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "weniger als eine Minute"
 msgid "Ecosystem"
 msgstr "Ökosystem"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "Weiter"
@@ -7676,8 +7795,13 @@ msgstr "Swap {fromAmount} für {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Betrag"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "SL-Preis über dem Limitpreis"
 msgid "for {comment}"
 msgstr "für {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "Kaufanfrage wird ausgeführt…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "GM-Kauf fehlgeschlagen"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "GM mit {0} und {1} kaufen bis zu den unten angegebenen Limits"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Einzahlung"
 
@@ -8207,6 +8341,10 @@ msgstr "Dezentralisierter permissionless On-Chain-Exchange mit tiefer Liquiditä
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "GESAMTVOLUMEN"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "Erhalten"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "Was ist GMX?"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "{tokenSymbol} staken"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "Link in die Zwischenablage kopiert"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "In Bearbeitung..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "Netzwerk für Ihr GMX Account und Ihre Positionen. Guthaben und Position
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Liquidität nur verfügbar auf {chainNames} oder {lastChainName}. Wechseln Sie das Netzwerk, um fortzufahren."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "Gesamtes Handelsvolumen Ihrer Empfehlungen"
@@ -9973,7 +10122,13 @@ msgstr "Empfehlungscode generieren"
 msgid "NET VALUE"
 msgstr "NETTOWERT"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "Transaktionen simulieren"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "Unbekannte Order"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -25,6 +25,8 @@ msgstr "Slippage exceeded"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "Price impact from closing. Positive values benefit you. <0>Read more</0>
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "Type"
 
@@ -442,6 +445,10 @@ msgstr "GMX Account balance"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "Best swap path"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr "Connect your wallet to see your deposits."
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "Transfer {nativeTokenSymbol} from other networks to {chainName}"
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "Stats"
 
@@ -831,6 +839,10 @@ msgstr "STIP.b retroactive bonus"
 msgid "in liquidity"
 msgstr "in liquidity"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "Decentralized money market"
@@ -868,6 +880,10 @@ msgstr "Telegram contact (optional)"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "Conversion creation failed"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr "Rebase +{0}% applied"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "Tokens"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr "Connect wallet to withdraw"
 
@@ -2026,6 +2043,10 @@ msgstr "Execution price for the order"
 msgid "Market temporarily disabled"
 msgstr "Market temporarily disabled"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr "Auto-growing"
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "Shift error"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Layer 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr "Approving…"
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} order for"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "Max"
 
@@ -2628,6 +2651,10 @@ msgstr "Token categories"
 msgid "You have not traded during the selected period"
 msgstr "You have not traded during the selected period"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr "Token Balance"
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Default parts for TWAP orders"
@@ -2715,6 +2742,10 @@ msgstr "Daily profit"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "Deposited {0} into {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr "Price Yield"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "We value your feedback"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr "Price updated"
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "Order type"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr "Transaction submitted"
 
@@ -3198,6 +3235,10 @@ msgstr "Change to {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "It's just an unwrap"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr "Debug Panel"
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "Trade confirmations"
 msgid "Insufficient GLV liquidity"
 msgstr "Insufficient GLV liquidity"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr "My Deposit"
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "May lack liquidity for parts of this order when triggered"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr "Withdrawing…"
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "Order canceled"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr "Connect wallet to deposit"
 
@@ -3617,6 +3664,10 @@ msgstr "Ann. performance"
 msgid "Closing position..."
 msgstr "Closing position..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr "Collecting data…"
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "Withdraw and unreserve GMX"
@@ -3668,6 +3719,10 @@ msgstr "No deposits required"
 msgid "Trading airdrop"
 msgstr "Trading airdrop"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr "Price +10%"
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "Found {0} events in the past {DAYS_BACK} days"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr "AUM"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "in {0}"
 msgid "{positionName} fees settled"
 msgstr "{positionName} fees settled"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr "Price -20%"
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
@@ -4584,6 +4648,8 @@ msgstr "Fail external swaps"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "Withdraw"
 
@@ -4625,6 +4691,10 @@ msgstr "Position size too small"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "Bonus APR"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr "+5% Rebase"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "Open interest {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr "Amount exceeds your VLP balance"
 
@@ -4923,6 +4994,10 @@ msgstr "Referral code added"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "Failed to claim funds"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr "Depositing…"
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "Buy failed"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr "USD value"
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "Users"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr "Total AUM"
 
@@ -5801,6 +5879,10 @@ msgstr "No trades match the selected filters"
 msgid "Decreased"
 msgstr "Decreased"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr "Provide liquidity to earn yield from RWA assets."
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "Earns fees from liquidity provision across GMX V2 markets"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "{balanceFormatted} remaining in old 1CT subaccount"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr "Shortfall Debt"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "Short liq."
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Liquidation fee"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr "No vaults configured. Deploy contracts first."
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "Order acceptable price"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "Updating {updateOrdersCount} TP/SL orders..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr "Estimated {0}"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "Execution price didn't meet acceptable price"
@@ -6487,6 +6581,10 @@ msgstr "Warning: May not execute due to low liquidity at your trigger price"
 msgid "Cancel TWAP Swap"
 msgstr "Cancel TWAP Swap"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr "Vault not found: {address}"
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "Transaction"
@@ -6574,6 +6672,7 @@ msgstr "Order error. Prices are volatile for this market, try again by <0>increa
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Asset"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} cancelled"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr "Removing liquidity..."
 
@@ -6961,6 +7061,10 @@ msgstr "Display PnL after fees"
 msgid "Share position"
 msgstr "Share position"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr "USD Value"
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr "Approval submitted — waiting for confirmation…"
 
@@ -7301,6 +7406,7 @@ msgstr "Enter deposit amount"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "Approve {0}"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Balance"
 
@@ -7407,6 +7514,10 @@ msgstr "Buy order executed"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "No opportunities match your search"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr "Estimated VLP"
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "Same as current active code"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "Trade from wallet or GMX Account"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr "← Back to Vaults"
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "less than a minute"
 msgid "Ecosystem"
 msgstr "Ecosystem"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr "per token"
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "Next"
@@ -7676,8 +7795,13 @@ msgstr "Swap {fromAmount} for {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Amount"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr "Mint 1,000 {0} to wallet"
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "SL price above limit price"
 msgid "for {comment}"
 msgstr "for {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr "My Deposit (USD)"
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "Fulfilling buy request..."
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "Buy GM failed"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr "Minted tokens to your wallet"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "Buy GM with {0} and {1} up to the caps below"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Deposit"
 
@@ -8207,6 +8341,10 @@ msgstr "Decentralised permissionless on-chain exchange with deep liquidity and l
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "TOTAL VOLUME"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr "Live (15s poll)"
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "Receive"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr "Liquidity removed"
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "What is GMX?"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr "Share price"
 
@@ -9078,6 +9218,10 @@ msgstr "Stake {tokenSymbol}"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "Link copied to clipboard"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr "My Position"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "In progress..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr "Liquidity added"
 
@@ -9804,6 +9949,10 @@ msgstr "Network for your GMX Account and positions. Balances and positions don't
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr "VLP Balance"
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "Total trading volume from your referrals"
@@ -9973,7 +10122,13 @@ msgstr "Generate referral code"
 msgid "NET VALUE"
 msgstr "NET VALUE"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr "Vaults"
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr "Share Price"
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "Simulate transactions"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr "Adding liquidity..."
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "Unknown order"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr "VLP Amount"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -25,6 +25,8 @@ msgstr "Deslizamiento excedido"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "Impacto en el precio al cerrar. Los valores positivos le benefician. <0>
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "Tipo"
 
@@ -442,6 +445,10 @@ msgstr "Saldo de GMX Account"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "Mejor ruta de intercambio"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "Transfiera {nativeTokenSymbol} desde otras redes a {chainName}"
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "Estadísticas"
 
@@ -831,6 +839,10 @@ msgstr "Bonificación retroactiva STIP.b"
 msgid "in liquidity"
 msgstr "en liquidez"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "Mercado monetario descentralizado"
@@ -868,6 +880,10 @@ msgstr "Contacto de Telegram (opcional)"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "Error en la creación de la conversión"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "Tokens"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "Precio de ejecución de la orden"
 msgid "Market temporarily disabled"
 msgstr "Mercado temporalmente deshabilitado"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "Error de cambio"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Capa 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} orden para"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "Máx."
 
@@ -2628,6 +2651,10 @@ msgstr "Categorías de tokens"
 msgid "You have not traded during the selected period"
 msgstr "No ha operado durante el período seleccionado"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Partes predeterminadas para órdenes TWAP"
@@ -2715,6 +2742,10 @@ msgstr "Beneficio diario"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "Depositado {0} en {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "Valoramos su opinión"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>Depositar</0> o <1>comprar</1> {wrappedNativeTokenSymbol}."
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "Tipo de orden"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "Cambiar a {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "Es solo un unwrap"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "Confirmaciones de operaciones"
 msgid "Insufficient GLV liquidity"
 msgstr "Liquidez de GLV insuficiente"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "Puede haber liquidez insuficiente para partes de esta orden cuando se ejecute"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "Orden cancelada"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "Rend. anualizado"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "Retirar y liberar la reserva de GMX"
@@ -3668,6 +3719,10 @@ msgstr "No se requieren depósitos"
 msgid "Trading airdrop"
 msgstr "Airdrop de trading"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "Se encontraron {0} eventos en los últimos {DAYS_BACK} días"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "en {0}"
 msgid "{positionName} fees settled"
 msgstr "Comisiones de {positionName} liquidadas"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Reembolsos por impacto en el precio acumulados. Reclamables después de 5 días. <0>Más información</0>."
@@ -4584,6 +4648,8 @@ msgstr "Forzar fallo de intercambios externos"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "Retirar"
 
@@ -4625,6 +4691,10 @@ msgstr "Tamaño de posición demasiado pequeño"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "APR de Bono"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "Interés abierto {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "Código de referido añadido"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Compre bonos GMX en Bond Protocol con descuento y un periodo de consolidación corto"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "Falló la reclamación de fondos"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "Compra fallida"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "Usuarios"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "No hay trades que coincidan con los filtros seleccionados"
 msgid "Decreased"
 msgstr "Reducido"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "Genera comisiones mediante la provisión de liquidez en los mercados de GMX V2"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "{balanceFormatted} restante en la subcuenta 1CT antigua"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "Liq. corto"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Comisión de liquidación"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "Precio aceptable de la orden"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "Actualizando {updateOrdersCount} órdenes TP/SL..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "El precio de ejecución no alcanzó el precio aceptable"
@@ -6487,6 +6581,10 @@ msgstr "Advertencia: Puede no ejecutarse debido a la baja liquidez en su precio 
 msgid "Cancel TWAP Swap"
 msgstr "Cancelar Intercambio TWAP"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "Transacción"
@@ -6574,6 +6672,7 @@ msgstr "Error de orden. Los precios son volátiles en este mercado, inténtelo d
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Activo"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} cancelada"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "Mostrar PnL después de comisiones"
 msgid "Share position"
 msgstr "Compartir posición"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "Cambie a <0><1/><2>Arbitrum</2></0> o <3><4/><5>Avalanche</5></3> para acceder a esas funciones"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>Volver a </0><1>Página inicial</1> <2>o </2> <3>Operar</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "Ingresa cantidad de depósito"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "Aprobar {0}"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Balance"
 
@@ -7407,6 +7514,10 @@ msgstr "Orden de compra ejecutada"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "Ninguna oportunidad coincide con su búsqueda"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "Igual que el código activo actual"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "Opere desde su monedero o GMX Account"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "menos de un minuto"
 msgid "Ecosystem"
 msgstr "Ecosistema"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "Siguiente"
@@ -7676,8 +7795,13 @@ msgstr "Intercambiar {fromAmount} por {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Importe"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "Precio de SL por encima del precio límite"
 msgid "for {comment}"
 msgstr "para {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "Ejecutando solicitud de compra…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "La compra de GM ha fallado"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "Comprar GM con {0} y {1} hasta los límites indicados a continuación"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Depositar"
 
@@ -8207,6 +8341,10 @@ msgstr "Exchange descentralizado sin permisos on-chain con liquidez profunda y b
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "VOLUMEN TOTAL"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "Recibir"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "¿Qué es GMX?"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "Hacer staking de {tokenSymbol}"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "Enlace copiado al portapapeles"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "En curso..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "Red para su GMX Account y posiciones. Los saldos y las posiciones no se 
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "La liquidez solo está disponible en {chainNames} o {lastChainName}. Cambie de red para continuar."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "Volumen de negociación total de sus referidos"
@@ -9973,7 +10122,13 @@ msgstr "Generar código de referido"
 msgid "NET VALUE"
 msgstr "VALOR NETO"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "Simular transacciones"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "Orden desconocida"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -25,6 +25,8 @@ msgstr "Glissement dépassé"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "Impact sur le prix à la clôture. Les valeurs positives vous sont favor
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "Type"
 
@@ -442,6 +445,10 @@ msgstr "Solde du GMX Account"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "Meilleur chemin de swap"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "Transférer des {nativeTokenSymbol} depuis d'autres réseaux vers {chain
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "Stats"
 
@@ -831,6 +839,10 @@ msgstr "Bonus rétroactif STIP.b"
 msgid "in liquidity"
 msgstr "en liquidité"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "Marché monétaire décentralisé"
@@ -868,6 +880,10 @@ msgstr "Contact Telegram (optionnel)"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "Échec de la création de la conversion"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "Tokens"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "Prix d'exécution de l'ordre"
 msgid "Market temporarily disabled"
 msgstr "Marché temporairement désactivé"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "Erreur de shift"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Layer 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} ordre pour"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "Max"
 
@@ -2628,6 +2651,10 @@ msgstr "Catégories de tokens"
 msgid "You have not traded during the selected period"
 msgstr "Vous n'avez pas effectué de transactions durant la période sélectionnée"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Nombre de parts par défaut pour les ordres TWAP"
@@ -2715,6 +2742,10 @@ msgstr "Profit quotidien"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "Déposé {0} dans {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "Nous apprécions vos retours"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>Déposer</0> ou <1>acheter</1> {wrappedNativeTokenSymbol}."
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "Type d'ordre"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "Changer pour {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "C'est un simple unwrap"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "Confirmations de transactions"
 msgid "Insufficient GLV liquidity"
 msgstr "Liquidité GLV insuffisante"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "La liquidité pourrait être insuffisante pour certaines parties de cet ordre lors de son déclenchement"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "Ordre annulé"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "Perf. annualisée"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "Retirer et libérer les GMX"
@@ -3668,6 +3719,10 @@ msgstr "Aucun dépôt requis"
 msgid "Trading airdrop"
 msgstr "Airdrop de trading"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "{0} événements trouvés au cours des {DAYS_BACK} derniers jours"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "dans {0}"
 msgid "{positionName} fees settled"
 msgstr "Frais de {positionName} réglés"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Remises sur l'impact sur le prix accumulées. Récupérables après 5 jours. <0>En savoir plus</0>."
@@ -4584,6 +4648,8 @@ msgstr "Forcer l'échec des swaps externes"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "Retirer"
 
@@ -4625,6 +4691,10 @@ msgstr "Taille de position trop faible"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "Taux de rendement annualisé bonus"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "Positions ouvertes {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "Code de parrainage ajouté"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Achetez des obligations GMX sur Bond Protocol avec une décote et une courte période d'acquisition progressive"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "Échec de la réclamation des fonds"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "Échec de l'achat"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "Utilisateurs"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "Aucun trade ne correspond aux filtres sélectionnés"
 msgid "Decreased"
 msgstr "Diminué"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "Génère des frais grâce à la fourniture de liquidité sur les marchés GMX V2"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "{balanceFormatted} restant dans l'ancien sous-compte 1CT"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "Liq. short"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Frais de liquidation"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "Prix acceptable de l'ordre"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "Mise à jour de {updateOrdersCount} ordres TP/SL..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "Le prix d'exécution n'a pas atteint le prix acceptable"
@@ -6487,6 +6581,10 @@ msgstr "Avertissement : l'exécution pourrait échouer en raison d'une faible li
 msgid "Cancel TWAP Swap"
 msgstr "Annuler le swap TWAP"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "Transaction"
@@ -6574,6 +6672,7 @@ msgstr "Erreur d'ordre. Les prix sont volatils pour ce marché, réessayez en <0
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Actif"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} annulé"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "Afficher le PnL après les frais"
 msgid "Share position"
 msgstr "Partager la position"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "Passez à <0><1/><2>Arbitrum</2></0> ou <3><4/><5>Avalanche</5></3> pour accéder à ces fonctionnalités"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>Retourner à </0><1>la page d'accueil</1> <2>ou </2> <3>Trader</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "Entrez le montant de dépôt"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "Approuver {0}"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Solde"
 
@@ -7407,6 +7514,10 @@ msgstr "Ordre d'achat exécuté"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "Aucune opportunité ne correspond à votre recherche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "Identique au code actif actuel"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "Négociez depuis le portefeuille ou le GMX Account"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "moins d'une minute"
 msgid "Ecosystem"
 msgstr "Écosystème"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "Suivant"
@@ -7676,8 +7795,13 @@ msgstr "Échanger {fromAmount} pour {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Montant"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "Prix du SL au-dessus du prix limite"
 msgid "for {comment}"
 msgstr "pour {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "Exécution de la demande d'achat…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "Échec de l'achat de GM"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "Acheter des GM avec {0} et {1} jusqu'aux plafonds ci-dessous"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Dépôt"
 
@@ -8207,6 +8341,10 @@ msgstr "Exchange décentralisé sans permission on-chain avec liquidité profond
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "VOLUME TOTAL"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "Recevoir"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "Qu’est-ce que GMX ?"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "Staker {tokenSymbol}"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "Lien copié dans le presse-papiers"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "En cours..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "Réseau pour votre GMX Account et vos positions. Les soldes et les posit
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Liquidité disponible uniquement sur {chainNames} ou {lastChainName}. Changez de réseau pour continuer."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "Volume de négociation total provenant de vos parrainages"
@@ -9973,7 +10122,13 @@ msgstr "Générer un code de parrainage"
 msgid "NET VALUE"
 msgstr "VALEUR NETTE"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "Simuler les transactions"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "Ordre inconnu"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -25,6 +25,8 @@ msgstr "スリッページ超過"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "クローズ時の価格への影響です。正の値はお客様に有
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "種類"
 
@@ -442,6 +445,10 @@ msgstr "GMX Account残高"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "最適スワップパス"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "他のネットワークから{chainName}へ{nativeTokenSymbol}を送金
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "統計"
 
@@ -831,6 +839,10 @@ msgstr "STIP.b遡及ボーナス"
 msgid "in liquidity"
 msgstr "流動性で"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "分散型マネーマーケット"
@@ -868,6 +880,10 @@ msgstr "Telegram連絡先（任意）"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "コンバージョンの作成に失敗しました"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "トークン"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "注文の約定価格"
 msgid "Market temporarily disabled"
 msgstr "マーケットは一時的に無効です"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "シフトエラー"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "レイヤー2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} 注文"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "最大"
 
@@ -2628,6 +2651,10 @@ msgstr "トークンカテゴリ"
 msgid "You have not traded during the selected period"
 msgstr "選択した期間中に取引はありませんでした"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP注文のデフォルト分割数"
@@ -2715,6 +2742,10 @@ msgstr "日次利益"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "{positionText}に{0}を入金"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "フィードバックをお待ちしております"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>入金</0>または<1>購入</1>{wrappedNativeTokenSymbol}。"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "注文タイプ"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "{0} に変更"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "アンラップのみです"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "取引確認"
 msgid "Insufficient GLV liquidity"
 msgstr "GLV流動性が不足しています"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "トリガー時に注文の一部で流動性が不足する可能性があります"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "注文がキャンセルされました"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "年率パフォーマンス"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "GMX を出金してリザーブを解除する"
@@ -3668,6 +3719,10 @@ msgstr "入金不要"
 msgid "Trading airdrop"
 msgstr "取引エアドロップ"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "過去 {DAYS_BACK} 日間に {0} 件のイベントが見つかりました"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "{0} 内"
 msgid "{positionName} fees settled"
 msgstr "{positionName} の手数料が精算されました"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "価格への影響リベートが発生しました。5日後に受取可能です。<0>詳細はこちら</0>。"
@@ -4584,6 +4648,8 @@ msgstr "外部スワップを失敗させる"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "出金"
 
@@ -4625,6 +4691,10 @@ msgstr "ポジションサイズが小さすぎます"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "ボーナスAPR"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "建玉 {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "リファラルコードが追加されました"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Bond ProtocolでGMXボンドを短いベスティング期間で割引購入します"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "資金の請求に失敗しました"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "購入失敗"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "ユーザー"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "選択したフィルターに一致するトレードはありません
 msgid "Decreased"
 msgstr "減額しました"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "GMX V2市場全体への流動性提供から手数料を獲得"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "旧1CTサブアカウントに{balanceFormatted}が残っています"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "ショート流動性"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "清算手数料"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "注文の許容価格"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "{updateOrdersCount}件のTP/SL注文を更新中..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "約定価格が許容価格を満たしませんでした"
@@ -6487,6 +6581,10 @@ msgstr "警告: トリガー価格での流動性不足により約定しない�
 msgid "Cancel TWAP Swap"
 msgstr "TWAPスワップをキャンセル"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "取引"
@@ -6574,6 +6672,7 @@ msgstr "注文エラー。この市場の価格は不安定です。<0>許容ス
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "資産"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} キャンセル済み"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "手数料差引後のPnLを表示"
 msgid "Share position"
 msgstr "ポジションを共有"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "これらの機能をご利用いただくには<0><1/><2>Arbitrum</2></0>または<3><4/><5>Avalanche</5></3>に切り替えてください"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>戻る </0><1>ホームページへ</1> <2>または </2> <3>トレードへ</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "入金額を入力"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "{0}を承認"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1 時間"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "残高"
 
@@ -7407,6 +7514,10 @@ msgstr "購入注文が約定しました"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "検索に一致する機会はありません"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "現在アクティブなコードと同じです"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "ウォレットまたはGMX Accountから取引"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "1分未満"
 msgid "Ecosystem"
 msgstr "エコシステム"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "次へ"
@@ -7676,8 +7795,13 @@ msgstr "{fromAmount} を {toAmount} にスワップ"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金額"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "SL価格がリミット価格を上回っています"
 msgid "for {comment}"
 msgstr "{comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "買いリクエストを実行中…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "GMの購入に失敗しました"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "以下の上限まで{0}と{1}でGMを購入できます"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "入金"
 
@@ -8207,6 +8341,10 @@ msgstr "2021年より稼働する深い流動性と低コストのパーミッ�
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "TOTAL VOLUME"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "受取"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "GMXとは？"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "{tokenSymbol}をステーク"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "リンクがクリップボードにコピーされました"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "処理中..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "GMX Accountとポジションのためのネットワークです。残�
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "流動性は{chainNames}または{lastChainName}でのみ利用可能です。続行するにはネットワークを切り替えてください。"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "紹介者からの合計取引高"
@@ -9973,7 +10122,13 @@ msgstr "リファラルコードを生成"
 msgid "NET VALUE"
 msgstr "純価値"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "トランザクションをシミュレート"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "不明な注文"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -25,6 +25,8 @@ msgstr "슬리피지 초과"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "포지션 종료 시 가격 영향입니다. 양수 값은 유리합니�
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "유형"
 
@@ -442,6 +445,10 @@ msgstr "GMX Account 잔액"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "최적 스왑 경로"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "다른 네트워크에서 {chainName}으로 {nativeTokenSymbol}을 전�
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "통계"
 
@@ -831,6 +839,10 @@ msgstr "STIP.b 소급 보너스"
 msgid "in liquidity"
 msgstr "유동성 내"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "탈중앙화 머니마켓"
@@ -868,6 +880,10 @@ msgstr "텔레그램 연락처 (선택)"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "전환 생성 실패"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "토큰"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "주문 체결가"
 msgid "Market temporarily disabled"
 msgstr "마켓이 일시적으로 비활성화되었습니다"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "시프트 오류"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "레이어 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} 주문"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "최대"
 
@@ -2628,6 +2651,10 @@ msgstr "토큰 카테고리"
 msgid "You have not traded during the selected period"
 msgstr "선택한 기간 동안 거래 내역이 없습니다"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP 주문의 기본 분할 수"
@@ -2715,6 +2742,10 @@ msgstr "일일 수익"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "{positionText}에 {0} 예치"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "소중한 의견을 남겨주십시오"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>입금</0> 또는 <1>구매</1> {wrappedNativeTokenSymbol}."
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "주문 유형"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "{0}으로 변경"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "단순 언래핑입니다"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "거래 확인 알림"
 msgid "Insufficient GLV liquidity"
 msgstr "GLV 유동성 부족"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "발동 시 이 주문의 일부에 대해 유동성이 부족할 수 있습니다"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "주문이 취소되었습니다"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "연환산 수익률"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "GMX 출금 및 예약 해제"
@@ -3668,6 +3719,10 @@ msgstr "입금 필요 없음"
 msgid "Trading airdrop"
 msgstr "거래 에어드롭"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "최근 {DAYS_BACK}일간 {0}개의 이벤트가 발견되었습니다"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "{0} 내"
 msgid "{positionName} fees settled"
 msgstr "{positionName} 수수료 정산 완료"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "가격 영향 리베이트가 누적되었습니다. 5일 후 수령 가능합니다. <0>자세히 보기</0>."
@@ -4584,6 +4648,8 @@ msgstr "외부 스왑 실패 처리"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "인출"
 
@@ -4625,6 +4691,10 @@ msgstr "포지션 크기가 너무 작습니다"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "보너스 APR"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "미결제약정 {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "추천 코드가 추가되었습니다"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Bond Protocol에서 짧은 베스팅 기간으로 GMX 채권을 할인 구매하십시오"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "자금 청구 실패"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "구매 실패"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "사용자"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "선택한 필터와 일치하는 거래가 없습니다"
 msgid "Decreased"
 msgstr "감소 완료"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "GMX V2 마켓 전반의 유동성 제공을 통해 수수료를 획득합니다"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "기존 1CT 서브계정에 {balanceFormatted} 잔여"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "숏 유동성"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "청산 수수료"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "주문 허용 가격"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "{updateOrdersCount}개 TP/SL 주문 업데이트 중..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "체결가가 허용 가격을 충족하지 못했습니다"
@@ -6487,6 +6581,10 @@ msgstr "경고: 조건가에서 유동성 부족으로 체결되지 않을 수 �
 msgid "Cancel TWAP Swap"
 msgstr "TWAP 스왑 취소"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "거래"
@@ -6574,6 +6672,7 @@ msgstr "주문 오류. 이 마켓의 가격 변동성이 높습니다. <0>허용
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "자산"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} 취소됨"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "수수료 차감 후 PnL 표시"
 msgid "Share position"
 msgstr "포지션 공유"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "해당 기능을 사용하려면 <0><1/><2>Arbitrum</2></0> 또는 <3><4/><5>Avalanche</5></3>(으)로 전환하십시오"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>로 돌아가기 </0><1>홈페이지</1> <2>또는 </2> <3>거래</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "입금 금액 입력"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "{0} 승인"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1시간"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "잔고"
 
@@ -7407,6 +7514,10 @@ msgstr "구매 주문이 체결되었습니다"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "검색 결과와 일치하는 기회가 없습니다"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "현재 활성 코드와 동일"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "지갑 또는 GMX Account에서 거래"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "1분 미만"
 msgid "Ecosystem"
 msgstr "이코시스템"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "다음"
@@ -7676,8 +7795,13 @@ msgstr "{fromAmount}을 {toAmount}으로 스왑"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "수량"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "SL 가격이 지정가보다 높습니다"
 msgid "for {comment}"
 msgstr "{comment}에 대해"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "매수 요청을 실행하는 중…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "GM 구매 실패"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "아래 한도까지 {0} 및 {1}(으)로 GM을 구매할 수 있습니다
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "예치"
 
@@ -8207,6 +8341,10 @@ msgstr "2021년부터 운영되는 깊은 유동성과 저비용의 탈중앙화
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "총 거래량"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "수령"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "GMX란 무엇인가요?"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "{tokenSymbol} 스테이킹"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "링크가 클립보드에 복사되었습니다"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "진행 중..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "GMX Account 및 포지션을 위한 네트워크입니다. 잔액과 포
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "유동성은 {chainNames} 또는 {lastChainName}에서만 이용 가능합니다. 계속하려면 네트워크를 전환하십시오."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "추천인의 총 거래량"
@@ -9973,7 +10122,13 @@ msgstr "추천 코드 생성"
 msgid "NET VALUE"
 msgstr "순가치"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "트랜잭션 시뮬레이션"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "알 수 없는 주문"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -25,6 +25,8 @@ msgstr ""
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr ""
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr ""
 
@@ -441,6 +444,10 @@ msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
 msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
@@ -759,6 +766,7 @@ msgstr ""
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr ""
 
@@ -831,6 +839,10 @@ msgstr ""
 msgid "in liquidity"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr ""
@@ -867,6 +879,10 @@ msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
+msgstr ""
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
 msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr ""
 msgid "Market temporarily disabled"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr ""
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr ""
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr ""
 
@@ -2628,6 +2651,10 @@ msgstr ""
 msgid "You have not traded during the selected period"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr ""
@@ -2714,6 +2741,10 @@ msgstr ""
 
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
 msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr ""
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr ""
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3197,6 +3234,10 @@ msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
 msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -3449,6 +3490,10 @@ msgstr ""
 msgid "Insufficient GLV liquidity"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr ""
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr ""
@@ -3668,6 +3719,10 @@ msgstr ""
 msgid "Trading airdrop"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr ""
@@ -3696,6 +3751,11 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
 msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
@@ -4255,6 +4315,10 @@ msgstr ""
 msgid "{positionName} fees settled"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr ""
@@ -4584,6 +4648,8 @@ msgstr ""
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr ""
 
@@ -4624,6 +4690,10 @@ msgstr ""
 #: src/components/AprInfo/AprInfo.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
 msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4922,6 +4993,10 @@ msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr ""
 msgid "Decreased"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr ""
@@ -5884,6 +5966,10 @@ msgstr ""
 
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
 msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
@@ -5997,6 +6083,10 @@ msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
 msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -6268,6 +6358,10 @@ msgstr ""
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr ""
@@ -6487,6 +6581,10 @@ msgstr ""
 msgid "Cancel TWAP Swap"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr ""
@@ -6574,6 +6672,7 @@ msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr ""
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr ""
 msgid "Share position"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr ""
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr ""
 
@@ -7357,6 +7463,7 @@ msgstr ""
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr ""
 
@@ -7406,6 +7513,10 @@ msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
 msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
@@ -7483,6 +7594,10 @@ msgstr ""
 
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
 msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -7629,6 +7744,10 @@ msgstr ""
 msgid "Ecosystem"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr ""
@@ -7676,7 +7795,12 @@ msgstr ""
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
 msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
@@ -7803,6 +7927,10 @@ msgstr ""
 msgid "for {comment}"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7836,6 +7964,10 @@ msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
+msgstr ""
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
 msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
@@ -8163,6 +8295,8 @@ msgstr ""
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr ""
 
@@ -8206,6 +8340,10 @@ msgstr ""
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9077,6 +9217,10 @@ msgstr ""
 
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr ""
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr ""
@@ -9973,7 +10122,13 @@ msgstr ""
 msgid "NET VALUE"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr ""
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -25,6 +25,8 @@ msgstr "Проскальзывание превышено"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "Влияние на цену при закрытии. Положител
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "Тип"
 
@@ -442,6 +445,10 @@ msgstr "Баланс GMX Account"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "Лучший путь свопа"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "Перевести {nativeTokenSymbol} из других сетей в {
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "Статистика"
 
@@ -831,6 +839,10 @@ msgstr "Ретроактивный бонус STIP.b"
 msgid "in liquidity"
 msgstr "используется для обеспечения ликвидности"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "Децентрализованный денежный рынок"
@@ -868,6 +880,10 @@ msgstr "Контакт в Telegram (опционально)"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "Не удалось создать конвертацию"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "Токены"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "Цена исполнения ордера"
 msgid "Market temporarily disabled"
 msgstr "Рынок временно отключён"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "Ошибка сдвига"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Layer 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} ордер за"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "Макс"
 
@@ -2628,6 +2651,10 @@ msgstr "Категории токенов"
 msgid "You have not traded during the selected period"
 msgstr "Вы не совершали сделок за выбранный период"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "Количество частей по умолчанию для TWAP-ордеров"
@@ -2715,6 +2742,10 @@ msgstr "Дневная прибыль"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "Внесено {0} в {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "Мы ценим ваше мнение"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>Внести</0> или <1>купить</1> {wrappedNativeTokenSymbol}."
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "Тип ордера"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "Изменить на {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "Это просто unwrap"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "Подтверждения сделок"
 msgid "Insufficient GLV liquidity"
 msgstr "Недостаточно ликвидности GLV"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "При срабатывании возможна недостаточная ликвидность для части этого ордера"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "Ордер отменён"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "Годовая доходность"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "Вывести и снять резервирование GMX"
@@ -3668,6 +3719,10 @@ msgstr "Нет необходимости в депозитах"
 msgid "Trading airdrop"
 msgstr "Торговый аирдроп"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "Найдено {0} событий за последние {DAYS_BACK} дней"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "в {0}"
 msgid "{positionName} fees settled"
 msgstr "Комиссии {positionName} урегулированы"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Возвраты за влияние на цену начислены. Доступны для получения через 5 дней. <0>Подробнее</0>."
@@ -4584,6 +4648,8 @@ msgstr "Принудительный сбой внешних свопов"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "Вывод"
 
@@ -4625,6 +4691,10 @@ msgstr "Размер позиции слишком мал"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "Бонусная Годовая Процентная Ставка"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "Открытый интерес {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "Реферальный код добавлен"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "Покупайте облигации GMX на Bond Protocol со скидкой и коротким периодом вестинга"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "Не удалось клеймить средства"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "Покупка не удалась"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "Пользователи"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "Нет сделок, соответствующих выбранным �
 msgid "Decreased"
 msgstr "Уменьшено"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "Получает комиссии от предоставления ликвидности на рынках GMX V2"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "{balanceFormatted} остаётся на старом субаккаунте 1CT"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "Шорт ликв."
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Комиссия за ликвидацию"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "Допустимая цена ордера"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "Обновление {updateOrdersCount} TP/SL ордеров..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "Цена исполнения не соответствовала допустимой цене"
@@ -6487,6 +6581,10 @@ msgstr "Предупреждение: может не исполниться и�
 msgid "Cancel TWAP Swap"
 msgstr "Отменить TWAP обмен"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "Транзакция"
@@ -6574,6 +6672,7 @@ msgstr "Ошибка ордера. Цены на этом рынке неста�
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Актив"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} отменён"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "Отображать PnL после комиссий"
 msgid "Share position"
 msgstr "Поделиться позицией"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "Переключитесь на <0><1/><2>Arbitrum</2></0> или <3><4/><5>Avalanche</5></3> для доступа к этим функциям"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>Вернуться к </0><1>Домашней странице</1> <2>или </2> <3>Торговле</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "Введите сумму внесения"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "Одобрить {0}"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1ч"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Баланс"
 
@@ -7407,6 +7514,10 @@ msgstr "Ордер на покупку исполнен"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "Нет возможностей, соответствующих вашему запросу"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "Такой же, как текущий активный код"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "Торговля с кошелька или GMX Account"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "меньше минуты"
 msgid "Ecosystem"
 msgstr "Экосистема"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "Далее"
@@ -7676,8 +7795,13 @@ msgstr "Обмен {fromAmount} на {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Сумма"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "Цена SL выше лимитной цены"
 msgid "for {comment}"
 msgstr "для {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "Выполнение запроса на покупку…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "Покупка GM не удалась"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "Купить GM за {0} и {1} в пределах лимитов ни�
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Депозит"
 
@@ -8207,6 +8341,10 @@ msgstr "Децентрализованная биржа без разрешен�
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "ОБЩИЙ ОБЪЁМ"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "Получение"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "Что такое GMX?"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "Застейкать {tokenSymbol}"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "Ссылка скопирована в буфер обмена"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "Выполняется..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "Сеть для вашего GMX Account и позиций. Баланс
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Ликвидность доступна только на {chainNames} или {lastChainName}. Переключите сеть для продолжения."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "Общий объём торгов от ваших рефералов"
@@ -9973,7 +10122,13 @@ msgstr "Создать реферальный код"
 msgid "NET VALUE"
 msgstr "НЕТТО-СТОИМОСТЬ"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "Симулировать транзакции"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "Неизвестный ордер"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -25,6 +25,8 @@ msgstr "滑點超出限制"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "平倉時的價格影響。正值對您有利。<0>了解更多</0>。"
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "類型"
 
@@ -442,6 +445,10 @@ msgstr "GMX Account 餘額"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "最佳兌換路徑"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "從其他網路轉帳 {nativeTokenSymbol} 至 {chainName}"
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "統計"
 
@@ -831,6 +839,10 @@ msgstr "STIP.b 追溯獎勵"
 msgid "in liquidity"
 msgstr "流動性"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "去中心化貨幣市場"
@@ -868,6 +880,10 @@ msgstr "Telegram 聯絡方式（選填）"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "轉換建立失敗"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "代幣"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "訂單的成交價格"
 msgid "Market temporarily disabled"
 msgstr "市場暫時停用"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "轉移錯誤"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Layer 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} 訂單於"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "最大"
 
@@ -2628,6 +2651,10 @@ msgstr "代幣類別"
 msgid "You have not traded during the selected period"
 msgstr "您在所選期間內未進行任何交易"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP 訂單的預設分段數"
@@ -2715,6 +2742,10 @@ msgstr "每日利潤"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "已存入 {0} 至 {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "我們重視您的意見"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>存入</0>或<1>買入</1> {wrappedNativeTokenSymbol}。"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "訂單類型"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "切換至 {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "這只是一個解包操作"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "交易確認通知"
 msgid "Insufficient GLV liquidity"
 msgstr "GLV 流動性不足"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "觸發時此訂單的部分可能缺乏流動性"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "訂單已取消"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "年化績效"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "提取並解除 GMX 預留"
@@ -3668,6 +3719,10 @@ msgstr "無需存入"
 msgid "Trading airdrop"
 msgstr "交易空投"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "在過去 {DAYS_BACK} 天內找到 {0} 個事件"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "於 {0}"
 msgid "{positionName} fees settled"
 msgstr "{positionName} 費用已結算"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "價格影響回饋已累積，5 天後可領取。<0>閱讀更多</0>。"
@@ -4584,6 +4648,8 @@ msgstr "強制外部兌換失敗"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "提取"
 
@@ -4625,6 +4691,10 @@ msgstr "倉位規模過小"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "額外 APR"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "未平倉量 {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "推薦碼已新增"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "在 Bond Protocol 上以折扣價購買 GMX 債券，享有短期歸屬期"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "領取資金失敗"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "買入失敗"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "用戶"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "沒有符合所選篩選條件的交易"
 msgid "Decreased"
 msgstr "已減倉"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "從 GMX V2 市場的流動性提供中賺取手續費"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "舊版 One-Click Trading 子帳戶中剩餘 {balanceFormatted}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "做空流動性"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "清算費用"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "訂單可接受價格"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "正在更新 {updateOrdersCount} 個 TP/SL 訂單..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "成交價格未達到可接受價格"
@@ -6487,6 +6581,10 @@ msgstr "警告：由於觸發價格處流動性不足，可能無法執行"
 msgid "Cancel TWAP Swap"
 msgstr "取消 TWAP 兌換"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "交易"
@@ -6574,6 +6672,7 @@ msgstr "訂單錯誤。此市場價格波動劇烈，請嘗試<0>提高允許的
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "資產"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} 已取消"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "顯示扣除費用後的 PnL"
 msgid "Share position"
 msgstr "分享倉位"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "切換至 <0><1/><2>Arbitrum</2></0> 或 <3><4/><5>Avalanche</5></3> 以使用這些功能"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>返回</0><1>首頁</1><2>或</2><3>交易</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "請輸入存入金額"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "授權 {0}"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "餘額"
 
@@ -7407,6 +7514,10 @@ msgstr "買入訂單已成交"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "沒有符合搜尋條件的機會"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "與目前使用中的代碼相同"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "從錢包或 GMX Account 交易"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "不到一分鐘"
 msgid "Ecosystem"
 msgstr "生態系統"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "下一頁"
@@ -7676,8 +7795,13 @@ msgstr "將 {fromAmount} 兌換為 {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金額"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "止損價格高於限價"
 msgid "for {comment}"
 msgstr "用於 {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "正在執行買入請求..."
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "購買 GM 失敗"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "使用 {0} 和 {1} 購買 GM，上限如下"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "存入"
 
@@ -8207,6 +8341,10 @@ msgstr "自 2021 年上線的去中心化無許可鏈上交易所，具有深度
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "TOTAL VOLUME"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "收到"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "什麼是 GMX？"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "質押 {tokenSymbol}"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "連結已複製到剪貼簿"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "進行中..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "您的 GMX Account 和倉位所在的網路。餘額和倉位不會在�
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "流動性僅在 {chainNames} 或 {lastChainName} 上可用。請切換網路以繼續。"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "來自您推薦的總交易量"
@@ -9973,7 +10122,13 @@ msgstr "產生推薦碼"
 msgid "NET VALUE"
 msgstr "淨值"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "模擬交易"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "未知訂單"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -25,6 +25,8 @@ msgstr "滑点超限"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 #: src/pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer.tsx
 #: src/pages/ReferralsTier/ReferralsTier.tsx
@@ -197,6 +199,7 @@ msgstr "平仓时的价格影响。正值对您有利。<0>了解更多</0>。"
 #: src/components/Referrals/TradersStats.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Type"
 msgstr "类型"
 
@@ -442,6 +445,10 @@ msgstr "GMX Account 余额"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "最佳兑换路径"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Connect your wallet to see your deposits."
+msgstr ""
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -759,6 +766,7 @@ msgstr "从其他网络转账 {nativeTokenSymbol} 至 {chainName}"
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Dashboard/DashboardV2.tsx
 #: src/pages/Dashboard/StatsCard.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Stats"
 msgstr "统计"
 
@@ -831,6 +839,10 @@ msgstr "STIP.b 追溯奖励"
 msgid "in liquidity"
 msgstr "流动性中"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
 msgstr "去中心化货币市场"
@@ -868,6 +880,10 @@ msgstr "Telegram 联系方式（可选）"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Conversion creation failed"
 msgstr "转换创建失败"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebase +{0}% applied"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "27% of protocol fees fund Treasury buybacks — rewards distributed at $90"
@@ -1474,6 +1490,7 @@ msgid "Tokens"
 msgstr "代币"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
 msgstr ""
 
@@ -2026,6 +2043,10 @@ msgstr "订单的成交价格"
 msgid "Market temporarily disabled"
 msgstr "市场暂时停用"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Auto-growing"
+msgstr ""
+
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
 msgstr "Shift 错误"
@@ -2373,6 +2394,7 @@ msgid "Layer 2"
 msgstr "Layer 2"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
 msgstr ""
 
@@ -2520,6 +2542,7 @@ msgstr "{txnTypeText} {0} 订单为"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
 msgstr "最大"
 
@@ -2628,6 +2651,10 @@ msgstr "代币类别"
 msgid "You have not traded during the selected period"
 msgstr "您在所选时间段内没有交易记录"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Token Balance"
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
 msgstr "TWAP 订单的默认份数"
@@ -2715,6 +2742,10 @@ msgstr "每日盈利"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Deposited {0} into {positionText}"
 msgstr "存款 {0} 到 {positionText}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price Yield"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -2933,6 +2964,10 @@ msgstr "我们重视您的反馈"
 msgid "<0>Deposit</0> or <1>buy</1> {wrappedNativeTokenSymbol}."
 msgstr "<0>存入</0>或<1>购买</1> {wrappedNativeTokenSymbol}。"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Price updated"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 #: src/components/StatusNotification/OrderStatusNotification.tsx
@@ -2977,6 +3012,8 @@ msgstr "订单类型"
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Transaction submitted"
 msgstr ""
 
@@ -3198,6 +3235,10 @@ msgstr "更改为 {0}"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "It's just an unwrap"
 msgstr "这只是一笔解包操作"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Debug Panel"
+msgstr ""
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3449,6 +3490,10 @@ msgstr "交易确认"
 msgid "Insufficient GLV liquidity"
 msgstr "GLV 流动性不足"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "My Deposit"
+msgstr ""
+
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -3484,6 +3529,7 @@ msgid "May lack liquidity for parts of this order when triggered"
 msgstr "触发时该订单部分子单可能流动性不足"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr ""
 
@@ -3540,6 +3586,7 @@ msgid "Order canceled"
 msgstr "订单已取消"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
 msgstr ""
 
@@ -3617,6 +3664,10 @@ msgstr "年化表现"
 msgid "Closing position..."
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Collecting data…"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
 msgstr "提取并解除 GMX 锁定"
@@ -3668,6 +3719,10 @@ msgstr "无需存入"
 msgid "Trading airdrop"
 msgstr "交易空投"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price +10%"
+msgstr ""
+
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
 msgstr "过去 {DAYS_BACK} 天内发现 {0} 个事件"
@@ -3697,6 +3752,11 @@ msgstr "V1 Arbitrum"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Avalanche"
 msgstr "Avalanche"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "AUM"
+msgstr ""
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4255,6 +4315,10 @@ msgstr "在 {0} 中"
 msgid "{positionName} fees settled"
 msgstr "{positionName} 费用已结算"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Price -20%"
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "价格影响返利已累计。5 天后可领取。<0>了解更多</0>。"
@@ -4584,6 +4648,8 @@ msgstr "强制外部兑换失败"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
 msgstr "提取"
 
@@ -4625,6 +4691,10 @@ msgstr "仓位规模过小"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Bonus APR"
 msgstr "奖金年化收益率"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "+5% Rebase"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
@@ -4718,6 +4788,7 @@ msgid "Open interest {directionLabel}"
 msgstr "未平仓量 {directionLabel}"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
 msgstr ""
 
@@ -4923,6 +4994,10 @@ msgstr "推荐码已添加"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
 msgstr "在 Bond Protocol 上以折扣价购买 GMX 债券，归属期较短"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5245,6 +5320,7 @@ msgid "Failed to claim funds"
 msgstr "申领资金失败"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
 msgstr ""
 
@@ -5306,6 +5382,7 @@ msgid "Buy failed"
 msgstr "买入失败"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
 msgstr ""
 
@@ -5314,6 +5391,7 @@ msgid "Users"
 msgstr "用户"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
 msgstr ""
 
@@ -5801,6 +5879,10 @@ msgstr "没有交易符合选定筛选条件"
 msgid "Decreased"
 msgstr "已减少"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Provide liquidity to earn yield from RWA assets."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
 msgstr "通过在 GMX V2 市场提供流动性赚取费用"
@@ -5885,6 +5967,10 @@ msgstr "Firebird Finance"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "{balanceFormatted} remaining in old 1CT subaccount"
 msgstr "旧 One-Click Trading 子账户中剩余 {balanceFormatted}"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Shortfall Debt"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -5998,6 +6084,10 @@ msgstr "做空流动性"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "清算费用"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6268,6 +6358,10 @@ msgstr "订单可接受价格"
 msgid "Updating {updateOrdersCount} TP/SL orders..."
 msgstr "正在更新 {updateOrdersCount} 个止盈/止损订单..."
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated {0}"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
 msgstr "成交价格未达到可接受价格"
@@ -6487,6 +6581,10 @@ msgstr "警告：由于触发价格处的流动性不足，订单可能无法执
 msgid "Cancel TWAP Swap"
 msgstr "取消 TWAP 交换"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Vault not found: {address}"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
 msgstr "交易"
@@ -6574,6 +6672,7 @@ msgstr "订单错误。该市场价格波动剧烈，请尝试<0>增加允许的
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "资产"
 
@@ -6621,6 +6720,7 @@ msgid "{orderText} cancelled"
 msgstr "{orderText} 已取消"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Removing liquidity..."
 msgstr ""
 
@@ -6961,6 +7061,10 @@ msgstr "显示扣除费用后的 PnL"
 msgid "Share position"
 msgstr "分享仓位"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "USD Value"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
 msgstr "切换至 <0><1/><2>Arbitrum</2></0> 或 <3><4/><5>Avalanche</5></3> 以使用这些功能"
@@ -7236,6 +7340,7 @@ msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
 msgstr "<0>返回 </0><1>主页</1> <2>或 </2> <3>交易</3>"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Approval submitted — waiting for confirmation…"
 msgstr ""
 
@@ -7301,6 +7406,7 @@ msgstr "输入存入金额"
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approve {0}"
 msgstr "授权 {0}"
 
@@ -7357,6 +7463,7 @@ msgstr "{formattedNetRate} / 1 小时"
 #: src/components/GmxAccountModal/MainView.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "余额"
 
@@ -7407,6 +7514,10 @@ msgstr "买入订单已执行"
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your search"
 msgstr "没有与您的搜索匹配的机会"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Estimated VLP"
+msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -7484,6 +7595,10 @@ msgstr "与当前活跃代码相同"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade from wallet or GMX Account"
 msgstr "从钱包或 GMX Account 进行交易"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "← Back to Vaults"
+msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -7629,6 +7744,10 @@ msgstr "不到一分钟"
 msgid "Ecosystem"
 msgstr "生态系统"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "per token"
+msgstr ""
+
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
 msgstr "下一个"
@@ -7676,8 +7795,13 @@ msgstr "将 {fromAmount} 交换为 {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金额"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Mint 1,000 {0} to wallet"
+msgstr ""
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -7803,6 +7927,10 @@ msgstr "止损价格高于限价"
 msgid "for {comment}"
 msgstr "用于 {comment}"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Deposit (USD)"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
@@ -7837,6 +7965,10 @@ msgstr "正在执行买入请求…"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Buy GM failed"
 msgstr "买入 GM 失败"
+
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Minted tokens to your wallet"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown shift GM order"
@@ -8163,6 +8295,8 @@ msgstr "使用 {0} 和 {1} 买入 GM，上限如下"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "存入"
 
@@ -8207,6 +8341,10 @@ msgstr "去中心化、无需许可、链上交易所，具备深度流动性和
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "TOTAL VOLUME"
 msgstr "TOTAL VOLUME"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Live (15s poll)"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -8265,6 +8403,7 @@ msgid "Receive"
 msgstr "接收"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
 msgstr ""
 
@@ -8994,6 +9133,7 @@ msgid "What is GMX?"
 msgstr "什么是 GMX？"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
 msgstr ""
 
@@ -9078,6 +9218,10 @@ msgstr "质押 {tokenSymbol}"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Link copied to clipboard"
 msgstr "链接已复制到剪贴板"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "My Position"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -9547,6 +9691,7 @@ msgid "In progress..."
 msgstr "处理中..."
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity added"
 msgstr ""
 
@@ -9804,6 +9949,10 @@ msgstr "您的 GMX Account 和仓位所在的网络。余额和仓位不会在�
 msgid "Liquidity only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "流动性仅在 {chainNames} 或 {lastChainName} 上可用。请切换网络以继续。"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "VLP Balance"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
 msgstr "来自您推荐的总交易量"
@@ -9973,7 +10122,13 @@ msgstr "生成推荐码"
 msgid "NET VALUE"
 msgstr "净值"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Vaults"
+msgstr ""
+
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
 msgstr ""
 
@@ -10071,6 +10226,7 @@ msgid "Simulate transactions"
 msgstr "模拟交易"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Adding liquidity..."
 msgstr ""
 
@@ -10182,6 +10338,7 @@ msgid "Unknown order"
 msgstr "未知订单"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
 msgstr ""
 

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1,0 +1,516 @@
+/**
+ * VaultDetailPage.tsx
+ *
+ * Uniswap-style vault detail page.
+ * Route: /vaults/:address
+ *
+ * Layout: left column (stats + chart) | right column (deposit/withdraw + debug)
+ */
+
+import { t } from "@lingui/macro";
+import { formatEther, parseUnits } from "ethers";
+import { ChangeEvent, useState } from "react";
+import { useHistory, useParams } from "react-router-dom";
+
+import { useVaultActions } from "domain/vantage/vaults/useVaultActions";
+import { useVaultDetail } from "domain/vantage/vaults/useVaultDetail";
+import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, getVaultConfigByAddress } from "domain/vantage/vaults/vaultConfig";
+import { useChainId } from "lib/chains";
+import useWallet from "lib/wallets/useWallet";
+
+import Button from "components/Button/Button";
+import NumberInput from "components/NumberInput/NumberInput";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WAD = BigInt("1000000000000000000");
+const MAINNET_CHAIN_IDS = new Set([1, 42161, 8453]); // Ethereum, Arbitrum One, Base
+
+function formatUsd(wad: bigint): string {
+  const n = parseFloat(formatEther(wad));
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
+}
+
+function formatToken(wad: bigint, symbol: string): string {
+  const n = parseFloat(formatEther(wad));
+  return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 6 })} ${symbol}`;
+}
+
+function formatPrice(wad: bigint): string {
+  const n = parseFloat(formatEther(wad));
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
+}
+
+// ---------------------------------------------------------------------------
+// Mini AUM sparkline (SVG)
+// ---------------------------------------------------------------------------
+
+function AumSparkline({ history }: { history: { aum: bigint }[] }) {
+  if (history.length < 2) {
+    return (
+      <div className="flex h-[120px] items-center justify-center text-13 text-slate-500">{t`Collecting data…`}</div>
+    );
+  }
+
+  const values = history.map((p) => Number(formatEther(p.aum)));
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const W = 400;
+  const H = 120;
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * W;
+    const y = H - ((v - min) / range) * (H - 20) - 10;
+    return `${x},${y}`;
+  });
+
+  const isPositive = values[values.length - 1] >= values[0];
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" preserveAspectRatio="none">
+      <polyline points={pts.join(" ")} fill="none" stroke={isPositive ? "#34d399" : "#f87171"} strokeWidth="2" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+type Tab = "deposit" | "withdraw";
+
+export default function VaultDetailPage() {
+  const { address } = useParams<{ address: string }>();
+  const history = useHistory();
+  const { account } = useWallet();
+  const { chainId } = useChainId();
+
+  const cfg = getVaultConfigByAddress(address);
+
+  const data = useVaultDetail(cfg!);
+  const actions = useVaultActions(cfg!, chainId);
+
+  const [activeTab, setActiveTab] = useState<Tab>("deposit");
+  const [depositInput, setDepositInput] = useState("");
+  const [withdrawInput, setWithdrawInput] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isTestnet = !MAINNET_CHAIN_IDS.has(chainId);
+
+  // ── Config missing guard ────────────────────────────────────────────────────
+  if (!cfg) {
+    return (
+      <div className="default-container page-layout">
+        <div className="mx-auto mt-40 max-w-[600px] text-center">
+          <p className="text-16 text-slate-400">{t`Vault not found: ${address}`}</p>
+          <Button variant="secondary" size="medium" className="mt-16" onClick={() => history.push("/vaults")}>
+            {t`← Back to Vaults`}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Derived values ──────────────────────────────────────────────────────────
+
+  const depositAmount: bigint = (() => {
+    try {
+      if (!depositInput || parseFloat(depositInput) <= 0) return 0n;
+      return parseUnits(depositInput, cfg.tokenDecimals);
+    } catch {
+      return 0n;
+    }
+  })();
+
+  const depositWad = cfg.tokenDecimals < 18 ? depositAmount * BigInt(10 ** (18 - cfg.tokenDecimals)) : depositAmount;
+  const estimatedShares = data.sharePrice > 0n ? (depositWad * WAD) / data.sharePrice : 0n;
+
+  const withdrawShares: bigint = (() => {
+    try {
+      if (!withdrawInput || parseFloat(withdrawInput) <= 0) return 0n;
+      return parseUnits(withdrawInput, 18);
+    } catch {
+      return 0n;
+    }
+  })();
+
+  const estimatedTokenOut: bigint =
+    withdrawShares > 0n && data.sharePrice > 0n && data.tokenPrice > 0n
+      ? (((withdrawShares * data.sharePrice) / WAD) * WAD) / data.tokenPrice
+      : 0n;
+
+  const needsApproval = depositAmount > 0n && actions.isApprovalNeeded(depositAmount);
+
+  // Below-AUM warning for Direct vault
+  const showDirectWarning = cfg.assetType === 0 && data.usdValue > 0n && data.aum < data.usdValue;
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  async function handleDeposit() {
+    if (depositAmount === 0n) return;
+    setIsSubmitting(true);
+    try {
+      await actions.deposit(depositAmount);
+      setDepositInput("");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleWithdraw() {
+    if (withdrawShares === 0n) return;
+    setIsSubmitting(true);
+    try {
+      await actions.withdraw(withdrawShares);
+      setWithdrawInput("");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleSetMaxWithdraw() {
+    if (data.vlpBalance > 0n) {
+      setWithdrawInput(formatEther(data.vlpBalance));
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="default-container page-layout">
+      <div className="mx-auto mt-24 max-w-[1100px]">
+        {/* Back link */}
+        <button
+          onClick={() => history.push("/vaults")}
+          className="mb-16 text-13 text-slate-400 transition-colors hover:text-white"
+        >
+          ← {t`Vaults`}
+        </button>
+
+        <div className="grid grid-cols-[1fr_360px] gap-20">
+          {/* ================================================================ */}
+          {/* Left column                                                       */}
+          {/* ================================================================ */}
+          <div className="space-y-20">
+            {/* Header */}
+            <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+              <div className="mb-8 flex items-center gap-12">
+                <div className="flex h-40 w-40 items-center justify-center rounded-full bg-slate-700 text-16 font-bold text-white">
+                  {cfg.symbol.slice(0, 2)}
+                </div>
+                <div>
+                  <div className="flex items-center gap-8">
+                    <h1 className="text-20 font-bold text-white">{cfg.symbol}</h1>
+                    <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[cfg.assetType]}`}>
+                      {ASSET_TYPE_LABEL[cfg.assetType]}
+                    </span>
+                    {cfg.assetType === 1 && (
+                      <span className="bg-emerald-900/40 text-emerald-400 animate-pulse rounded-full px-8 py-2 text-11">
+                        {t`Auto-growing`}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-2 text-13 text-slate-400">{cfg.name}</div>
+                </div>
+              </div>
+
+              {/* Price row */}
+              <div className="mt-12 flex items-baseline gap-8">
+                <span className="text-28 font-bold text-white">{formatPrice(data.tokenPrice)}</span>
+                <span className="text-14 text-slate-400">{t`per token`}</span>
+              </div>
+            </div>
+
+            {/* AUM Chart */}
+            <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+              <div className="mb-12 flex items-center justify-between">
+                <h2 className="text-14 font-semibold text-white">{t`AUM`}</h2>
+                <span className="text-13 text-slate-400">{t`Live (15s poll)`}</span>
+              </div>
+              <AumSparkline history={data.aumHistory} />
+            </div>
+
+            {/* Stats */}
+            <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+              <h2 className="mb-16 text-14 font-semibold text-white">{t`Stats`}</h2>
+              <div className="grid grid-cols-2 gap-16">
+                <StatRow label={t`Total AUM`} value={data.isLoading ? "—" : formatUsd(data.aum)} />
+                <StatRow label={t`Share Price`} value={data.isLoading ? "—" : formatPrice(data.sharePrice)} />
+                {account && (
+                  <StatRow label={t`My Deposit (USD)`} value={data.isLoading ? "—" : formatUsd(data.usdValue)} />
+                )}
+                {account && data.shortfall > 0n && (
+                  <StatRow label={t`Shortfall Debt`} value={formatToken(data.shortfall, cfg.symbol)} highlight="red" />
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* ================================================================ */}
+          {/* Right column                                                      */}
+          {/* ================================================================ */}
+          <div className="space-y-16">
+            {/* Direct vault warning */}
+            {showDirectWarning && (
+              <div className="text-red-300 rounded-4 border border-red-700 bg-red-900/30 px-16 py-12 text-13">
+                ⚠️ {t`Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled.`}
+              </div>
+            )}
+
+            {/* Shortfall warning */}
+            {data.shortfall > 0n && (
+              <div className="border-amber-700 bg-amber-900/30 text-amber-300 rounded-4 border px-16 py-12 text-13">
+                ⚠️{" "}
+                {t`You have a shortfall debt of ${formatToken(data.shortfall, cfg.symbol)}. This will be settled when the insurance fund is sufficient.`}
+              </div>
+            )}
+
+            {/* Deposit / Withdraw panel */}
+            <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary">
+              {/* Tab header */}
+              <div className="flex border-b border-stroke-primary">
+                {(["deposit", "withdraw"] as Tab[]).map((tab) => (
+                  <button
+                    key={tab}
+                    onClick={() => setActiveTab(tab)}
+                    className={`flex-1 py-12 text-14 font-medium transition-colors ${
+                      activeTab === tab
+                        ? "border-b-2 border-blue-400 text-white"
+                        : "hover:text-slate-200 text-slate-400"
+                    }`}
+                  >
+                    {tab === "deposit" ? t`Deposit` : t`Withdraw`}
+                  </button>
+                ))}
+              </div>
+
+              <div className="p-20">
+                {/* ── Deposit tab ─────────────────────────────────────────── */}
+                {activeTab === "deposit" && (
+                  <div className="flex flex-col gap-16">
+                    <div>
+                      <label className="mb-6 block text-12 text-slate-400">
+                        {t`Amount`} ({cfg.symbol})
+                      </label>
+                      <div className="flex items-center gap-8 rounded-4 border border-stroke-primary bg-slate-800 px-12 py-10">
+                        <NumberInput
+                          value={depositInput}
+                          onValueChange={(e: ChangeEvent<HTMLInputElement>) => setDepositInput(e.target.value)}
+                          placeholder="0.00"
+                          maxDecimals={cfg.tokenDecimals}
+                          className="bg-transparent flex-1 text-16 text-white outline-none"
+                        />
+                        <span className="text-14 font-medium text-slate-400">{cfg.symbol}</span>
+                      </div>
+                      {account && data.tokenBalance > 0n && (
+                        <div className="mt-4 text-12 text-slate-500">
+                          {t`Balance`}: {formatToken(data.tokenBalance, cfg.symbol)}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Preview */}
+                    {depositAmount > 0n && (
+                      <div className="space-y-4 text-13 text-slate-400">
+                        <div className="flex justify-between">
+                          <span>{t`Estimated VLP`}</span>
+                          <span className="text-white">{formatToken(estimatedShares, "VLP")}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span>{t`Share price`}</span>
+                          <span className="text-white">{formatPrice(data.sharePrice)}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    {!account ? (
+                      <div className="py-8 text-center text-14 text-slate-400">{t`Connect wallet to deposit`}</div>
+                    ) : needsApproval ? (
+                      <Button
+                        variant="primary"
+                        size="medium"
+                        disabled={depositAmount === 0n || isSubmitting || actions.isApproving}
+                        onClick={() => actions.approve()}
+                        className="w-full"
+                      >
+                        {actions.isApproving ? t`Approving…` : t`Approve ${cfg.symbol}`}
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="primary"
+                        size="medium"
+                        disabled={depositAmount === 0n || isSubmitting}
+                        onClick={handleDeposit}
+                        className="w-full"
+                      >
+                        {isSubmitting ? t`Depositing…` : t`Deposit`}
+                      </Button>
+                    )}
+                  </div>
+                )}
+
+                {/* ── Withdraw tab ─────────────────────────────────────────── */}
+                {activeTab === "withdraw" && (
+                  <div className="flex flex-col gap-16">
+                    <div>
+                      <div className="mb-6 flex justify-between">
+                        <label className="text-12 text-slate-400">{t`VLP Amount`}</label>
+                        {account && data.vlpBalance > 0n && (
+                          <button onClick={handleSetMaxWithdraw} className="text-12 text-blue-400 hover:text-blue-300">
+                            {t`Max`}: {parseFloat(formatEther(data.vlpBalance)).toFixed(4)} VLP
+                          </button>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-8 rounded-4 border border-stroke-primary bg-slate-800 px-12 py-10">
+                        <NumberInput
+                          value={withdrawInput}
+                          onValueChange={(e: ChangeEvent<HTMLInputElement>) => setWithdrawInput(e.target.value)}
+                          placeholder="0.000000"
+                          maxDecimals={18}
+                          className="bg-transparent flex-1 text-16 text-white outline-none"
+                        />
+                        <span className="text-14 font-medium text-slate-400">VLP</span>
+                      </div>
+                    </div>
+
+                    {/* Preview */}
+                    {withdrawShares > 0n && (
+                      <div className="space-y-4 text-13 text-slate-400">
+                        <div className="flex justify-between">
+                          <span>{t`Estimated ${cfg.symbol}`}</span>
+                          <span className="text-white">{formatToken(estimatedTokenOut, cfg.symbol)}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span>{t`USD value`}</span>
+                          <span className="text-white">{formatUsd((withdrawShares * data.sharePrice) / WAD)}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    {!account ? (
+                      <div className="py-8 text-center text-14 text-slate-400">{t`Connect wallet to withdraw`}</div>
+                    ) : (
+                      <Button
+                        variant="primary"
+                        size="medium"
+                        disabled={withdrawShares === 0n || isSubmitting || withdrawShares > data.vlpBalance}
+                        onClick={handleWithdraw}
+                        className="w-full"
+                      >
+                        {isSubmitting ? t`Withdrawing…` : t`Withdraw`}
+                      </Button>
+                    )}
+
+                    {withdrawShares > data.vlpBalance && data.vlpBalance > 0n && (
+                      <div className="text-12 text-red-400">{t`Amount exceeds your VLP balance`}</div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* My Position */}
+            {account && data.vlpBalance > 0n && (
+              <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+                <h2 className="mb-12 text-14 font-semibold text-white">{t`My Position`}</h2>
+                <div className="space-y-8 text-13">
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">{t`VLP Balance`}</span>
+                    <span className="text-white">{formatToken(data.vlpBalance, "VLP")}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">{t`USD Value`}</span>
+                    <span className="text-white">{formatUsd(data.usdValue)}</span>
+                  </div>
+                  {cfg.assetType === 1 && (
+                    <div className="flex justify-between">
+                      <span className="text-slate-400">{t`Token Balance`}</span>
+                      <span className="text-emerald-400">{formatToken(data.tokenBalance, cfg.symbol)}</span>
+                    </div>
+                  )}
+                  {cfg.assetType === 2 && data.tokenPrice > WAD && (
+                    <div className="flex justify-between">
+                      <span className="text-slate-400">{t`Price Yield`}</span>
+                      <span className="text-blue-400">
+                        +{((parseFloat(formatEther(data.tokenPrice)) - 1) * 100).toFixed(2)}%
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Debug panel (testnet only) */}
+            {isTestnet && cfg.isMock && (
+              <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+                <h2 className="text-slate-300 mb-12 text-13 font-semibold">{t`Debug Panel`}</h2>
+                <div className="flex flex-col gap-8">
+                  {/* Mint tokens */}
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={() => actions.debugMint(parseUnits("1000", cfg.tokenDecimals))}
+                    className="w-full text-12"
+                  >
+                    {t`Mint 1,000 ${cfg.symbol} to wallet`}
+                  </Button>
+
+                  {/* Rebasing-specific */}
+                  {cfg.assetType === 1 && (
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      onClick={() => actions.debugRebase(500)}
+                      className="w-full text-12"
+                    >
+                      {t`+5% Rebase`}
+                    </Button>
+                  )}
+
+                  {/* PriceShare / Direct price controls */}
+                  {(cfg.assetType === 2 || cfg.assetType === 0) && (
+                    <>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() => actions.debugSetPrice((data.tokenPrice * 110n) / 100n)}
+                        className="w-full text-12"
+                      >
+                        {t`Price +10%`}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() => actions.debugSetPrice((data.tokenPrice * 80n) / 100n)}
+                        className="text-orange-400 hover:text-orange-300 w-full text-12"
+                      >
+                        {t`Price -20%`} {cfg.assetType === 0 ? "(liquidation test)" : ""}
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StatRow helper
+// ---------------------------------------------------------------------------
+
+function StatRow({ label, value, highlight }: { label: string; value: string; highlight?: "red" }) {
+  return (
+    <div>
+      <div className="mb-2 text-12 text-slate-400">{label}</div>
+      <div className={`text-14 font-semibold ${highlight === "red" ? "text-red-400" : "text-white"}`}>{value}</div>
+    </div>
+  );
+}

--- a/src/pages/Vaults/VaultsPage.tsx
+++ b/src/pages/Vaults/VaultsPage.tsx
@@ -1,0 +1,154 @@
+/**
+ * VaultsPage.tsx
+ *
+ * Kamino Lend-style table view of all 4 Vaults.
+ * Route: /vaults
+ *
+ * Columns: Asset | Type | AUM | APY | My Deposit
+ * Interaction: row click → /vaults/:address
+ */
+
+import { t } from "@lingui/macro";
+import { formatEther } from "ethers";
+import { useState } from "react";
+import { useHistory } from "react-router-dom";
+
+import { useVaultList } from "domain/vantage/vaults/useVaultList";
+import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL } from "domain/vantage/vaults/vaultConfig";
+import useWallet from "lib/wallets/useWallet";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatUsd(wad: bigint): string {
+  const n = parseFloat(formatEther(wad));
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sort types
+// ---------------------------------------------------------------------------
+
+type SortKey = "aum" | "none";
+type SortDir = "asc" | "desc";
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function VaultsPage() {
+  const { account } = useWallet();
+  const history = useHistory();
+  const items = useVaultList();
+
+  const [sortKey, setSortKey] = useState<SortKey>("none");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  }
+
+  const sorted = [...items].sort((a, b) => {
+    if (sortKey === "aum") {
+      return sortDir === "desc" ? Number(b.aum - a.aum) : Number(a.aum - b.aum);
+    }
+    return 0;
+  });
+
+  return (
+    <div className="default-container page-layout">
+      <div className="mx-auto mt-24 max-w-[900px]">
+        {/* Header */}
+        <div className="mb-24">
+          <h1 className="text-h1">{t`Vaults`}</h1>
+          <p className="text-body-medium mt-4 text-slate-400">{t`Provide liquidity to earn yield from RWA assets.`}</p>
+        </div>
+
+        {/* Table */}
+        <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary">
+          {/* Table header */}
+          <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-0 border-b border-stroke-primary px-20 py-12 text-12 text-slate-400">
+            <div>{t`Asset`}</div>
+            <div
+              className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "aum" ? "text-white" : ""}`}
+              onClick={() => handleSort("aum")}
+            >
+              {t`AUM`} {sortKey === "aum" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
+            </div>
+            <div className="text-right">{t`Type`}</div>
+            <div className="text-right">{account ? t`My Deposit` : ""}</div>
+          </div>
+
+          {/* Rows */}
+          {sorted.map((item) => (
+            <div
+              key={item.key}
+              onClick={() => item.vaultAddress && history.push(`/vaults/${item.vaultAddress}`)}
+              className="grid cursor-pointer grid-cols-[2fr_1fr_1fr_1fr] items-center gap-0 border-b border-stroke-primary px-20 py-16 transition-colors last:border-0 hover:bg-slate-800/40"
+            >
+              {/* Asset */}
+              <div className="flex items-center gap-12">
+                <div className="flex h-36 w-36 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
+                  {item.symbol.slice(0, 2)}
+                </div>
+                <div>
+                  <div className="text-15 font-semibold text-white">{item.symbol}</div>
+                  <div className="text-12 text-slate-400">{item.name}</div>
+                </div>
+              </div>
+
+              {/* AUM */}
+              <div className="text-right">
+                {item.isLoading ? (
+                  <span className="text-slate-500">—</span>
+                ) : (
+                  <span className="text-15 font-medium text-white">{formatUsd(item.aum)}</span>
+                )}
+              </div>
+
+              {/* Type badge */}
+              <div className="flex justify-end">
+                <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[item.assetType]}`}>
+                  {ASSET_TYPE_LABEL[item.assetType]}
+                </span>
+              </div>
+
+              {/* My Deposit */}
+              <div className="text-right">
+                {!account ? (
+                  <span className="text-14 text-slate-500">—</span>
+                ) : item.isLoading ? (
+                  <span className="text-14 text-slate-500">…</span>
+                ) : item.usdValue > 0n ? (
+                  <span className="text-15 font-medium text-white">{formatUsd(item.usdValue)}</span>
+                ) : (
+                  <span className="text-14 text-slate-500">—</span>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {/* Empty state */}
+          {items.length === 0 && (
+            <div className="py-40 text-center text-14 text-slate-400">
+              {t`No vaults configured. Deploy contracts first.`}
+            </div>
+          )}
+        </div>
+
+        {/* Footer hint */}
+        {!account && (
+          <p className="mt-16 text-center text-13 text-slate-500">{t`Connect your wallet to see your deposits.`}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/vantage/abis/MockRebasingRWA.json
+++ b/src/vantage/abis/MockRebasingRWA.json
@@ -1,0 +1,184 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "yieldAdded", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalPooledAssets", "type": "uint256" }
+    ],
+    "name": "Rebased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "assetType",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "amount", "type": "uint256" }],
+    "name": "rebase",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "basisPoints", "type": "uint256" }],
+    "name": "rebaseByUI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint8", "name": "decimals_", "type": "uint8" }],
+    "name": "setDecimals",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "sharesOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalPooledAssets",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalShares",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/vantage/abis/MockStandardRWA.json
+++ b/src/vantage/abis/MockStandardRWA.json
@@ -1,0 +1,141 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "assetTypeId_", "type": "uint8" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "assetType",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint8", "name": "decimals_", "type": "uint8" }],
+    "name": "setDecimals",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
## 概要

4 Vault（USDC / mBUIDL / mUSDY / mRWA）の一覧ページ `/vaults` と詳細ページ `/vaults/:address` を実装。

- **一覧**: Kamino Lend スタイルのテーブル（AUM ソート対応）
- **詳細**: Uniswap スタイルの 2 カラムレイアウト（左: チャート + Stats、右: 入出金 + Debug）

## 追加ファイル

### Domain hooks
| ファイル | 概要 |
|---|---|
| `domain/vantage/vaults/vaultConfig.ts` | 4 vault の静的設定（アドレス・型・decimals）|
| `domain/vantage/vaults/useVaultList.ts` | 15s ポーリングで AUM / sharePrice / My Deposit を取得 |
| `domain/vantage/vaults/useVaultDetail.ts` | 詳細データ取得（Rebasing は 5s ポーリング）|
| `domain/vantage/vaults/useVaultActions.ts` | deposit / withdraw / debug アクション |

### Pages
| ファイル | 概要 |
|---|---|
| `pages/Vaults/VaultsPage.tsx` | Kamino 参考テーブル（AUM ソート対応）|
| `pages/VaultDetail/VaultDetailPage.tsx` | Uniswap 参考 2 カラムレイアウト |

### ABIs
- `vantage/abis/MockRebasingRWA.json`: `rebaseByUI` / `assetType()=1`
- `vantage/abis/MockStandardRWA.json`: `assetType()=0 or 2`

### Routes 追加 (`MainRoutes.tsx`)
- `/vaults` → VaultsPage
- `/vaults/:address` → VaultDetailPage

## 種別ごとの UI 差分

| 種別 | assetType | 固有表示 |
|---|---|---|
| **Rebasing** | 1 | 5s 高頻度ポーリング、「Auto-growing」バッジ、トークン残高リアルタイム表示 |
| **PriceShare** | 2 | 現在価格 vs 基準価格の利回り表示、Debug Price +10%/-20% |
| **Direct** | 0 | AUM < My Deposit で赤色警告バナー、Debug Price -20%（清算テスト用）|
| **USDC** | stable | 安定コインバッジ、利回り表示なし |

## Debug Panel（testnet 限定）

- **Mint 1,000 tokens** to wallet（全種別）
- **+5% Rebase**（Rebasing のみ）
- **Price +10% / -20%**（PriceShare / Direct）

## 前提

- `bcellar-monorepo` PR #163 のデプロイスクリプルが先にマージ・実行され、`frontend-localhost.json` に `mockRWALPManagers` / `mockRWALPTokens` / `MockPriceFeed` が含まれている必要あり
- デプロイ後に `vantage/deployments/frontend-localhost.json` をコピーして `addresses` を更新

## テスト計画

- [ ] `pnpm dev` で `/vaults` にアクセスし 4 vault が表示される
- [ ] 行クリックで `/vaults/:address` に遷移する
- [ ] USDC vault: Deposit → Approve → Deposit トランザクションフローが動作する
- [ ] Mock RWA vault: Debug Panel で Mint → Deposit が動作する
- [ ] Rebasing vault: Deposit 後に +5% Rebase でトークン残高がリアルタイム増加する
- [ ] PriceShare vault: Price +10% で利回り表示が更新される
- [ ] Direct vault: Price -20% で AUM < My Deposit の警告が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)