### PR TITLE
feat: Debug Panel の Sync Rebasing Balance ボタン追加 (Issue #165)

### DIFF
--- a/src/domain/vantage/vaults/useVaultActions.ts
+++ b/src/domain/vantage/vaults/useVaultActions.ts
@@ -209,22 +209,25 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
   );
 
   // ---------------------------------------------------------------------------
-  // Debug: Sync NAV (calls vault.syncNetAssetValue — Keeper role required)
+  // Debug: Sync Rebasing Balance (calls vault.syncRebasingBalance — Keeper role required)
+  //        Only meaningful for Rebasing (assetType 1) vaults.
   // ---------------------------------------------------------------------------
 
-  const debugSyncNav = useCallback(async (): Promise<void> => {
+  const debugSyncRebasingBalance = useCallback(async (): Promise<void> => {
     if (!signer) return;
     try {
       const vault = new Contract(cfg.vaultAddress, VaultAbi, signer);
       const tx = await (
-        vault as ethers.Contract & { syncNetAssetValue: () => Promise<{ wait: () => Promise<unknown> }> }
-      ).syncNetAssetValue();
+        vault as ethers.Contract & {
+          syncRebasingBalance: (token: string) => Promise<{ wait: () => Promise<unknown> }>;
+        }
+      ).syncRebasingBalance(cfg.tokenAddress);
       await tx.wait();
-      helperToast.success(t`NAV synced`);
+      helperToast.success(t`Rebasing balance synced`);
     } catch (err: unknown) {
       helperToast.error(err instanceof Error ? err.message : String(err));
     }
-  }, [signer, cfg.vaultAddress]);
+  }, [signer, cfg.vaultAddress, cfg.tokenAddress]);
 
   // ---------------------------------------------------------------------------
   // Debug: Mint tokens to user (testnet only)
@@ -255,7 +258,7 @@ export function useVaultActions(cfg: VaultConfig, chainId: number = DEFAULT_SETT
     debugRebase,
     debugSetPrice,
     debugMint,
-    debugSyncNav,
+    debugSyncRebasingBalance,
     isApprovalNeeded,
     isApproving,
     allowance,

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3537,6 +3537,10 @@ msgstr "Bei Auslösung kann für Teile dieser Order unzureichende Liquidität vo
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "Was macht GMX kosteneffizienter als andere Perpetual-Plattformen?"
@@ -6198,6 +6202,10 @@ msgstr "Positionsgröße übersteigt den Poolwert"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "Auswirkungsexponent (positiv)"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "Netzwerk auswählen"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "Netzwerkgebühr"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3537,6 +3537,10 @@ msgstr "May lack liquidity for parts of this order when triggered"
 msgid "Withdrawing…"
 msgstr "Withdrawing…"
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr "Rebasing balance synced"
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "What makes GMX more cost-efficient than other perpetual platforms?"
@@ -6198,6 +6202,10 @@ msgstr "Position size exceeds pool value"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "Impact exponent (positive)"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr "Sync Rebasing Balance"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "Select network"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr "NAV synced"
+#~ msgid "NAV synced"
+#~ msgstr "NAV synced"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "Network fee"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr "Sync NAV"
+#~ msgid "Sync NAV"
+#~ msgstr "Sync NAV"
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3537,6 +3537,10 @@ msgstr "Puede haber liquidez insuficiente para partes de esta orden cuando se ej
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "¿Qué hace a GMX más eficiente en costos que otras plataformas perpetuas?"
@@ -6198,6 +6202,10 @@ msgstr "El tamaño de la posición supera el valor del pool"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "Exponente de impacto (positivo)"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "Seleccionar red"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "Comisión de red"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3537,6 +3537,10 @@ msgstr "La liquidité pourrait être insuffisante pour certaines parties de cet 
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "Qu'est-ce qui rend GMX plus rentable que d'autres plateformes perpétuelles ?"
@@ -6198,6 +6202,10 @@ msgstr "La taille de la position dépasse la valeur du pool"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "Exposant d'impact (positif)"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "Sélectionner le réseau"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "Frais de réseau"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3537,6 +3537,10 @@ msgstr "トリガー時に注文の一部で流動性が不足する可能性が
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "GMXが他のパーペチュアルプラットフォームよりコスト効率が高い理由は何ですか？"
@@ -6198,6 +6202,10 @@ msgstr "ポジションサイズがプール価値を超えています"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "インパクト指数（正）"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "ネットワークを選択"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "ネットワーク手数料"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3537,6 +3537,10 @@ msgstr "발동 시 이 주문의 일부에 대해 유동성이 부족할 수 있
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "GMX가 다른 영구 플랫폼보다 비용 효율적인 이유는 무엇인가요?"
@@ -6198,6 +6202,10 @@ msgstr "포지션 규모가 풀 가치를 초과합니다"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "영향 지수 (양수)"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "네트워크 선택"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "네트워크 수수료"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -3537,6 +3537,10 @@ msgstr ""
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr ""
@@ -6197,6 +6201,10 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -3537,6 +3537,10 @@ msgstr "При срабатывании возможна недостаточн�
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "Что делает GMX более экономичным, чем другие перпетуальные платформы?"
@@ -6198,6 +6202,10 @@ msgstr "Размер позиции превышает стоимость пул
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "Экспонента влияния (положительная)"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "Выберите сеть"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "Комиссия сети"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -3537,6 +3537,10 @@ msgstr "觸發時此訂單的部分可能缺乏流動性"
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "為什麼 GMX 比其他永續合約平台更具成本效益？"
@@ -6198,6 +6202,10 @@ msgstr "倉位規模超過池價值"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "影響指數（正向）"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "選擇網路"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "網路費用"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3537,6 +3537,10 @@ msgstr "触发时该订单部分子单可能流动性不足"
 msgid "Withdrawing…"
 msgstr ""
 
+#: src/domain/vantage/vaults/useVaultActions.ts
+msgid "Rebasing balance synced"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "What makes GMX more cost-efficient than other perpetual platforms?"
 msgstr "是什么让 GMX 比其他永续平台更具成本效益？"
@@ -6198,6 +6202,10 @@ msgstr "仓位大小超过池价值"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Impact exponent (positive)"
 msgstr "影响指数（正值）"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Sync Rebasing Balance"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -9479,8 +9487,8 @@ msgid "Select network"
 msgstr "选择网络"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
-msgid "NAV synced"
-msgstr ""
+#~ msgid "NAV synced"
+#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10711,8 +10719,8 @@ msgid "Network fee"
 msgstr "网络费用"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
-msgid "Sync NAV"
-msgstr ""
+#~ msgid "Sync NAV"
+#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -514,29 +514,29 @@ export default function VaultDetailPage() {
                     {t`Mint 1,000 ${cfg.symbol} to wallet`}
                   </Button>
 
-                  {/* Sync NAV */}
-                  <Button
-                    variant="secondary"
-                    size="small"
-                    onClick={async () => {
-                      await actions.debugSyncNav();
-                      await data.refresh();
-                    }}
-                    className="w-full text-12"
-                  >
-                    {t`Sync NAV`}
-                  </Button>
-
                   {/* Rebasing-specific */}
                   {cfg.assetType === 1 && (
-                    <Button
-                      variant="secondary"
-                      size="small"
-                      onClick={() => actions.debugRebase(500)}
-                      className="w-full text-12"
-                    >
-                      {t`+5% Rebase`}
-                    </Button>
+                    <>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() => actions.debugRebase(500)}
+                        className="w-full text-12"
+                      >
+                        {t`+5% Rebase`}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={async () => {
+                          await actions.debugSyncRebasingBalance();
+                          await data.refresh();
+                        }}
+                        className="w-full text-12"
+                      >
+                        {t`Sync Rebasing Balance`}
+                      </Button>
+                    </>
                   )}
 
                   {/* PriceShare / Direct price controls */}

--- a/src/vantage/abis/Vault.json
+++ b/src/vantage/abis/Vault.json
@@ -992,6 +992,25 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "newBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "RebasingBalanceSynced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "surplus",
         "type": "uint256"
       }
@@ -3020,6 +3039,19 @@
   {
     "inputs": [],
     "name": "syncNetAssetValue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "syncRebasingBalance",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"


### PR DESCRIPTION
## 概要

Issue #165 フロントエンド対応: Debug Panel の Sync NAV ボタンを Rebasing Vault 専用の Sync Rebasing Balance ボタンに変更。

## 変更内容

### `useVaultActions.ts`
- `debugSyncNav` (syncNetAssetValue 呼び出し) を削除
- `debugSyncRebasingBalance` を追加 — `vault.syncRebasingBalance(tokenAddress)` を呼び出す

### `VaultDetailPage.tsx`
- Debug Panel の Sync NAV ボタンを削除
- Rebasing Vault (assetType === 1) のみに `Sync Rebasing Balance` ボタンを表示

### `src/vantage/abis/Vault.json`
- `RebasingBalanceSynced` イベント・`syncRebasingBalance(address)` 関数を追加

## 関連
- コントラクト側 PR: itchii-06/bcellar-monorepo#167

🤖 Generated with [Claude Code](https://claude.com/claude-code)