### PR TITLE
feat: APY表示・Tx履歴・Debug機能の追加 (Issue #162)

### DIFF
--- a/src/domain/vantage/vaults/useVaultActions.ts
+++ b/src/domain/vantage/vaults/useVaultActions.ts
@@ -9,21 +9,24 @@
  *
  *   withdraw(shares)
  *     LPManager.removeLiquidity  (no approve needed — LPManager burns VLP)
+ *
+ * NOTE: allowance is checked via a direct ethers call instead of
+ * useTokensAllowanceData, because the GMX Multicall infrastructure does not
+ * support localhost (chainId 31337). The direct approach works on all networks.
  */
 
 import { t } from "@lingui/macro";
 import { Contract, ethers } from "ethers";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { maxUint256 } from "viem";
 
 import { DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
 import { usePendingTxns } from "context/PendingTxnsContext/PendingTxnsContext";
-import { useTokensAllowanceData } from "domain/synthetics/tokens/useTokenAllowanceData";
 import { pushSuccessNotification } from "lib/contracts/notifications";
 import { helperToast } from "lib/helperToast";
+import { getProvider } from "lib/rpc";
 import useWallet from "lib/wallets/useWallet";
 import TokenAbi from "sdk/abis/Token";
-import type { AnyChainId } from "sdk/configs/chains";
 import LPManagerAbi from "vantage/abis/LPManager.json";
 
 import type { VaultConfig } from "./vaultConfig";
@@ -42,38 +45,58 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
   );
 
   // ---------------------------------------------------------------------------
-  // Approval state
+  // Allowance — direct ethers call (works on localhost + all testnets)
   // ---------------------------------------------------------------------------
 
-  const [approvingToken, setApprovingToken] = useState<string | undefined>();
+  const [allowance, setAllowance] = useState<bigint>(0n);
+  const [isApproving, setIsApproving] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const { tokensAllowanceData, isLoading: isAllowanceLoading } = useTokensAllowanceData(chainId as AnyChainId, {
-    spenderAddress: cfg.lpManagerAddress,
-    tokenAddresses: cfg.tokenAddress ? [cfg.tokenAddress] : [],
-  });
+  const fetchAllowance = useCallback(async () => {
+    if (!account || !cfg.tokenAddress || !cfg.lpManagerAddress) return;
+    try {
+      const provider = getProvider(undefined, chainId);
+      const token = new Contract(cfg.tokenAddress, TokenAbi, provider);
+      const raw = (await token.allowance(account, cfg.lpManagerAddress)) as bigint;
+      setAllowance(raw);
+    } catch {
+      // Silently ignore RPC errors
+    }
+  }, [account, cfg.tokenAddress, cfg.lpManagerAddress, chainId]);
+
+  useEffect(() => {
+    fetchAllowance();
+    intervalRef.current = setInterval(fetchAllowance, 5_000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [fetchAllowance]);
 
   const isApprovalNeeded = useCallback(
     (amount: bigint): boolean => {
-      if (!tokensAllowanceData) return true;
-      const allowance = tokensAllowanceData[cfg.tokenAddress];
-      if (allowance === undefined) return true;
+      if (!account) return false; // wallet not connected — don't show approve
       return allowance < amount;
     },
-    [tokensAllowanceData, cfg.tokenAddress]
+    [allowance, account]
   );
+
+  // ---------------------------------------------------------------------------
+  // Approve
+  // ---------------------------------------------------------------------------
 
   const approve = useCallback(async (): Promise<void> => {
     if (!signer) return;
-    setApprovingToken(cfg.tokenAddress);
+    setIsApproving(true);
     try {
       const contract = new Contract(cfg.tokenAddress, TokenAbi, signer);
       const tx = await contract.approve(cfg.lpManagerAddress, maxUint256);
       helperToast.info(t`Approval submitted — waiting for confirmation…`);
       await tx.wait();
+      await fetchAllowance(); // refresh immediately after approval
     } finally {
-      setApprovingToken(undefined);
+      setIsApproving(false);
     }
-  }, [signer, cfg.tokenAddress, cfg.lpManagerAddress]);
+  }, [signer, cfg.tokenAddress, cfg.lpManagerAddress, fetchAllowance]);
 
   // ---------------------------------------------------------------------------
   // Deposit
@@ -210,8 +233,7 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
     debugSetPrice,
     debugMint,
     isApprovalNeeded,
-    isAllowanceLoading,
-    isApproving: Boolean(approvingToken),
+    isApproving,
     isReady: Boolean(account && signer),
   };
 }

--- a/src/domain/vantage/vaults/useVaultActions.ts
+++ b/src/domain/vantage/vaults/useVaultActions.ts
@@ -28,6 +28,7 @@ import { getProvider } from "lib/rpc";
 import useWallet from "lib/wallets/useWallet";
 import TokenAbi from "sdk/abis/Token";
 import LPManagerAbi from "vantage/abis/LPManager.json";
+import VaultAbi from "vantage/abis/Vault.json";
 
 import type { VaultConfig } from "./vaultConfig";
 
@@ -49,6 +50,7 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
   // ---------------------------------------------------------------------------
 
   const [allowance, setAllowance] = useState<bigint>(0n);
+  const [isAllowanceLoaded, setIsAllowanceLoaded] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -59,12 +61,15 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
       const token = new Contract(cfg.tokenAddress, TokenAbi, provider);
       const raw = (await token.allowance(account, cfg.lpManagerAddress)) as bigint;
       setAllowance(raw);
+      setIsAllowanceLoaded(true);
     } catch {
       // Silently ignore RPC errors
     }
   }, [account, cfg.tokenAddress, cfg.lpManagerAddress, chainId]);
 
   useEffect(() => {
+    setIsAllowanceLoaded(false);
+    setAllowance(0n);
     fetchAllowance();
     intervalRef.current = setInterval(fetchAllowance, 5_000);
     return () => {
@@ -204,6 +209,24 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
   );
 
   // ---------------------------------------------------------------------------
+  // Debug: Sync NAV (calls vault.syncNetAssetValue — Keeper role required)
+  // ---------------------------------------------------------------------------
+
+  const debugSyncNav = useCallback(async (): Promise<void> => {
+    if (!signer) return;
+    try {
+      const vault = new Contract(cfg.vaultAddress, VaultAbi, signer);
+      const tx = await (
+        vault as ethers.Contract & { syncNetAssetValue: () => Promise<{ wait: () => Promise<unknown> }> }
+      ).syncNetAssetValue();
+      await tx.wait();
+      helperToast.success(t`NAV synced`);
+    } catch (err: unknown) {
+      helperToast.error(err instanceof Error ? err.message : String(err));
+    }
+  }, [signer, cfg.vaultAddress]);
+
+  // ---------------------------------------------------------------------------
   // Debug: Mint tokens to user (testnet only)
   // ---------------------------------------------------------------------------
 
@@ -232,9 +255,11 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
     debugRebase,
     debugSetPrice,
     debugMint,
+    debugSyncNav,
     isApprovalNeeded,
     isApproving,
     allowance,
+    isAllowanceLoaded,
     isReady: Boolean(account && signer),
   };
 }

--- a/src/domain/vantage/vaults/useVaultActions.ts
+++ b/src/domain/vantage/vaults/useVaultActions.ts
@@ -234,6 +234,7 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
     debugMint,
     isApprovalNeeded,
     isApproving,
+    allowance,
     isReady: Boolean(account && signer),
   };
 }

--- a/src/domain/vantage/vaults/useVaultApy.ts
+++ b/src/domain/vantage/vaults/useVaultApy.ts
@@ -1,0 +1,145 @@
+/**
+ * useVaultApy.ts
+ *
+ * Computes annualised percentage yield (APY) per vault type:
+ *
+ *   Rebasing  — reads on-chain `Rebased` events, compounds the growth factors,
+ *               then annualises over the observed time window.
+ *               Requires ≥2 rebase events to produce a value.
+ *
+ *   PriceShare — tracks the token price polled from MockPriceFeed in memory.
+ *               Once the price has moved from the initial observation the rate
+ *               is annualised (simple, not compounded).
+ *               Returns null until the first price change is detected.
+ *
+ *   Direct / Stable — always returns null (no yield expectation).
+ */
+
+import { Contract } from "ethers";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
+import MockPriceFeedAbi from "vantage/abis/MockPriceFeed.json";
+import MockRebasingRWAAbi from "vantage/abis/MockRebasingRWA.json";
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
+
+import type { VaultConfig } from "./vaultConfig";
+
+const d = localhostDeployment.addresses as { MockPriceFeed?: string };
+const MOCK_PRICE_FEED = d.MockPriceFeed ?? "";
+
+const YEAR_SEC = 365 * 24 * 3600;
+const BLOCK_LOOKBACK = 100_000;
+const MIN_TIMESPAN_SEC = 10; // ignore windows shorter than this
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useVaultApy(cfg: VaultConfig): number | null {
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const [apy, setApy] = useState<number | null>(null);
+
+  // For PriceShare: remember the first price observation
+  const priceInitRef = useRef<{ price: bigint; ts: number } | null>(null);
+
+  const compute = useCallback(async () => {
+    // ── Rebasing ────────────────────────────────────────────────────────────
+    if (cfg.assetType === 1) {
+      try {
+        const token = new Contract(cfg.tokenAddress, MockRebasingRWAAbi, provider);
+        const latest = await provider.getBlockNumber();
+        const from = Math.max(0, latest - BLOCK_LOOKBACK);
+
+        const logs = await token.queryFilter(token.filters.Rebased(), from);
+        if (logs.length < 2) {
+          setApy(null);
+          return;
+        }
+
+        const [firstBlk, lastBlk] = await Promise.all([
+          provider.getBlock(logs[0].blockNumber),
+          provider.getBlock(logs[logs.length - 1].blockNumber),
+        ]);
+        const timespan = (lastBlk?.timestamp ?? 0) - (firstBlk?.timestamp ?? 0);
+        if (timespan < MIN_TIMESPAN_SEC) {
+          setApy(null);
+          return;
+        }
+
+        // Compound all observed rebase growth factors
+        let growth = 1.0;
+        for (const log of logs) {
+          const e = token.interface.parseLog({ topics: [...log.topics], data: log.data });
+          const yieldAdded = Number(e?.args.yieldAdded ?? 0n);
+          const newTotal = Number(e?.args.newTotalPooledAssets ?? 0n);
+          const prevTotal = newTotal - yieldAdded;
+          if (prevTotal > 0) growth *= newTotal / prevTotal;
+        }
+
+        // Annualise: (1 + r)^(year / timespan) − 1
+        const annualised = Math.pow(growth, YEAR_SEC / timespan) - 1;
+        setApy(isFinite(annualised) ? annualised : null);
+      } catch {
+        setApy(null);
+      }
+      return;
+    }
+
+    // ── PriceShare ──────────────────────────────────────────────────────────
+    if (cfg.assetType === 2) {
+      if (!MOCK_PRICE_FEED) {
+        setApy(null);
+        return;
+      }
+      try {
+        const feed = new Contract(MOCK_PRICE_FEED, MockPriceFeedAbi, provider);
+        const currentPrice = (await feed.prices(cfg.tokenAddress)) as bigint;
+        if (currentPrice === 0n) {
+          setApy(null);
+          return;
+        }
+
+        const now = Date.now();
+        if (!priceInitRef.current) {
+          priceInitRef.current = { price: currentPrice, ts: now };
+          setApy(null);
+          return;
+        }
+
+        const elapsed = (now - priceInitRef.current.ts) / 1000;
+        if (elapsed < MIN_TIMESPAN_SEC) {
+          setApy(null);
+          return;
+        }
+
+        const initPrice = priceInitRef.current.price;
+        if (currentPrice <= initPrice) {
+          setApy(null);
+          return;
+        }
+
+        const simpleRate = Number(currentPrice - initPrice) / Number(initPrice);
+        setApy(simpleRate * (YEAR_SEC / elapsed));
+      } catch {
+        setApy(null);
+      }
+      return;
+    }
+
+    // ── Direct / Stable ─────────────────────────────────────────────────────
+    setApy(null);
+  }, [cfg, provider]);
+
+  useEffect(() => {
+    priceInitRef.current = null; // reset on config change
+    compute();
+    const interval = setInterval(compute, cfg.assetType === 1 ? 5_000 : 15_000);
+    return () => clearInterval(interval);
+  }, [compute, cfg.assetType]);
+
+  return apy;
+}

--- a/src/domain/vantage/vaults/useVaultDetail.ts
+++ b/src/domain/vantage/vaults/useVaultDetail.ts
@@ -14,9 +14,8 @@
  */
 
 import { Contract } from "ethers";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
 import { getProvider } from "lib/rpc";
 import useWallet from "lib/wallets/useWallet";
 import LPManagerAbi from "vantage/abis/LPManager.json";
@@ -47,6 +46,7 @@ export interface VaultDetailData {
   shortfall: bigint; // user's shortfall debt for this token
   aumHistory: AumDataPoint[];
   isLoading: boolean;
+  refresh: () => Promise<void>; // manually trigger a data refetch
 }
 
 // ---------------------------------------------------------------------------
@@ -61,11 +61,13 @@ const MAX_HISTORY_POINTS = 50;
 const d = localhostDeployment.addresses as { MockPriceFeed?: string };
 const MOCK_PRICE_FEED = d.MockPriceFeed ?? "";
 
-export function useVaultDetail(cfg: VaultConfig): VaultDetailData {
-  const { account } = useWallet();
-  const provider = getProvider(undefined, DEFAULT_SETTLEMENT_CHAIN_ID);
+type VaultDetailState = Omit<VaultDetailData, "refresh">;
 
-  const [data, setData] = useState<VaultDetailData>({
+export function useVaultDetail(cfg: VaultConfig, chainId: number): VaultDetailData {
+  const { account } = useWallet();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const [data, setData] = useState<VaultDetailState>({
     aum: 0n,
     sharePrice: WAD,
     tokenPrice: WAD,
@@ -80,54 +82,58 @@ export function useVaultDetail(cfg: VaultConfig): VaultDetailData {
   const aumHistoryRef = useRef<AumDataPoint[]>([]);
 
   const fetch = useCallback(async () => {
+    const vault = new Contract(cfg.vaultAddress, VaultAbi, provider);
+    const lpManager = new Contract(cfg.lpManagerAddress, LPManagerAbi, provider);
+    const lpToken = new Contract(cfg.lpTokenAddress, LPTokenAbi, provider);
+    const token = new Contract(cfg.tokenAddress, MockERC20Abi, provider);
+
+    // --- User balances: fetch independently so they always display ---
+    const [vlpBalance, tokenBalance, shortfall] = await Promise.all([
+      account ? (lpToken.balanceOf(account) as Promise<bigint>).catch(() => 0n) : Promise.resolve(0n),
+      account ? (token.balanceOf(account) as Promise<bigint>).catch(() => 0n) : Promise.resolve(0n),
+      account
+        ? (vault.userShortfallDebt(account, cfg.tokenAddress) as Promise<bigint>).catch(() => 0n)
+        : Promise.resolve(0n),
+    ]);
+
+    // --- Vault state: may fail if no liquidity yet ---
+    let aum = 0n;
+    let sharePrice = WAD;
     try {
-      const vault = new Contract(cfg.vaultAddress, VaultAbi, provider);
-      const lpManager = new Contract(cfg.lpManagerAddress, LPManagerAbi, provider);
-      const lpToken = new Contract(cfg.lpTokenAddress, LPTokenAbi, provider);
-      const token = new Contract(cfg.tokenAddress, MockERC20Abi, provider);
-
-      const fetchPromises: Promise<unknown>[] = [
-        vault.getAUM(),
-        lpManager.getSharePrice(),
-        account ? lpToken.balanceOf(account) : Promise.resolve(0n),
-        account ? token.balanceOf(account) : Promise.resolve(0n),
-        account ? vault.userShortfallDebt(account, cfg.tokenAddress) : Promise.resolve(0n),
-      ];
-
-      // Fetch token price from MockPriceFeed for PriceShare / Direct vaults
-      let tokenPrice: bigint = WAD;
-      if (MOCK_PRICE_FEED && (cfg.assetType === 0 || cfg.assetType === 2)) {
-        const feed = new Contract(MOCK_PRICE_FEED, MockPriceFeedAbi, provider);
-        try {
-          tokenPrice = (await feed.prices(cfg.tokenAddress)) as bigint;
-          if (tokenPrice === 0n) tokenPrice = WAD;
-        } catch {
-          tokenPrice = WAD;
-        }
-      }
-
-      const [aum, sharePrice, vlpBalance, tokenBalance, shortfall] = (await Promise.all(fetchPromises)) as bigint[];
-
-      const usdValue = (vlpBalance * sharePrice) / WAD;
-
-      // Append AUM to history
-      const point: AumDataPoint = { timestamp: Date.now(), aum };
-      aumHistoryRef.current = [...aumHistoryRef.current.slice(-MAX_HISTORY_POINTS + 1), point];
-
-      setData({
-        aum,
-        sharePrice,
-        tokenPrice,
-        vlpBalance,
-        usdValue,
-        tokenBalance,
-        shortfall,
-        aumHistory: [...aumHistoryRef.current],
-        isLoading: false,
-      });
+      [aum, sharePrice] = (await Promise.all([vault.getAUM(), lpManager.getSharePrice()])) as bigint[];
     } catch {
-      setData((prev) => ({ ...prev, isLoading: false }));
+      // Keep defaults when vault is not yet seeded
     }
+
+    // --- Token price from MockPriceFeed (PriceShare / Direct) ---
+    let tokenPrice: bigint = WAD;
+    if (MOCK_PRICE_FEED && (cfg.assetType === 0 || cfg.assetType === 2)) {
+      const feed = new Contract(MOCK_PRICE_FEED, MockPriceFeedAbi, provider);
+      try {
+        tokenPrice = (await feed.prices(cfg.tokenAddress)) as bigint;
+        if (tokenPrice === 0n) tokenPrice = WAD;
+      } catch {
+        tokenPrice = WAD;
+      }
+    }
+
+    const usdValue = (vlpBalance * sharePrice) / WAD;
+
+    // Append AUM to history
+    const point: AumDataPoint = { timestamp: Date.now(), aum };
+    aumHistoryRef.current = [...aumHistoryRef.current.slice(-MAX_HISTORY_POINTS + 1), point];
+
+    setData({
+      aum,
+      sharePrice,
+      tokenPrice,
+      vlpBalance,
+      usdValue,
+      tokenBalance,
+      shortfall,
+      aumHistory: [...aumHistoryRef.current],
+      isLoading: false,
+    });
   }, [cfg, account, provider]);
 
   useEffect(() => {
@@ -138,5 +144,5 @@ export function useVaultDetail(cfg: VaultConfig): VaultDetailData {
     return () => clearInterval(timer);
   }, [fetch, cfg.assetType]);
 
-  return data;
+  return { ...data, refresh: fetch };
 }

--- a/src/domain/vantage/vaults/useVaultList.ts
+++ b/src/domain/vantage/vaults/useVaultList.ts
@@ -8,9 +8,9 @@
  */
 
 import { Contract } from "ethers";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { DEFAULT_SETTLEMENT_CHAIN_ID } from "config/chains";
+import { useChainId } from "lib/chains";
 import { getProvider } from "lib/rpc";
 import useWallet from "lib/wallets/useWallet";
 import LPManagerAbi from "vantage/abis/LPManager.json";
@@ -40,7 +40,8 @@ const POLL_INTERVAL_MS = 15_000;
 
 export function useVaultList(): VaultListItem[] {
   const { account } = useWallet();
-  const provider = getProvider(undefined, DEFAULT_SETTLEMENT_CHAIN_ID);
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
 
   const buildInitial = (): VaultListItem[] =>
     VAULT_CONFIGS.map((cfg) => ({

--- a/src/domain/vantage/vaults/useVaultTxHistory.ts
+++ b/src/domain/vantage/vaults/useVaultTxHistory.ts
@@ -1,0 +1,103 @@
+/**
+ * useVaultTxHistory.ts
+ *
+ * Fetches AddLiquidity / RemoveLiquidity events from the vault's LPManager
+ * for the connected wallet. Returns the 20 most recent transactions.
+ */
+
+import { Contract } from "ethers";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+import LPManagerAbi from "vantage/abis/LPManager.json";
+
+import type { VaultConfig } from "./vaultConfig";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TxType = "deposit" | "withdraw";
+
+export interface VaultTx {
+  type: TxType;
+  txHash: string;
+  blockNumber: number;
+  tokenAmount: bigint;
+  usdValue: bigint; // only on deposit; 0n for withdraw
+  sharesMinted: bigint; // only on deposit; 0n for withdraw
+  sharesBurned: bigint; // only on withdraw; 0n for deposit
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const MAX_TXS = 20;
+const BLOCK_LOOKBACK = 100_000; // scan last 100k blocks (localhost)
+
+export function useVaultTxHistory(cfg: VaultConfig): { txs: VaultTx[]; isLoading: boolean } {
+  const { account } = useWallet();
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const [txs, setTxs] = useState<VaultTx[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetch = useCallback(async () => {
+    if (!account || !cfg.lpManagerAddress) return;
+    setIsLoading(true);
+    try {
+      const lpManager = new Contract(cfg.lpManagerAddress, LPManagerAbi, provider);
+      const latestBlock = await provider.getBlockNumber();
+      const fromBlock = Math.max(0, latestBlock - BLOCK_LOOKBACK);
+
+      const [depositLogs, withdrawLogs] = await Promise.all([
+        lpManager.queryFilter(lpManager.filters.AddLiquidity(account), fromBlock),
+        lpManager.queryFilter(lpManager.filters.RemoveLiquidity(account), fromBlock),
+      ]);
+
+      const deposits: VaultTx[] = depositLogs.map((log) => {
+        const e = lpManager.interface.parseLog({ topics: [...log.topics], data: log.data });
+        return {
+          type: "deposit",
+          txHash: log.transactionHash,
+          blockNumber: log.blockNumber,
+          tokenAmount: e?.args.tokenAmount as bigint,
+          usdValue: e?.args.usdValue as bigint,
+          sharesMinted: e?.args.sharesMinted as bigint,
+          sharesBurned: 0n,
+        };
+      });
+
+      const withdraws: VaultTx[] = withdrawLogs.map((log) => {
+        const e = lpManager.interface.parseLog({ topics: [...log.topics], data: log.data });
+        return {
+          type: "withdraw",
+          txHash: log.transactionHash,
+          blockNumber: log.blockNumber,
+          tokenAmount: e?.args.tokenAmount as bigint,
+          usdValue: 0n,
+          sharesMinted: 0n,
+          sharesBurned: e?.args.sharesBurned as bigint,
+        };
+      });
+
+      const all = [...deposits, ...withdraws].sort((a, b) => b.blockNumber - a.blockNumber).slice(0, MAX_TXS);
+
+      setTxs(all);
+    } catch {
+      // Silently ignore RPC errors
+    } finally {
+      setIsLoading(false);
+    }
+  }, [account, cfg.lpManagerAddress, provider]);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { txs, isLoading };
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Balance"
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1265,6 +1265,10 @@ msgstr "Liquidität nur auf {chainNames} verfügbar. Wechseln Sie das Netzwerk, 
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "Externer Tausch {0} zu {1}"
@@ -4648,6 +4652,7 @@ msgstr "Externe Swaps fehlschlagen lassen"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "GM mit {0} und {1} kaufen bis zu den unten angegebenen Limits"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Einzahlung"
 
@@ -9472,6 +9478,10 @@ msgstr "TRACKER"
 msgid "Select network"
 msgstr "Netzwerk auswählen"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "Kein Verlust des Fonds-Eigentums"
@@ -9614,6 +9624,11 @@ msgstr "Verwenden Sie die TP/SL-Schaltfläche, um TP/SL-Orders zu setzen."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "Guthaben wird übertragen nach..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Netzwerkgebühr"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Balance"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1265,6 +1265,10 @@ msgstr "Liquidity only available on {chainNames}. Switch networks to continue."
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr "Transactions"
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "External swap {0} to {1}"
@@ -4648,6 +4652,7 @@ msgstr "Fail external swaps"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "Buy GM with {0} and {1} up to the caps below"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Deposit"
 
@@ -9472,6 +9478,10 @@ msgstr "TRACKER"
 msgid "Select network"
 msgstr "Select network"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr "NAV synced"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "No loss of fund ownership"
@@ -9615,6 +9625,11 @@ msgstr "Use the TP/SL button to set TP/SL orders."
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
 msgstr "Close Long"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
+msgstr "APY"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Traders referred on Arbitrum"
@@ -10694,6 +10709,10 @@ msgstr "Funds bridging to..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Network fee"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr "Sync NAV"
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Balance"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1265,6 +1265,10 @@ msgstr "Liquidez disponible únicamente en {chainNames}. Cambie de red para cont
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "Intercambio externo de {0} a {1}"
@@ -4648,6 +4652,7 @@ msgstr "Forzar fallo de intercambios externos"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "Comprar GM con {0} y {1} hasta los límites indicados a continuación"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Depositar"
 
@@ -9472,6 +9478,10 @@ msgstr "TRACKER"
 msgid "Select network"
 msgstr "Seleccionar red"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "Sin pérdida de propiedad de fondos"
@@ -9614,6 +9624,11 @@ msgstr "Utilice el botón TP/SL para establecer órdenes TP/SL."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "Fondos transfiriéndose a..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Comisión de red"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Solde"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1265,6 +1265,10 @@ msgstr "Liquidité disponible uniquement sur {chainNames}. Changez de réseau po
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "Échange externe de {0} vers {1}"
@@ -4648,6 +4652,7 @@ msgstr "Forcer l'échec des swaps externes"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "Acheter des GM avec {0} et {1} jusqu'aux plafonds ci-dessous"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Dépôt"
 
@@ -9472,6 +9478,10 @@ msgstr "TRACKER"
 msgid "Select network"
 msgstr "Sélectionner le réseau"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "Aucune perte de propriété des fonds"
@@ -9614,6 +9624,11 @@ msgstr "Utilisez le bouton TP/SL pour définir des ordres TP/SL."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "Transfert des fonds vers..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Frais de réseau"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1 時間"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "残高"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1265,6 +1265,10 @@ msgstr "流動性は {chainNames} でのみ利用可能です。続行するに�
 msgid "Stop-Loss"
 msgstr "ストップロス"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "外部スワップ {0} → {1}"
@@ -4648,6 +4652,7 @@ msgstr "外部スワップを失敗させる"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "以下の上限まで{0}と{1}でGMを購入できます"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "入金"
 
@@ -9472,6 +9478,10 @@ msgstr "TRACKER"
 msgid "Select network"
 msgstr "ネットワークを選択"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "資金所有権の損失なし"
@@ -9614,6 +9624,11 @@ msgstr "TP/SLボタンを使用してTP/SL注文を設定してください。"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "ブリッジ送金中..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "ネットワーク手数料"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1265,6 +1265,10 @@ msgstr "유동성은 {chainNames}에서만 이용 가능합니다. 계속하려�
 msgid "Stop-Loss"
 msgstr "손절매"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "외부 스왑 {0} → {1}"
@@ -4648,6 +4652,7 @@ msgstr "외부 스왑 실패 처리"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "아래 한도까지 {0} 및 {1}(으)로 GM을 구매할 수 있습니다
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "예치"
 
@@ -9472,6 +9478,10 @@ msgstr "트래커"
 msgid "Select network"
 msgstr "네트워크 선택"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "자금 소유권 손실 없음"
@@ -9614,6 +9624,11 @@ msgstr "TP/SL 버튼을 사용하여 TP/SL 주문을 설정하십시오."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "자금 브릿징 중..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "네트워크 수수료"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1시간"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "잔고"
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1265,6 +1265,10 @@ msgstr ""
 msgid "Stop-Loss"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr ""
@@ -4648,6 +4652,7 @@ msgstr ""
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr ""
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr ""
 
@@ -9472,6 +9478,10 @@ msgstr ""
 msgid "Select network"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr ""
@@ -9614,6 +9624,11 @@ msgstr ""
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10693,6 +10708,10 @@ msgstr ""
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
 msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -7464,6 +7464,7 @@ msgstr ""
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr ""
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1ч"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "Баланс"
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1265,6 +1265,10 @@ msgstr "Ликвидность доступна только в сети {chainN
 msgid "Stop-Loss"
 msgstr "Стоп-лосс"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "Внешний обмен {0} на {1}"
@@ -4648,6 +4652,7 @@ msgstr "Принудительный сбой внешних свопов"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "Купить GM за {0} и {1} в пределах лимитов ни�
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "Депозит"
 
@@ -9472,6 +9478,10 @@ msgstr "ТРЕКЕР"
 msgid "Select network"
 msgstr "Выберите сеть"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "Нет потери владения средствами"
@@ -9614,6 +9624,11 @@ msgstr "Используйте кнопку TP/SL для установки TP/S
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "Перевод средств в..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Комиссия сети"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1265,6 +1265,10 @@ msgstr "流動性僅在 {chainNames} 上可用。請切換網路以繼續。"
 msgid "Stop-Loss"
 msgstr "止損"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "外部兌換 {0} 至 {1}"
@@ -4648,6 +4652,7 @@ msgstr "強制外部兌換失敗"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "使用 {0} 和 {1} 購買 GM，上限如下"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "存入"
 
@@ -9472,6 +9478,10 @@ msgstr "追蹤器"
 msgid "Select network"
 msgstr "選擇網路"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "資金所有權不受影響"
@@ -9614,6 +9624,11 @@ msgstr "使用 TP/SL 按鈕設定 TP/SL 訂單。"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "資金正在跨鏈至..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "網路費用"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1h"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "餘額"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -7464,6 +7464,7 @@ msgstr "{formattedNetRate} / 1 小时"
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Balance"
 msgstr "余额"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1265,6 +1265,10 @@ msgstr "流动性仅在 {chainNames} 上可用。请切换网络以继续。"
 msgid "Stop-Loss"
 msgstr "止损"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
 msgstr "外部兑换 {0} 至 {1}"
@@ -4648,6 +4652,7 @@ msgstr "强制外部兑换失败"
 #: src/pages/UiPage/BannerTest.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdraw"
@@ -8298,6 +8303,7 @@ msgstr "使用 {0} 和 {1} 买入 GM，上限如下"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Deposit"
 msgstr "存入"
 
@@ -9472,6 +9478,10 @@ msgstr "追踪器"
 msgid "Select network"
 msgstr "选择网络"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "NAV synced"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
 msgstr "无资金所有权损失"
@@ -9614,6 +9624,11 @@ msgstr "使用 TP/SL 按钮设置 TP/SL 订单。"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
 msgid "Close Long"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "APY"
 msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -10694,6 +10709,10 @@ msgstr "资金正在跨链转移至..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "网络费用"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync NAV"
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -8,12 +8,14 @@
  */
 
 import { t } from "@lingui/macro";
-import { formatEther, parseUnits } from "ethers";
+import { formatEther, formatUnits, parseUnits } from "ethers";
 import { ChangeEvent, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 
 import { useVaultActions } from "domain/vantage/vaults/useVaultActions";
+import { useVaultApy } from "domain/vantage/vaults/useVaultApy";
 import { useVaultDetail } from "domain/vantage/vaults/useVaultDetail";
+import { useVaultTxHistory } from "domain/vantage/vaults/useVaultTxHistory";
 import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, getVaultConfigByAddress } from "domain/vantage/vaults/vaultConfig";
 import { useChainId } from "lib/chains";
 import useWallet from "lib/wallets/useWallet";
@@ -35,8 +37,8 @@ function formatUsd(wad: bigint): string {
   return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
 }
 
-function formatToken(wad: bigint, symbol: string): string {
-  const n = parseFloat(formatEther(wad));
+function formatToken(amount: bigint, symbol: string, decimals = 18): string {
+  const n = parseFloat(formatUnits(amount, decimals));
   return `${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 6 })} ${symbol}`;
 }
 
@@ -91,8 +93,10 @@ export default function VaultDetailPage() {
 
   const cfg = getVaultConfigByAddress(address);
 
-  const data = useVaultDetail(cfg!);
+  const data = useVaultDetail(cfg!, chainId);
   const actions = useVaultActions(cfg!, chainId);
+  const { txs } = useVaultTxHistory(cfg!);
+  const apy = useVaultApy(cfg!);
 
   const [activeTab, setActiveTab] = useState<Tab>("deposit");
   const [depositInput, setDepositInput] = useState("");
@@ -143,11 +147,13 @@ export default function VaultDetailPage() {
       ? (((withdrawShares * data.sharePrice) / WAD) * WAD) / data.tokenPrice
       : 0n;
 
-  // Show Approve button if:
-  //   - wallet connected, AND
-  //   - no allowance at all (amount not yet entered), OR allowance < entered amount
+  // Show Approve button only after allowance is fetched (avoids flash on page load).
+  // If no allowance at all: show Approve even before amount is entered.
+  // If allowance < entered amount: show Approve.
   const needsApproval =
-    Boolean(account) && (depositAmount > 0n ? actions.isApprovalNeeded(depositAmount) : actions.allowance === 0n);
+    Boolean(account) &&
+    actions.isAllowanceLoaded &&
+    (depositAmount > 0n ? actions.isApprovalNeeded(depositAmount) : actions.allowance === 0n);
 
   // Below-AUM warning for Direct vault
   const showDirectWarning = cfg.assetType === 0 && data.usdValue > 0n && data.aum < data.usdValue;
@@ -243,15 +249,50 @@ export default function VaultDetailPage() {
               <h2 className="mb-16 text-14 font-semibold text-white">{t`Stats`}</h2>
               <div className="grid grid-cols-2 gap-16">
                 <StatRow label={t`Total AUM`} value={data.isLoading ? "—" : formatUsd(data.aum)} />
+                <StatRow
+                  label={t`APY`}
+                  value={apy === null ? "—" : `${(apy * 100).toFixed(2)}%`}
+                  highlight={apy !== null ? "green" : undefined}
+                />
                 <StatRow label={t`Share Price`} value={data.isLoading ? "—" : formatPrice(data.sharePrice)} />
                 {account && (
                   <StatRow label={t`My Deposit (USD)`} value={data.isLoading ? "—" : formatUsd(data.usdValue)} />
                 )}
                 {account && data.shortfall > 0n && (
-                  <StatRow label={t`Shortfall Debt`} value={formatToken(data.shortfall, cfg.symbol)} highlight="red" />
+                  <StatRow
+                    label={t`Shortfall Debt`}
+                    value={formatToken(data.shortfall, cfg.symbol, cfg.tokenDecimals)}
+                    highlight="red"
+                  />
                 )}
               </div>
             </div>
+
+            {/* Transactions */}
+            {account && txs.length > 0 && (
+              <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+                <h2 className="mb-12 text-14 font-semibold text-white">{t`Transactions`}</h2>
+                <div className="space-y-8">
+                  {txs.map((tx) => (
+                    <div key={tx.txHash} className="flex items-center justify-between text-13">
+                      <div className="flex items-center gap-8">
+                        <span
+                          className={`rounded-full px-8 py-2 text-11 font-medium ${
+                            tx.type === "deposit"
+                              ? "bg-emerald-900/60 text-emerald-300"
+                              : "bg-orange-900/60 text-orange-300"
+                          }`}
+                        >
+                          {tx.type === "deposit" ? t`Deposit` : t`Withdraw`}
+                        </span>
+                        <span className="text-white">{formatToken(tx.tokenAmount, cfg.symbol, cfg.tokenDecimals)}</span>
+                      </div>
+                      <span className="font-mono text-12 text-slate-500">#{tx.blockNumber}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* ================================================================ */}
@@ -269,7 +310,7 @@ export default function VaultDetailPage() {
             {data.shortfall > 0n && (
               <div className="border-amber-700 bg-amber-900/30 text-amber-300 rounded-4 border px-16 py-12 text-13">
                 ⚠️{" "}
-                {t`You have a shortfall debt of ${formatToken(data.shortfall, cfg.symbol)}. This will be settled when the insurance fund is sufficient.`}
+                {t`You have a shortfall debt of ${formatToken(data.shortfall, cfg.symbol, cfg.tokenDecimals)}. This will be settled when the insurance fund is sufficient.`}
               </div>
             )}
 
@@ -312,7 +353,8 @@ export default function VaultDetailPage() {
                       </div>
                       {account && (
                         <div className="mt-4 text-12 text-slate-500">
-                          {t`Balance`}: {data.isLoading ? "…" : formatToken(data.tokenBalance, cfg.symbol)}
+                          {t`Balance`}:{" "}
+                          {data.isLoading ? "…" : formatToken(data.tokenBalance, cfg.symbol, cfg.tokenDecimals)}
                         </div>
                       )}
                     </div>
@@ -391,7 +433,9 @@ export default function VaultDetailPage() {
                       <div className="space-y-4 text-13 text-slate-400">
                         <div className="flex justify-between">
                           <span>{t`Estimated ${cfg.symbol}`}</span>
-                          <span className="text-white">{formatToken(estimatedTokenOut, cfg.symbol)}</span>
+                          <span className="text-white">
+                            {formatToken(estimatedTokenOut, cfg.symbol, cfg.tokenDecimals)}
+                          </span>
                         </div>
                         <div className="flex justify-between">
                           <span>{t`USD value`}</span>
@@ -438,7 +482,9 @@ export default function VaultDetailPage() {
                   {cfg.assetType === 1 && (
                     <div className="flex justify-between">
                       <span className="text-slate-400">{t`Token Balance`}</span>
-                      <span className="text-emerald-400">{formatToken(data.tokenBalance, cfg.symbol)}</span>
+                      <span className="text-emerald-400">
+                        {formatToken(data.tokenBalance, cfg.symbol, cfg.tokenDecimals)}
+                      </span>
                     </div>
                   )}
                   {cfg.assetType === 2 && data.tokenPrice > WAD && (
@@ -466,6 +512,19 @@ export default function VaultDetailPage() {
                     className="w-full text-12"
                   >
                     {t`Mint 1,000 ${cfg.symbol} to wallet`}
+                  </Button>
+
+                  {/* Sync NAV */}
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={async () => {
+                      await actions.debugSyncNav();
+                      await data.refresh();
+                    }}
+                    className="w-full text-12"
+                  >
+                    {t`Sync NAV`}
                   </Button>
 
                   {/* Rebasing-specific */}
@@ -515,11 +574,12 @@ export default function VaultDetailPage() {
 // StatRow helper
 // ---------------------------------------------------------------------------
 
-function StatRow({ label, value, highlight }: { label: string; value: string; highlight?: "red" }) {
+function StatRow({ label, value, highlight }: { label: string; value: string; highlight?: "red" | "green" }) {
+  const color = highlight === "red" ? "text-red-400" : highlight === "green" ? "text-emerald-400" : "text-white";
   return (
     <div>
       <div className="mb-2 text-12 text-slate-400">{label}</div>
-      <div className={`text-14 font-semibold ${highlight === "red" ? "text-red-400" : "text-white"}`}>{value}</div>
+      <div className={`text-14 font-semibold ${color}`}>{value}</div>
     </div>
   );
 }

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -310,9 +310,9 @@ export default function VaultDetailPage() {
                         />
                         <span className="text-14 font-medium text-slate-400">{cfg.symbol}</span>
                       </div>
-                      {account && data.tokenBalance > 0n && (
+                      {account && (
                         <div className="mt-4 text-12 text-slate-500">
-                          {t`Balance`}: {formatToken(data.tokenBalance, cfg.symbol)}
+                          {t`Balance`}: {data.isLoading ? "…" : formatToken(data.tokenBalance, cfg.symbol)}
                         </div>
                       )}
                     </div>
@@ -379,6 +379,11 @@ export default function VaultDetailPage() {
                         />
                         <span className="text-14 font-medium text-slate-400">VLP</span>
                       </div>
+                      {account && (
+                        <div className="mt-4 text-12 text-slate-500">
+                          {t`Balance`}: {data.isLoading ? "…" : formatToken(data.vlpBalance, "VLP")}
+                        </div>
+                      )}
                     </div>
 
                     {/* Preview */}

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -143,7 +143,11 @@ export default function VaultDetailPage() {
       ? (((withdrawShares * data.sharePrice) / WAD) * WAD) / data.tokenPrice
       : 0n;
 
-  const needsApproval = depositAmount > 0n && actions.isApprovalNeeded(depositAmount);
+  // Show Approve button if:
+  //   - wallet connected, AND
+  //   - no allowance at all (amount not yet entered), OR allowance < entered amount
+  const needsApproval =
+    Boolean(account) && (depositAmount > 0n ? actions.isApprovalNeeded(depositAmount) : actions.allowance === 0n);
 
   // Below-AUM warning for Direct vault
   const showDirectWarning = cfg.assetType === 0 && data.usdValue > 0n && data.aum < data.usdValue;
@@ -333,7 +337,7 @@ export default function VaultDetailPage() {
                       <Button
                         variant="primary"
                         size="medium"
-                        disabled={depositAmount === 0n || isSubmitting || actions.isApproving}
+                        disabled={isSubmitting || actions.isApproving}
                         onClick={() => actions.approve()}
                         className="w-full"
                       >

--- a/src/pages/Vaults/VaultsPage.tsx
+++ b/src/pages/Vaults/VaultsPage.tsx
@@ -13,8 +13,9 @@ import { formatEther } from "ethers";
 import { useState } from "react";
 import { useHistory } from "react-router-dom";
 
+import { useVaultApy } from "domain/vantage/vaults/useVaultApy";
 import { useVaultList } from "domain/vantage/vaults/useVaultList";
-import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL } from "domain/vantage/vaults/vaultConfig";
+import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, VAULT_CONFIGS } from "domain/vantage/vaults/vaultConfig";
 import useWallet from "lib/wallets/useWallet";
 
 // ---------------------------------------------------------------------------
@@ -32,7 +33,7 @@ function formatUsd(wad: bigint): string {
 // Sort types
 // ---------------------------------------------------------------------------
 
-type SortKey = "aum" | "none";
+type SortKey = "aum" | "apy" | "none";
 type SortDir = "asc" | "desc";
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,18 @@ export default function VaultsPage() {
   const { account } = useWallet();
   const history = useHistory();
   const items = useVaultList();
+
+  // APY per vault — hooks must be called unconditionally in fixed order
+  const apy0 = useVaultApy(VAULT_CONFIGS[0]);
+  const apy1 = useVaultApy(VAULT_CONFIGS[1]);
+  const apy2 = useVaultApy(VAULT_CONFIGS[2]);
+  const apy3 = useVaultApy(VAULT_CONFIGS[3]);
+  const apyByKey: Record<string, number | null> = {
+    [VAULT_CONFIGS[0].key]: apy0,
+    [VAULT_CONFIGS[1].key]: apy1,
+    [VAULT_CONFIGS[2].key]: apy2,
+    [VAULT_CONFIGS[3].key]: apy3,
+  };
 
   const [sortKey, setSortKey] = useState<SortKey>("none");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -60,6 +73,11 @@ export default function VaultsPage() {
     if (sortKey === "aum") {
       return sortDir === "desc" ? Number(b.aum - a.aum) : Number(a.aum - b.aum);
     }
+    if (sortKey === "apy") {
+      const apyA = apyByKey[a.key] ?? -Infinity;
+      const apyB = apyByKey[b.key] ?? -Infinity;
+      return sortDir === "desc" ? apyB - apyA : apyA - apyB;
+    }
     return 0;
   });
 
@@ -75,7 +93,7 @@ export default function VaultsPage() {
         {/* Table */}
         <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary">
           {/* Table header */}
-          <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-0 border-b border-stroke-primary px-20 py-12 text-12 text-slate-400">
+          <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-0 border-b border-stroke-primary px-20 py-12 text-12 text-slate-400">
             <div>{t`Asset`}</div>
             <div
               className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "aum" ? "text-white" : ""}`}
@@ -83,58 +101,76 @@ export default function VaultsPage() {
             >
               {t`AUM`} {sortKey === "aum" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
             </div>
+            <div
+              className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "apy" ? "text-white" : ""}`}
+              onClick={() => handleSort("apy")}
+            >
+              {t`APY`} {sortKey === "apy" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
+            </div>
             <div className="text-right">{t`Type`}</div>
             <div className="text-right">{account ? t`My Deposit` : ""}</div>
           </div>
 
           {/* Rows */}
-          {sorted.map((item) => (
-            <div
-              key={item.key}
-              onClick={() => item.vaultAddress && history.push(`/vaults/${item.vaultAddress}`)}
-              className="grid cursor-pointer grid-cols-[2fr_1fr_1fr_1fr] items-center gap-0 border-b border-stroke-primary px-20 py-16 transition-colors last:border-0 hover:bg-slate-800/40"
-            >
-              {/* Asset */}
-              <div className="flex items-center gap-12">
-                <div className="flex h-36 w-36 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
-                  {item.symbol.slice(0, 2)}
+          {sorted.map((item) => {
+            const apy = apyByKey[item.key];
+            return (
+              <div
+                key={item.key}
+                onClick={() => item.vaultAddress && history.push(`/vaults/${item.vaultAddress}`)}
+                className="grid cursor-pointer grid-cols-[2fr_1fr_1fr_1fr_1fr] items-center gap-0 border-b border-stroke-primary px-20 py-16 transition-colors last:border-0 hover:bg-slate-800/40"
+              >
+                {/* Asset */}
+                <div className="flex items-center gap-12">
+                  <div className="flex h-36 w-36 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
+                    {item.symbol.slice(0, 2)}
+                  </div>
+                  <div>
+                    <div className="text-15 font-semibold text-white">{item.symbol}</div>
+                    <div className="text-12 text-slate-400">{item.name}</div>
+                  </div>
                 </div>
-                <div>
-                  <div className="text-15 font-semibold text-white">{item.symbol}</div>
-                  <div className="text-12 text-slate-400">{item.name}</div>
+
+                {/* AUM */}
+                <div className="text-right">
+                  {item.isLoading ? (
+                    <span className="text-slate-500">—</span>
+                  ) : (
+                    <span className="text-15 font-medium text-white">{formatUsd(item.aum)}</span>
+                  )}
+                </div>
+
+                {/* APY */}
+                <div className="text-right">
+                  {apy === null ? (
+                    <span className="text-14 text-slate-500">—</span>
+                  ) : (
+                    <span className="text-15 font-medium text-green-400">{(apy * 100).toFixed(2)}%</span>
+                  )}
+                </div>
+
+                {/* Type badge */}
+                <div className="flex justify-end">
+                  <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[item.assetType]}`}>
+                    {ASSET_TYPE_LABEL[item.assetType]}
+                  </span>
+                </div>
+
+                {/* My Deposit */}
+                <div className="text-right">
+                  {!account ? (
+                    <span className="text-14 text-slate-500">—</span>
+                  ) : item.isLoading ? (
+                    <span className="text-14 text-slate-500">…</span>
+                  ) : item.usdValue > 0n ? (
+                    <span className="text-15 font-medium text-white">{formatUsd(item.usdValue)}</span>
+                  ) : (
+                    <span className="text-14 text-slate-500">—</span>
+                  )}
                 </div>
               </div>
-
-              {/* AUM */}
-              <div className="text-right">
-                {item.isLoading ? (
-                  <span className="text-slate-500">—</span>
-                ) : (
-                  <span className="text-15 font-medium text-white">{formatUsd(item.aum)}</span>
-                )}
-              </div>
-
-              {/* Type badge */}
-              <div className="flex justify-end">
-                <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[item.assetType]}`}>
-                  {ASSET_TYPE_LABEL[item.assetType]}
-                </span>
-              </div>
-
-              {/* My Deposit */}
-              <div className="text-right">
-                {!account ? (
-                  <span className="text-14 text-slate-500">—</span>
-                ) : item.isLoading ? (
-                  <span className="text-14 text-slate-500">…</span>
-                ) : item.usdValue > 0n ? (
-                  <span className="text-15 font-medium text-white">{formatUsd(item.usdValue)}</span>
-                ) : (
-                  <span className="text-14 text-slate-500">—</span>
-                )}
-              </div>
-            </div>
-          ))}
+            );
+          })}
 
           {/* Empty state */}
           {items.length === 0 && (

--- a/src/vantage/deployments/frontend-localhost.json
+++ b/src/vantage/deployments/frontend-localhost.json
@@ -10,10 +10,31 @@
     "Router": "0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1",
     "PositionRouter": "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE",
     "OrderBook": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+    "MockPriceFeed": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
     "tokens": {
       "USDC": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
       "ETH": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
       "WETH": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
+    },
+    "mockRWA": {
+      "Rebasing": "0x851356ae760d987E095750cCeb3bC6014560891C",
+      "PriceShare": "0xf5059a5D33d5853360D16C683c16e67980206f36",
+      "Direct": "0x95401dc811bb5740090279Ba06cfA8fcF6113778"
+    },
+    "mockRWAVaults": {
+      "Rebasing": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
+      "PriceShare": "0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf",
+      "Direct": "0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00"
+    },
+    "mockRWALPTokens": {
+      "Rebasing": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+      "PriceShare": "0xCD8a1C3ba11CF5ECfa6267617243239504a98d90",
+      "Direct": "0xc351628EB244ec633d5f21fBD6621e1a683B1181"
+    },
+    "mockRWALPManagers": {
+      "Rebasing": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029",
+      "PriceShare": "0x82e01223d51Eb87e16A03E24687EDF0F294da6f1",
+      "Direct": "0xFD471836031dc5108809D173A067e8486B9047A3"
     }
   },
   "abis": {
@@ -8836,6 +8857,1019 @@
           }
         ],
         "stateMutability": "view",
+        "type": "function"
+      }
+    ],
+    "MockPriceFeed": [
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_token",
+            "type": "address"
+          }
+        ],
+        "name": "getLastPriceTimestamp",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_token",
+            "type": "address"
+          }
+        ],
+        "name": "getLatestPrimaryPrice",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_token",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "name": "getPrice",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_token",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "name": "getPrimaryPrice",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_token",
+            "type": "address"
+          }
+        ],
+        "name": "isMarketOpen",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "name": "lastPriceTimestamps",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "name": "marketClosed",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "",
+            "type": "address"
+          }
+        ],
+        "name": "prices",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          }
+        ],
+        "name": "setLastPriceTimestamp",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "closed",
+            "type": "bool"
+          }
+        ],
+        "name": "setMarketClosed",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          }
+        ],
+        "name": "setPrice",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    ],
+    "MockRebasingRWA": [
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "name_",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "symbol_",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "Approval",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "yieldAdded",
+            "type": "uint256"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "newTotalPooledAssets",
+            "type": "uint256"
+          }
+        ],
+        "name": "Rebased",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "Transfer",
+        "type": "event"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          }
+        ],
+        "name": "allowance",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "approve",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "assetType",
+        "outputs": [
+          {
+            "internalType": "uint8",
+            "name": "",
+            "type": "uint8"
+          }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "burn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+          {
+            "internalType": "uint8",
+            "name": "",
+            "type": "uint8"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "mint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "rebase",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "basisPoints",
+            "type": "uint256"
+          }
+        ],
+        "name": "rebaseByUI",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint8",
+            "name": "decimals_",
+            "type": "uint8"
+          }
+        ],
+        "name": "setDecimals",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "sharesOf",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "totalPooledAssets",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "totalShares",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    ],
+    "MockStandardRWA": [
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "name_",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "symbol_",
+            "type": "string"
+          },
+          {
+            "internalType": "uint8",
+            "name": "assetTypeId_",
+            "type": "uint8"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "allowance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "needed",
+            "type": "uint256"
+          }
+        ],
+        "name": "ERC20InsufficientAllowance",
+        "type": "error"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "needed",
+            "type": "uint256"
+          }
+        ],
+        "name": "ERC20InsufficientBalance",
+        "type": "error"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "approver",
+            "type": "address"
+          }
+        ],
+        "name": "ERC20InvalidApprover",
+        "type": "error"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "receiver",
+            "type": "address"
+          }
+        ],
+        "name": "ERC20InvalidReceiver",
+        "type": "error"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          }
+        ],
+        "name": "ERC20InvalidSender",
+        "type": "error"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          }
+        ],
+        "name": "ERC20InvalidSpender",
+        "type": "error"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "Approval",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "Transfer",
+        "type": "event"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          }
+        ],
+        "name": "allowance",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "approve",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "assetType",
+        "outputs": [
+          {
+            "internalType": "uint8",
+            "name": "",
+            "type": "uint8"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          }
+        ],
+        "name": "balanceOf",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "burn",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+          {
+            "internalType": "uint8",
+            "name": "",
+            "type": "uint8"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "mint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "name",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "uint8",
+            "name": "decimals_",
+            "type": "uint8"
+          }
+        ],
+        "name": "setDecimals",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [
+          {
+            "internalType": "string",
+            "name": "",
+            "type": "string"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transferFrom",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
+          }
+        ],
+        "stateMutability": "nonpayable",
         "type": "function"
       }
     ]


### PR DESCRIPTION
## 概要

Issue #162 の残り完了条件を実装。

- APY 表示（Vaults 一覧・詳細ページ）
- Tx 履歴セクション（詳細ページ）
- Debug パネルに Sync NAV ボタン追加
- Approve ボタンのフラッシュ防止 (`isAllowanceLoaded`)
- トークン残高表示の小数桁修正 (`formatUnits` 対応)
- `useChainId()` で正しいチェーンID取得（Arbitrum → localhost 修正）
- `provider` の `useMemo` によるレンダリング最適化

## 主な変更ファイル

### 新規
- `useVaultApy.ts` — Rebasing (Rebased events 複利計算) / PriceShare (in-memory 価格追跡) APY フック
- `useVaultTxHistory.ts` — LPManager の AddLiquidity / RemoveLiquidity イベントから Tx 履歴取得

### 変更
- `VaultsPage.tsx` — APY 列追加（5列グリッド）、AUM/APY ソート対応
- `VaultDetailPage.tsx` — APY 表示行・Tx 履歴セクション・Sync NAV ボタン追加
- `useVaultDetail.ts` — `chainId` パラメータ化、`refresh` 関数を戻り値に追加
- `useVaultList.ts` — `useChainId()` で正しいチェーン取得
- `useVaultActions.ts` — `isAllowanceLoaded` フラグ・`debugSyncNav` 追加

## バグ修正

- APY が `Infinity` になる問題: timespan が短い場合に `Math.pow` がオーバーフローするため、`isFinite` チェックで `null` にフォールバック
- USDC 残高が常に 0 になる問題: `formatEther`（18桁）→ `formatUnits(amount, 6)` に修正
- 残高が全て 0 になる問題: `DEFAULT_SETTLEMENT_CHAIN_ID`（Arbitrum）→ `useChainId()` で localhost を正しく参照
- Approve ボタンがページリロード後に瞬間表示される問題: `isAllowanceLoaded` フラグで初回フェッチ完了まで非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)