### PR TITLE
feat(trade): Position open/close UI via PositionRouter (#151)

### DIFF
--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -29,6 +29,7 @@ import Referrals from "pages/Referrals/Referrals";
 import ReferralsTier from "pages/ReferralsTier/ReferralsTier";
 import { SyntheticsPage } from "pages/SyntheticsPage/SyntheticsPage";
 import { SyntheticsStats } from "pages/SyntheticsStats/SyntheticsStats";
+import TradePage from "pages/Trade/TradePage";
 import VantageLPPage from "pages/VantageLP/VantageLPPage";
 import VaultDetailPage from "pages/VaultDetail/VaultDetailPage";
 import VaultsPage from "pages/Vaults/VaultsPage";
@@ -170,6 +171,9 @@ export function MainRoutes({ openSettings }: { openSettings: () => void }) {
       </Route>
       <Route exact path="/vaults/:address">
         <VaultDetailPage />
+      </Route>
+      <Route exact path="/trade">
+        <TradePage />
       </Route>
       <Route exact path="/jobs">
         <Jobs />

--- a/src/domain/vantage/trade/usePositionRequests.ts
+++ b/src/domain/vantage/trade/usePositionRequests.ts
@@ -1,0 +1,211 @@
+/**
+ * usePositionRequests.ts
+ *
+ * Tracks pending PositionRouter requests for the connected wallet.
+ *
+ * State machine per request:
+ *   pending → executed   (ExecuteIncreasePosition / ExecuteDecreasePosition event)
+ *           → cancelled  (CancelIncreasePosition / CancelDecreasePosition event)
+ *           → expired    (block.timestamp > createdAt + maxTimeDelay)
+ *
+ * Persistence: stored in localStorage so requests survive page reloads.
+ */
+
+import { Contract } from "ethers";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+import PositionRouterAbi from "vantage/abis/PositionRouter.json";
+import { getVantageContractAddress } from "vantage/contracts";
+
+export type RequestStatus = "pending" | "executed" | "cancelled" | "expired";
+export type RequestType = "increase" | "decrease";
+
+export type PositionRequest = {
+  requestKey: string;
+  type: RequestType;
+  /** Unix ms when the on-chain request was created (from block.timestamp × 1000) */
+  createdAtMs: number;
+  /** block.timestamp + maxTimeDelay × 1000 */
+  expiresAtMs: number;
+  status: RequestStatus;
+  // Human-readable metadata
+  indexToken: string;
+  isLong: boolean;
+  sizeDelta: bigint;
+};
+
+const STORAGE_KEY_PREFIX = "vantage:positionRequests:";
+
+function storageKey(account: string, chainId: number) {
+  return `${STORAGE_KEY_PREFIX}${chainId}:${account.toLowerCase()}`;
+}
+
+function loadRequests(account: string, chainId: number): PositionRequest[] {
+  try {
+    const raw = localStorage.getItem(storageKey(account, chainId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as PositionRequest[];
+    // Restore bigint fields that JSON stringifies as strings
+    return parsed.map((r) => ({ ...r, sizeDelta: BigInt(r.sizeDelta) }));
+  } catch {
+    return [];
+  }
+}
+
+function saveRequests(account: string, chainId: number, requests: PositionRequest[]) {
+  try {
+    // JSON doesn't support bigint — convert to string
+    const serializable = requests.map((r) => ({ ...r, sizeDelta: r.sizeDelta.toString() }));
+    localStorage.setItem(storageKey(account, chainId), JSON.stringify(serializable));
+  } catch {
+    // Ignore quota errors
+  }
+}
+
+export type UsePositionRequestsResult = {
+  requests: PositionRequest[];
+  /** Add a newly created request (call after createIncreasePosition succeeds). */
+  addRequest: (req: Omit<PositionRequest, "status">) => void;
+  /** Manually mark a request as cancelled (optimistic UI update). */
+  markCancelled: (requestKey: string) => void;
+  /** Remove completed (executed / cancelled / expired) requests from the list. */
+  clearCompleted: () => void;
+};
+
+const POLL_INTERVAL_MS = 8_000;
+const BLOCK_LOOKBACK = 50_000;
+
+export function usePositionRequests(): UsePositionRequestsResult {
+  const { account } = useWallet();
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const [requests, setRequests] = useState<PositionRequest[]>([]);
+  const requestsRef = useRef<PositionRequest[]>([]);
+
+  // Sync ref, state, and localStorage
+  function updateRequests(updated: PositionRequest[]) {
+    requestsRef.current = updated;
+    setRequests(updated);
+    if (account) saveRequests(account, chainId, updated);
+  }
+
+  // Load from localStorage on account / chainId change
+  useEffect(() => {
+    if (!account) {
+      updateRequests([]);
+      requestsRef.current = [];
+      return;
+    }
+    const stored = loadRequests(account, chainId);
+    requestsRef.current = stored;
+    updateRequests(stored);
+  }, [account, chainId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Expire pending requests whose deadline has passed
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = Date.now();
+      const current = requestsRef.current;
+      const updated = current.map((r) =>
+        r.status === "pending" && r.expiresAtMs > 0 && now > r.expiresAtMs
+          ? { ...r, status: "expired" as RequestStatus }
+          : r
+      );
+      if (updated.some((r, i) => r.status !== current[i].status)) {
+        updateRequests(updated);
+      }
+    }, 5_000);
+    return () => clearInterval(timer);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Poll for Execute / Cancel events to update request statuses
+  useEffect(() => {
+    if (!account) return;
+
+    const positionRouterAddress = getVantageContractAddress(chainId, "PositionRouter");
+    if (!positionRouterAddress) return;
+
+    const contract = new Contract(positionRouterAddress, PositionRouterAbi, provider);
+
+    async function poll() {
+      const current = requestsRef.current;
+      const pending = current.filter((r) => r.status === "pending");
+      if (pending.length === 0) return;
+
+      try {
+        const latest = await provider.getBlockNumber();
+        const fromBlock = Math.max(0, latest - BLOCK_LOOKBACK);
+
+        // Query all execute/cancel events in one batch
+        const [execInc, cancelInc, execDec, cancelDec] = await Promise.all([
+          contract.queryFilter(contract.filters.ExecuteIncreasePosition(), fromBlock),
+          contract.queryFilter(contract.filters.CancelIncreasePosition(), fromBlock),
+          contract.queryFilter(contract.filters.ExecuteDecreasePosition(), fromBlock),
+          contract.queryFilter(contract.filters.CancelDecreasePosition(), fromBlock),
+        ]);
+
+        const executedKeys = new Set([
+          ...execInc.map((l) => {
+            const p = contract.interface.parseLog({ topics: [...l.topics], data: l.data });
+            return p?.args.requestKey as string;
+          }),
+          ...execDec.map((l) => {
+            const p = contract.interface.parseLog({ topics: [...l.topics], data: l.data });
+            return p?.args.requestKey as string;
+          }),
+        ]);
+        const cancelledKeys = new Set([
+          ...cancelInc.map((l) => {
+            const p = contract.interface.parseLog({ topics: [...l.topics], data: l.data });
+            return p?.args.requestKey as string;
+          }),
+          ...cancelDec.map((l) => {
+            const p = contract.interface.parseLog({ topics: [...l.topics], data: l.data });
+            return p?.args.requestKey as string;
+          }),
+        ]);
+
+        const updated = current.map((r) => {
+          if (r.status !== "pending") return r;
+          if (executedKeys.has(r.requestKey)) return { ...r, status: "executed" as RequestStatus };
+          if (cancelledKeys.has(r.requestKey)) return { ...r, status: "cancelled" as RequestStatus };
+          return r;
+        });
+
+        if (updated.some((r, i) => r.status !== current[i].status)) {
+          updateRequests(updated);
+        }
+      } catch {
+        // Silently ignore RPC errors
+      }
+    }
+
+    poll();
+    const timer = setInterval(poll, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [account, chainId, provider]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const addRequest = useCallback(
+    (req: Omit<PositionRequest, "status">) => {
+      const newReq: PositionRequest = { ...req, status: "pending" };
+      updateRequests([newReq, ...requestsRef.current]);
+    },
+    [] // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const markCancelled = useCallback((requestKey: string) => {
+    updateRequests(
+      requestsRef.current.map((r) => (r.requestKey === requestKey ? { ...r, status: "cancelled" as RequestStatus } : r))
+    );
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const clearCompleted = useCallback(() => {
+    updateRequests(requestsRef.current.filter((r) => r.status === "pending"));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { requests, addRequest, markCancelled, clearCompleted };
+}

--- a/src/domain/vantage/trade/usePositionRouterTrade.ts
+++ b/src/domain/vantage/trade/usePositionRouterTrade.ts
@@ -1,0 +1,231 @@
+/**
+ * usePositionRouterTrade.ts
+ *
+ * Submits open/close requests through PositionRouter (2-step async flow).
+ * Returns the requestKey emitted by the contract so callers can track status.
+ *
+ * Flow:
+ *   createIncreasePosition / createDecreasePosition
+ *     → Keeper executes after block delay
+ *     → ExecuteIncreasePosition / ExecuteDecreasePosition event emitted
+ */
+
+import { t } from "@lingui/macro";
+import { parseEther } from "ethers";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { usePositionRouter } from "hooks/useVantageContracts";
+import { useChainId } from "lib/chains";
+import { helperToast } from "lib/helperToast";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+
+import { calcAcceptablePrice } from "./utils";
+
+export const DEFAULT_SLIPPAGE_BPS = 30; // 0.3%
+
+export type IncreaseRequest = {
+  collateralToken: string;
+  indexToken: string;
+  amountIn: bigint;
+  sizeDelta: bigint;
+  isLong: boolean;
+  markPrice: bigint;
+  slippageBps?: number;
+  useNativeEth?: boolean;
+};
+
+export type DecreaseRequest = {
+  collateralToken: string;
+  indexToken: string;
+  collateralDelta: bigint;
+  sizeDelta: bigint;
+  isLong: boolean;
+  receiver: string;
+  markPrice: bigint;
+  slippageBps?: number;
+};
+
+export type PositionRouterTradeResult = {
+  /** Opens a new position via PositionRouter. Returns requestKey on success. */
+  createIncreasePosition: (req: IncreaseRequest) => Promise<string | null>;
+  /** Closes / reduces a position via PositionRouter. Returns requestKey on success. */
+  createDecreasePosition: (req: DecreaseRequest) => Promise<string | null>;
+  /** Cancels a pending increase request by key. */
+  cancelIncreasePosition: (requestKey: string) => Promise<void>;
+  /** Cancels a pending decrease request by key. */
+  cancelDecreasePosition: (requestKey: string) => Promise<void>;
+  /** Minimum execution fee (in wei) required by PositionRouter. */
+  minExecutionFee: bigint;
+  /** Maximum time delay (in seconds) before a request expires. */
+  maxTimeDelay: number;
+  isReady: boolean;
+};
+
+export function usePositionRouterTrade(): PositionRouterTradeResult {
+  const { account, signer } = useWallet();
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const positionRouterRead = usePositionRouter(provider, chainId);
+  const positionRouterWrite = usePositionRouter(signer ?? undefined, chainId);
+
+  const [minExecutionFee, setMinExecutionFee] = useState<bigint>(parseEther("0.001"));
+  const [maxTimeDelay, setMaxTimeDelay] = useState<number>(0);
+
+  // Fetch contract parameters once on mount / chainId change
+  useEffect(() => {
+    positionRouterRead
+      .minExecutionFee()
+      .then((v) => setMinExecutionFee(v))
+      .catch((_e) => {
+        /* ignore */
+      });
+    positionRouterRead
+      .maxTimeDelay()
+      .then((v) => setMaxTimeDelay(Number(v)))
+      .catch((_e) => {
+        /* ignore */
+      });
+  }, [positionRouterRead, chainId]);
+
+  const createIncreasePosition = useCallback(
+    async (req: IncreaseRequest): Promise<string | null> => {
+      if (!account || !signer) {
+        helperToast.error(t`Wallet not connected`);
+        return null;
+      }
+      const slippageBps = req.slippageBps ?? DEFAULT_SLIPPAGE_BPS;
+      const acceptablePrice = calcAcceptablePrice(req.markPrice, slippageBps, req.isLong, true);
+
+      try {
+        let tx;
+        if (req.useNativeEth) {
+          // ETH collateral: msg.value = collateralAmount + executionFee
+          const totalValue = req.amountIn + minExecutionFee;
+          tx = await positionRouterWrite.increasePositionETH(
+            req.indexToken,
+            req.sizeDelta,
+            req.isLong,
+            acceptablePrice,
+            minExecutionFee,
+            { value: totalValue }
+          );
+        } else {
+          tx = await positionRouterWrite.createIncreasePosition(
+            req.collateralToken,
+            req.indexToken,
+            req.amountIn,
+            req.sizeDelta,
+            req.isLong,
+            acceptablePrice,
+            { value: minExecutionFee }
+          );
+        }
+
+        helperToast.info(t`Request submitted — waiting for Keeper execution`);
+        const receipt = await tx.wait();
+
+        // Extract requestKey from CreateIncreasePosition event
+        const iface = positionRouterWrite.interface;
+        for (const log of receipt?.logs ?? []) {
+          try {
+            const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+            if (parsed?.name === "CreateIncreasePosition") {
+              return parsed.args.requestKey as string;
+            }
+          } catch {
+            // skip unparseable logs
+          }
+        }
+        return null;
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+        return null;
+      }
+    },
+    [account, signer, positionRouterWrite, minExecutionFee]
+  );
+
+  const createDecreasePosition = useCallback(
+    async (req: DecreaseRequest): Promise<string | null> => {
+      if (!account || !signer) {
+        helperToast.error(t`Wallet not connected`);
+        return null;
+      }
+      const slippageBps = req.slippageBps ?? DEFAULT_SLIPPAGE_BPS;
+      const acceptablePrice = calcAcceptablePrice(req.markPrice, slippageBps, req.isLong, false);
+
+      try {
+        const tx = await positionRouterWrite.createDecreasePosition(
+          req.collateralToken,
+          req.indexToken,
+          req.collateralDelta,
+          req.sizeDelta,
+          req.isLong,
+          req.receiver,
+          acceptablePrice,
+          { value: minExecutionFee }
+        );
+
+        helperToast.info(t`Close request submitted — waiting for Keeper execution`);
+        const receipt = await tx.wait();
+
+        const iface = positionRouterWrite.interface;
+        for (const log of receipt?.logs ?? []) {
+          try {
+            const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+            if (parsed?.name === "CreateDecreasePosition") {
+              return parsed.args.requestKey as string;
+            }
+          } catch {
+            // skip unparseable logs
+          }
+        }
+        return null;
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+        return null;
+      }
+    },
+    [account, signer, positionRouterWrite, minExecutionFee]
+  );
+
+  const cancelIncreasePosition = useCallback(
+    async (requestKey: string): Promise<void> => {
+      if (!signer) return;
+      try {
+        const tx = await positionRouterWrite.cancelIncreasePosition(requestKey);
+        await tx.wait();
+        helperToast.success(t`Increase request cancelled`);
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [signer, positionRouterWrite]
+  );
+
+  const cancelDecreasePosition = useCallback(
+    async (requestKey: string): Promise<void> => {
+      if (!signer) return;
+      try {
+        const tx = await positionRouterWrite.cancelDecreasePosition(requestKey);
+        await tx.wait();
+        helperToast.success(t`Decrease request cancelled`);
+      } catch (err: unknown) {
+        helperToast.error(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [signer, positionRouterWrite]
+  );
+
+  return {
+    createIncreasePosition,
+    createDecreasePosition,
+    cancelIncreasePosition,
+    cancelDecreasePosition,
+    minExecutionFee,
+    maxTimeDelay,
+    isReady: Boolean(account && signer),
+  };
+}

--- a/src/domain/vantage/trade/useSpread.ts
+++ b/src/domain/vantage/trade/useSpread.ts
@@ -1,0 +1,74 @@
+/**
+ * useSpread.ts
+ *
+ * Computes the current Bid/Ask spread for a token by comparing
+ * Vault.getMaxPrice (Ask) and Vault.getMinPrice (Bid).
+ *
+ * Spread formula:
+ *   spreadBps = (maxPrice - minPrice) * 10_000 / maxPrice
+ *   bidPrice  = minPrice  (used for long close / short open)
+ *   askPrice  = maxPrice  (used for long open / short close)
+ */
+
+import { Contract } from "ethers";
+import { useEffect, useMemo, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
+import VaultAbi from "vantage/abis/Vault.json";
+import { getVantageContractAddress } from "vantage/contracts";
+
+export type SpreadData = {
+  /** Ask price — use for long open / short close (1e18) */
+  askPrice: bigint;
+  /** Bid price — use for long close / short open (1e18) */
+  bidPrice: bigint;
+  /** Spread in basis points (0 if prices are equal) */
+  spreadBps: number;
+  isLoading: boolean;
+};
+
+const POLL_MS = 10_000;
+
+export function useSpread(tokenAddress: string | undefined): SpreadData {
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const [data, setData] = useState<SpreadData>({
+    askPrice: 0n,
+    bidPrice: 0n,
+    spreadBps: 0,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    if (!tokenAddress) {
+      setData({ askPrice: 0n, bidPrice: 0n, spreadBps: 0, isLoading: false });
+      return;
+    }
+
+    const vaultAddress = getVantageContractAddress(chainId, "Vault");
+    const vault = new Contract(vaultAddress, VaultAbi, provider);
+
+    async function fetch() {
+      try {
+        const [maxPrice, minPrice] = await Promise.all([
+          vault.getMaxPrice(tokenAddress) as Promise<bigint>,
+          vault.getMinPrice(tokenAddress) as Promise<bigint>,
+        ]);
+
+        const spreadBps = maxPrice > 0n ? Number(((maxPrice - minPrice) * 10_000n) / maxPrice) : 0;
+
+        setData({ askPrice: maxPrice, bidPrice: minPrice, spreadBps, isLoading: false });
+      } catch {
+        setData((prev) => ({ ...prev, isLoading: false }));
+      }
+    }
+
+    fetch();
+    const timer = setInterval(fetch, POLL_MS);
+    return () => clearInterval(timer);
+  }, [tokenAddress, chainId, provider]);
+
+  return data;
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -23,6 +23,8 @@ msgstr "Slippage überschritten"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "Einstellungen"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "Token auswählen"
 msgid "Image generation failed. Refresh and try again."
 msgstr "Bilderzeugung fehlgeschlagen. Aktualisieren Sie die Seite und versuchen Sie es erneut."
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "Entstaken..."
@@ -602,9 +610,17 @@ msgstr "Von der GMX-Community entwickelte Projekte. <0/>Seien Sie vorsichtig bei
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "Weitere Möglichkeiten"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "Unbekannter Fehler"
 msgid "Market Swap"
 msgstr "Markt-Tausch"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Details anzeigen"
@@ -925,6 +945,10 @@ msgstr "Gebührenwerte werden bei Erhalt berechnet. Ohne Anreize."
 msgid "TVL in vaults and pools"
 msgstr "TVL in Vaults und Pools"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1. Platz"
 msgid "Caption"
 msgstr "Caption"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "{0} wird bei Ausführung in {1} getauscht"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "Nicht realisierter Gewinn/Verlust"
 
@@ -1432,6 +1458,8 @@ msgstr "Übersicht"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "Kollateral"
 
@@ -1600,6 +1628,10 @@ msgstr "Weniger anzeigen"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "Vesten"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "Kontoübertragung abschließen"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "Symbole & Bilder"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "Preis-Impact-Rückerstattungen werden beansprucht…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "Open-Interest-Reservefaktor Longs"
 msgid "Layer 2"
 msgstr "Layer 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "Sie haben eine <0>ausstehende Übertragung</0> an {pendingReceiver}"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "Wie können wir Ihre Anliegen berücksichtigen?"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "Keine berechtigten Bestände erkannt"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "Helfen Sie uns, GMX zu verbessern. Aus Sicherheitsgründen werden wir Sie nicht zuerst kontaktieren. Senden Sie \"I have feedback\" an unser offizielles Konto:"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "Bestehende Position verwendet {0} als Sicherheit. Diese Order wird nicht darauf angewendet. <0>Zu {1}-Sicherheit wechseln</0>"
@@ -2632,6 +2682,8 @@ msgstr "Kaufe GMX auf {chainName}"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "Größe"
 
@@ -3021,6 +3073,10 @@ msgstr "Ordertyp"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Sicherheits-Spread"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "Kaufe GMX von zentralisierten Diensten"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "Unzureichende Liquidität. Die Order wird ausgeführt, sobald Liquiditä
 msgid "Your transfer is complete"
 msgstr "Ihre Übertragung ist abgeschlossen"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "und"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading ist mit dem nativen Token des Netzwerks {0} nicht verfü
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "Handeln"
 
@@ -3937,6 +3999,10 @@ msgstr "Selbstübertragung nicht unterstützt"
 msgid "Generating session..."
 msgstr "Sitzung generieren..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "Wie starte ich auf GMX?"
@@ -3986,6 +4052,8 @@ msgstr "Virtuelle Markt-ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Hebelwirkung"
 
@@ -4009,6 +4077,10 @@ msgstr "Genehmigung signieren"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "{daysConsidered}T verdiente Gebühren"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "Maximal 5 automatisch stornierbare TP/SL-Orders erlaubt. Zusätzliche Or
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "Markt"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "Smart Wallets werden bei Express Trading oder One-Click Trading nicht unterstützt"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "Ausgeführt"
 
@@ -4115,6 +4189,10 @@ msgstr "Kann ich jederzeit unstaken?"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "Maximale Gewinngrenze erreicht"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "Swap eingereicht"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Die Differenz zwischen erwartetem und tatsächlichem Ausführungspreis aufgrund von Volatilität. Orders werden nicht ausgeführt, wenn die Slippage Ihr Maximum überschreitet. Passen Sie den Standardwert in den Einstellungen an.<0/><1/>Ein niedriger Wert (z. B. weniger als -{0}) kann bei Volatilität zu fehlgeschlagenen Orders führen.<2/><3/>Slippage unterscheidet sich vom Preiseinfluss, der auf Open-Interest-Ungleichgewichten basiert. <4>Mehr erfahren</4>."
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "Bestehende Position im {0}-Pool, aber nicht genügend Liquidität für diese Order"
@@ -4237,6 +4319,11 @@ msgstr "Liquidiert"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "Beanspruchung wird verarbeitet..."
 msgid "Failed to load order data:"
 msgstr "Orderdaten konnten nicht geladen werden:"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "Netzwerk"
@@ -4567,6 +4658,7 @@ msgstr "GM Pools"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "Einstellungen aktualisiert"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "Short"
 
@@ -5225,6 +5320,10 @@ msgstr "Links"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "Maximaler verleihbarer Einflussfaktor für Abhebungen"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} Short Stop Market: {0} einer Short-Position, wenn der Preis
 msgid "Settings"
 msgstr "Einstellungen"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "Klicken Sie auf das Bearbeitungssymbol, um die Sicherheit anzupassen."
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Gestaket auf Avalanche"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "Stabile Renditen ohne Management"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "Spread"
 
@@ -6602,6 +6710,10 @@ msgstr "Letztes Jahr"
 msgid "per"
 msgstr "pro"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "Reservefaktor Longs"
@@ -6766,6 +6878,7 @@ msgstr "Wählen Sie einen Vermögenswert zum Einzahlen"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "Keine offenen Positionen"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "Unzureichende Liquidität zum Swappen von Kollateral"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "Governance"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -7742,6 +7859,10 @@ msgstr "Übermitteln"
 msgid "Claimed"
 msgstr "Beansprucht"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "weniger als eine Minute"
@@ -7888,6 +8009,10 @@ msgstr "Benachrichtigungen"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "Handelsmodus"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "Eröffnungsgebühr"
 msgid "Edit referral code"
 msgstr "Empfehlungscode bearbeiten"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "Verkaufsauftrag gesendet"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "Größe erhöhen (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "Aktualisieren"
 
@@ -8408,6 +8539,11 @@ msgstr "<0>{0}</0> beanspruchen"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "Erhalten"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "{nativeTokenSymbol} transferieren"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "LIQUIDITÄT SHORT"
@@ -8519,6 +8659,10 @@ msgstr "Zusammensetzung der Deckung"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "Einlösbare Rückvergütungen"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "Handelsverlauf"
 msgid "Exposure to backing tokens"
 msgstr "Engagement in Sicherungstoken"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "Typ suchen"
@@ -9047,6 +9199,10 @@ msgstr "Express + One-Click"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "GM Token repräsentieren Anteile an einem Liquiditätspool für einen einzelnen GMX Markt. Kaufen Sie GM, um Liquidität bereitzustellen und Gebühren aus dem Hebelhandel, Tauschgeschäften und Market-Making-Aktivitäten auf diesem spezifischen Markt zu verdienen. Alle Belohnungen werden automatisch reinvestiert."
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} erfolgreich verkauft, aber die Bridge zu Base ist fehlges
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "Long"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "Verwenden Sie die TP/SL-Schaltfläche, um TP/SL-Orders zu setzen."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "Die One-Click Trading Genehmigung ist ungültig. Dies kann beim Wechsel 
 msgid "GLP to GM airdrop"
 msgstr "GLP zu GM Airdrop"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "Verkaufsorder storniert"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "Einstiegspreis"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
@@ -10887,6 +11052,7 @@ msgstr "mehrere Asset-Klassen"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "Schließen"
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -23,6 +23,8 @@ msgstr "Slippage exceeded"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "settings"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr "Open Short"
 
@@ -505,6 +509,10 @@ msgstr "Select token"
 msgid "Image generation failed. Refresh and try again."
 msgstr "Image generation failed. Refresh and try again."
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr "Open Positions"
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "Unstaking..."
@@ -602,9 +610,17 @@ msgstr "Projects developed by the GMX community. <0/>Exercise caution when inter
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr "Bid"
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "Additional opportunities"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr "Avg Entry"
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "Unknown error"
 msgid "Market Swap"
 msgstr "Market Swap"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr "Loading positions…"
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "View details"
@@ -925,6 +945,10 @@ msgstr "Fee values calculated when earned. Excludes incentives."
 msgid "TVL in vaults and pools"
 msgstr "TVL in vaults and pools"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr "Clear completed"
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1st place"
 msgid "Caption"
 msgstr "Caption"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr "Approve USDC"
@@ -1206,6 +1231,7 @@ msgstr "{0} swapped to {1} when executed"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "Unrealized PnL"
 
@@ -1432,6 +1458,8 @@ msgstr "Overview"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "Collateral"
 
@@ -1600,6 +1628,10 @@ msgstr "Show less"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "Vest"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr "Connect wallet to see positions"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "Complete account transfer"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "Icons & images"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr "Approved"
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr "Unknown Order"
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "Claiming price impact rebates..."
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr "Close Position"
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "Open interest reserve factor longs"
 msgid "Layer 2"
 msgstr "Layer 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "You have a <0>pending transfer</0> to {pendingReceiver}"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "How can we address your concerns?"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr "Closing Size"
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "No eligible holdings detected"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr "Slippage"
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
@@ -2632,6 +2682,8 @@ msgstr "Buy GMX on {chainName}"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "Size"
 
@@ -3021,6 +3073,10 @@ msgstr "Order type"
 msgid "Transaction submitted"
 msgstr "Transaction submitted"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr "Ask"
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Collateral spread"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "Buy GMX from centralized services"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr "Close Short"
 
@@ -3482,6 +3539,10 @@ msgstr "Insufficient liquidity. Order will fill when liquidity is available."
 msgid "Your transfer is complete"
 msgstr "Your transfer is complete"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr "Custom %"
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "and"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading is unavailable with the network's native token {0}. Cons
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "Trade"
 
@@ -3937,6 +3999,10 @@ msgstr "Self-transfer not supported"
 msgid "Generating session..."
 msgstr "Generating session..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr "Close request submitted — waiting for Keeper execution"
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "How do I get started on GMX?"
@@ -3986,6 +4052,8 @@ msgstr "Virtual market ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Leverage"
 
@@ -4009,6 +4077,10 @@ msgstr "Sign permit"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "{daysConsidered}d earned fees"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr "Expires"
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "Max 5 auto-cancel TP/SL orders allowed. Extra orders require manual canc
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "Market"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "Smart wallets are not supported on Express Trading or One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "Executed"
 
@@ -4115,6 +4189,10 @@ msgstr "Can I unstake anytime?"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "Max profit limit reached"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr "Pending Requests"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "Swap submitted"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr "Expired"
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "Existing position in {0} pool but lacks liquidity for this order"
@@ -4237,6 +4319,11 @@ msgstr "Liquidated"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr "Submitting…"
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "Processing claim..."
 msgid "Failed to load order data:"
 msgstr "Failed to load order data:"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr "Decrease request cancelled"
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "Network"
@@ -4567,6 +4658,7 @@ msgstr "GM pools"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "Settings updated"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "Short"
 
@@ -5225,6 +5320,10 @@ msgstr "Links"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "Max lendable impact factor for withdrawals"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr "Reduce Position ({closePct}%)"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} Short Stop Market: {0} a short position when the price is b
 msgid "Settings"
 msgstr "Settings"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr "Increase request cancelled"
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "Click the edit icon to adjust collateral."
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Staked on Avalanche"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr "Pending"
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "Steady returns without management"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "Spread"
 
@@ -6602,6 +6710,10 @@ msgstr "Last year"
 msgid "per"
 msgstr "per"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr "Position Size"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "Reserve factor longs"
@@ -6766,6 +6878,7 @@ msgstr "Select an asset to deposit"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "No open positions"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "Insufficient liquidity to swap collateral"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr "Open Long"
 
@@ -6998,6 +7113,8 @@ msgstr "Governance"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -7742,6 +7859,10 @@ msgstr "Submit"
 msgid "Claimed"
 msgstr "Claimed"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr "Connect wallet to trade"
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "less than a minute"
@@ -7888,6 +8009,10 @@ msgstr "Notifications"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "Trading mode"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr "Back"
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "Open fee"
 msgid "Edit referral code"
 msgstr "Edit referral code"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr "Acceptable Price"
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "Sell request sent"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "Increase size (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "Refresh"
 
@@ -8408,6 +8539,11 @@ msgstr "Claim <0>{0}</0>"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "Receive"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr "Execution Fee"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "Transfer {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr "Opening position..."
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr "Side"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "LIQUIDITY SHORT"
@@ -8519,6 +8659,10 @@ msgstr "Backing composition"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "Claimable rebates"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr "Slippage Tolerance"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "Trade history"
 msgid "Exposure to backing tokens"
 msgstr "Exposure to backing tokens"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr "Request submitted — waiting for Keeper execution"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr "No pending requests"
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "Search type"
@@ -9047,6 +9199,10 @@ msgstr "Express + One-Click"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr "Open Long / Short positions via PositionRouter."
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} sold successfully, but bridge to Base failed. Your funds 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "Long"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "Use the TP/SL button to set TP/SL orders."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr "Close Long"
 
@@ -10170,6 +10330,10 @@ msgstr "One-Click Trading approval is invalid. This may happen when switching ch
 msgid "GLP to GM airdrop"
 msgstr "GLP to GM airdrop"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr "Pending Orders"
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "Sell order cancelled"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "Entry price"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "Cancelled"
 
@@ -10887,6 +11052,7 @@ msgstr "multiple asset classes"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "Close"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -23,6 +23,8 @@ msgstr "Deslizamiento excedido"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "configuración"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "Seleccionar token"
 msgid "Image generation failed. Refresh and try again."
 msgstr "La generación de la imagen ha fallado. Actualice la página e inténtelo de nuevo."
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "Retirando del staking..."
@@ -602,9 +610,17 @@ msgstr "Proyectos desarrollados por la comunidad de GMX. <0/>Tenga precaución a
 msgid "ADDRESS"
 msgstr "DIRECCIÓN"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "Oportunidades adicionales"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "Error desconocido"
 msgid "Market Swap"
 msgstr "Intercambio de Mercado"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Ver detalles"
@@ -925,6 +945,10 @@ msgstr "Valores de comisiones calculados en el momento en que se obtienen. No in
 msgid "TVL in vaults and pools"
 msgstr "TVL en bóvedas y pools"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1.er puesto"
 msgid "Caption"
 msgstr "Caption"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "{0} se intercambia por {1} cuando se ejecuta"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "PnL No Realizado"
 
@@ -1432,6 +1458,8 @@ msgstr "Resumen"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "Garantía"
 
@@ -1600,6 +1628,10 @@ msgstr "Mostrar menos"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "Adquirir"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "Completar transferencia de cuenta"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "Iconos e imágenes"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "Reclamando reembolsos de impacto en el precio…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "Factor de reserva de interés abierto largos"
 msgid "Layer 2"
 msgstr "Capa 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "Tiene una <0>transferencia pendiente</0> a {pendingReceiver}"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "¿Cómo podemos atender sus inquietudes?"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "No se detectaron tenencias elegibles"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "Ayúdenos a mejorar GMX. Por seguridad, no le contactaremos primero. Envíe \"I have feedback\" a nuestra cuenta oficial:"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "La posición existente utiliza garantía {0}. Esta orden no se aplicará a ella. <0>Cambiar a garantía {1}</0>"
@@ -2632,6 +2682,8 @@ msgstr "Comprar GMX en {chainName}"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "Tamaño"
 
@@ -3021,6 +3073,10 @@ msgstr "Tipo de orden"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Diferencial de garantía"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "Comprar GMX en servicios centralizados"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "Liquidez insuficiente. La orden se ejecutará cuando haya liquidez dispo
 msgid "Your transfer is complete"
 msgstr "Su transferencia se ha completado"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "y"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading no está disponible con el token nativo de la red {0}. C
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "Trading"
 
@@ -3937,6 +3999,10 @@ msgstr "Autotransferencia no permitida"
 msgid "Generating session..."
 msgstr "Generando sesión..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "¿Cómo empiezo en GMX?"
@@ -3986,6 +4052,8 @@ msgstr "ID de mercado virtual"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Apalancamiento"
 
@@ -4009,6 +4077,10 @@ msgstr "Firmar permiso"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "Comisiones obtenidas en {daysConsidered}d"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "Se permiten un máximo de 5 órdenes TP/SL con cancelación automática.
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "Mercado"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "Los monederos inteligentes no son compatibles con Express Trading ni con One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "Ejecutada"
 
@@ -4115,6 +4189,10 @@ msgstr "¿Puedo retirar el staking en cualquier momento?"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "Límite máximo de beneficio alcanzado"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "Intercambio enviado"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "La diferencia entre el precio de ejecución esperado y el real debido a la volatilidad. Las órdenes no se ejecutarán si el deslizamiento supera su máximo. Ajuste el valor predeterminado en configuración.<0/><1/>Un valor bajo (p. ej., inferior a -{0}) puede provocar órdenes fallidas durante períodos de volatilidad.<2/><3/>El deslizamiento difiere del impacto en el precio, que se basa en desequilibrios del interés abierto. <4>Más información</4>."
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "Posición existente en el pool {0}, pero carece de liquidez para esta orden"
@@ -4237,6 +4319,11 @@ msgstr "Liquidado"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "Procesando reclamación..."
 msgid "Failed to load order data:"
 msgstr "Error al cargar los datos de la orden:"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "Red"
@@ -4567,6 +4658,7 @@ msgstr "GM pools"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "GyP"
 
@@ -5157,6 +5249,9 @@ msgstr "Configuración actualizada"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "Corto"
 
@@ -5225,6 +5320,10 @@ msgstr "Enlaces"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "Factor de impacto prestable máximo para retiradas"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} Short Stop Market: {0} una posición corta cuando el precio
 msgid "Settings"
 msgstr "Ajustes"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "Haga clic en el icono de edición para ajustar la garantía."
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Stakeado en Avalanche"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "Retornos estables sin gestión"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "Deslizamiento"
 
@@ -6602,6 +6710,10 @@ msgstr "Último año"
 msgid "per"
 msgstr "por"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "Factor de reserva largos"
@@ -6766,6 +6878,7 @@ msgstr "Seleccione un activo para depositar"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "No hay posiciones abiertas"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "Liquidez insuficiente para intercambiar garantía"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "Gobernanza"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -7742,6 +7859,10 @@ msgstr "Enviar"
 msgid "Claimed"
 msgstr "Reclamado"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "menos de un minuto"
@@ -7888,6 +8009,10 @@ msgstr "Notificaciones"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "Modo de trading"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "Comisión de apertura"
 msgid "Edit referral code"
 msgstr "Editar código de referido"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "Solicitud de venta enviada"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "Aumentar tamaño (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "Actualizar"
 
@@ -8408,6 +8539,11 @@ msgstr "Reclamar <0>{0}</0>"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "Recibir"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "Transferir {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "LIQUIDEZ SHORT"
@@ -8519,6 +8659,10 @@ msgstr "Composición del respaldo"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "Reembolsos reclamables"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "Historial de operaciones"
 msgid "Exposure to backing tokens"
 msgstr "Exposición a los tokens de respaldo"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "Buscar tipo"
@@ -9047,6 +9199,10 @@ msgstr "Express + Un Clic"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "Los tokens GM representan participaciones en un pool de liquidez para un mercado GMX individual. Compre GM para proporcionar liquidez y ganar comisiones del trading con apalancamiento, intercambios y actividad de creación de mercado en ese mercado específico. Todas las recompensas se reinvierten automáticamente."
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} vendido correctamente, pero el puente a Base falló. Sus 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "Largo"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "Utilice el botón TP/SL para establecer órdenes TP/SL."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "La aprobación de One-Click Trading no es válida. Esto puede ocurrir al
 msgid "GLP to GM airdrop"
 msgstr "GLP to GM airdrop"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "Orden de venta cancelada"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "Precio de entrada"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -10887,6 +11052,7 @@ msgstr "múltiples clases de activos"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "Cerrar"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -23,6 +23,8 @@ msgstr "Glissement dépassé"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "paramètres"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "Sélectionner un jeton"
 msgid "Image generation failed. Refresh and try again."
 msgstr "La génération d'image a échoué. Actualisez et réessayez."
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "Retrait du staking..."
@@ -602,9 +610,17 @@ msgstr "Projets développés par la communauté GMX. <0/>Faites preuve de pruden
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "Opportunités supplémentaires"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "Erreur inconnue"
 msgid "Market Swap"
 msgstr "Swap de marché"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Voir les détails"
@@ -925,6 +945,10 @@ msgstr "Valeurs des frais calculées au moment où ils sont perçus. Hors incita
 msgid "TVL in vaults and pools"
 msgstr "TVL dans les coffres et les pools"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1re place"
 msgid "Caption"
 msgstr "Légende"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "{0} échangé contre {1} lors de l'exécution"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "PnL non réalisé"
 
@@ -1432,6 +1458,8 @@ msgstr "Aperçu"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "Collatéral"
 
@@ -1600,6 +1628,10 @@ msgstr "Afficher moins"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "Vester"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "Finaliser le transfert de compte"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "Icônes et images"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "Réclamation des remboursements d'impact sur le prix…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "Facteur de réserve des positions ouvertes longs"
 msgid "Layer 2"
 msgstr "Layer 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "Vous avez un <0>transfert en attente</0> vers {pendingReceiver}"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "Comment pouvons-nous répondre à vos préoccupations ?"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "Aucun actif éligible détecté"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "Aidez-nous à améliorer GMX. Pour des raisons de sécurité, nous ne vous contacterons pas en premier. Envoyez « I have feedback » à notre compte officiel :"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "La position existante utilise la garantie {0}. Cet ordre ne s'y appliquera pas. <0>Passer à la garantie {1}</0>"
@@ -2632,6 +2682,8 @@ msgstr "Acheter GMX sur {chainName}"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "Taille"
 
@@ -3021,6 +3073,10 @@ msgstr "Type d'ordre"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Écart de garantie"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "Acheter GMX sur des services centralisés"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "Liquidité insuffisante. L'ordre sera exécuté lorsque la liquidité se
 msgid "Your transfer is complete"
 msgstr "Votre transfert est terminé"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "et"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading n'est pas disponible avec le jeton natif du réseau {0}.
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "Trader"
 
@@ -3937,6 +3999,10 @@ msgstr "Auto-transfert non pris en charge"
 msgid "Generating session..."
 msgstr "Génération de session..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "Comment commencer sur GMX ?"
@@ -3986,6 +4052,8 @@ msgstr "ID de marché virtuel"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Levier"
 
@@ -4009,6 +4077,10 @@ msgstr "Signer le permis"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "Frais gagnés sur {daysConsidered}j"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "Maximum de 5 ordres TP/SL à annulation automatique autorisés. Les ordr
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "Marché"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "Les portefeuilles intelligents ne sont pas pris en charge avec Express Trading ou One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "Exécutée"
 
@@ -4115,6 +4189,10 @@ msgstr "Puis-je unstaker à tout moment ?"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "Limite de profit maximum atteinte"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "Swap soumis"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "La différence entre le prix d'exécution attendu et le prix réel due à la volatilité. Les ordres ne s'exécuteront pas si le glissement dépasse votre maximum. Ajustez la valeur par défaut dans les paramètres.<0/><1/>Une valeur faible (par ex. inférieure à -{0}) peut entraîner l'échec d'ordres en période de volatilité.<2/><3/>Le glissement diffère de l'impact sur le prix, qui est basé sur les déséquilibres des positions ouvertes. <4>En savoir plus</4>."
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "Position existante dans le pool {0} mais liquidité insuffisante pour cet ordre"
@@ -4237,6 +4319,11 @@ msgstr "Liquidé"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "Traitement de la récupération en cours..."
 msgid "Failed to load order data:"
 msgstr "Échec du chargement des données de l'ordre :"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "Réseau"
@@ -4567,6 +4658,7 @@ msgstr "Pools GM"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "Paramètres mis à jour"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "Short"
 
@@ -5225,6 +5320,10 @@ msgstr "Liens"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "Facteur d'impact prêtable max pour les retraits"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} Short Stop Market : {0} une position short lorsque le prix 
 msgid "Settings"
 msgstr "Paramètres"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "Cliquez sur l'icône de modification pour ajuster la garantie."
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Staké sur Avalanche"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "Rendements stables sans gestion"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "Écart"
 
@@ -6602,6 +6710,10 @@ msgstr "Année dernière"
 msgid "per"
 msgstr "par"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "Facteur de réserve longs"
@@ -6766,6 +6878,7 @@ msgstr "Sélectionnez un actif à déposer"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "Aucune position ouverte"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "Liquidité insuffisante pour échanger le collatéral"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "Gouvernance"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -7742,6 +7859,10 @@ msgstr "Soumettre"
 msgid "Claimed"
 msgstr "Récupéré"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "moins d'une minute"
@@ -7888,6 +8009,10 @@ msgstr "Notifications"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "Mode de trading"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "Frais d'ouverture"
 msgid "Edit referral code"
 msgstr "Modifier le code de parrainage"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "Demande de vente envoyée"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "Augmenter la taille (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -8408,6 +8539,11 @@ msgstr "Réclamer <0>{0}</0>"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "Recevoir"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "Transférer {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "LIQUIDITÉ SHORT"
@@ -8519,6 +8659,10 @@ msgstr "Composition de l'adossement"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "Remises réclamables"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "Historique des trades"
 msgid "Exposure to backing tokens"
 msgstr "Exposition aux tokens de garantie"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "Rechercher un type"
@@ -9047,6 +9199,10 @@ msgstr "Express + One-Click"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "Les tokens GM représentent des parts dans un pool de liquidité pour un marché GMX unique. Achetez des GM pour fournir de la liquidité et percevoir des frais issus du trading avec effet de levier, des échanges et de l'activité de tenue de marché sur ce marché spécifique. Toutes les récompenses sont automatiquement réinvesties."
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} vendu avec succès, mais le pont vers Base a échoué. Vo
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "Long"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "Utilisez le bouton TP/SL pour définir des ordres TP/SL."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "L'approbation One-Click Trading n'est plus valide. Cela peut se produire
 msgid "GLP to GM airdrop"
 msgstr "Airdrop GLP vers GM"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "Ordre de vente annulé"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "Prix d'entrée"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "Annulé"
 
@@ -10887,6 +11052,7 @@ msgstr "plusieurs classes d'actifs"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "Fermer"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -23,6 +23,8 @@ msgstr "スリッページ超過"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "設定"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "トークンを選択"
 msgid "Image generation failed. Refresh and try again."
 msgstr "画像の生成に失敗しました。更新して再度お試しください。"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "ステーキング解除中..."
@@ -602,9 +610,17 @@ msgstr "GMXコミュニティによって開発されたプロジェクトです
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "追加の機会"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "不明なエラー"
 msgid "Market Swap"
 msgstr "市場スワップ"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "詳細を表示"
@@ -925,6 +945,10 @@ msgstr "手数料は獲得時に計算されます。インセンティブは含
 msgid "TVL in vaults and pools"
 msgstr "ボールトおよびプール内のTVL"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1位"
 msgid "Caption"
 msgstr "キャプション"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "約定時に {0} が {1} にスワップされます"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "未実現PnL"
 
@@ -1432,6 +1458,8 @@ msgstr "概要"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "担保"
 
@@ -1600,6 +1628,10 @@ msgstr "少なく表示"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "べスト"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "アカウント送金の完了"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "アイコンと画像"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "価格影響リベートを請求中…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "建玉リザーブファクター（ロング）"
 msgid "Layer 2"
 msgstr "レイヤー2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "{pendingReceiver}への<0>保留中の送金</0>があります"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "ご懸念にどのように対応すればよろしいでしょうか？"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "対象となる保有資産が検出されませんでした"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "GMXの改善にご協力ください。セキュリティのため、こちらから先にご連絡することはありません。公式アカウントに「I have feedback」とお送りください:"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "既存のポジションは{0}担保を使用しています。この注文は適用されません。<0>{1}担保に切り替える</0>"
@@ -2632,6 +2682,8 @@ msgstr "{chainName}でGMXを購入"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "サイズ"
 
@@ -3021,6 +3073,10 @@ msgstr "注文タイプ"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "担保スプレッド"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "中央集権型サービスからGMXを購入"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "流動性不足です。流動性が確保され次第、注文が約定
 msgid "Your transfer is complete"
 msgstr "送金が完了しました"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "と"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading はネットワークのネイティブトークン {0} 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "トレード"
 
@@ -3937,6 +3999,10 @@ msgstr "自己転送はサポートされていません"
 msgid "Generating session..."
 msgstr "セッション生成中..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "GMXを始めるにはどうしたらいいですか？"
@@ -3986,6 +4052,8 @@ msgstr "仮想マーケットID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "レバレッジ"
 
@@ -4009,6 +4077,10 @@ msgstr "パーミットに署名"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "{daysConsidered}日間の獲得手数料"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "自動キャンセルTP/SL注文は最大5件まで許可されていま
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "マーケット"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "スマートウォレットは Express Trading および One-Click Trading に対応していません"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "実行済み"
 
@@ -4115,6 +4189,10 @@ msgstr "いつでもアンステークできますか？"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "最大利益上限に達しました"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "スワップを送信しました"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "ボラティリティによる予想約定価格と実際の約定価格の差です。スリッページが最大値を超えると注文は約定されません。デフォルト値は設定で調整できます。<0/><1/>低い値（例: -{0} 未満）を設定すると、ボラティリティが高い時に注文が失敗する可能性があります。<2/><3/>スリッページは建玉の偏りに基づく価格への影響とは異なります。<4>詳細はこちら</4>。"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "{0} プールに既存のポジションがありますが、この注文に必要な流動性が不足しています"
@@ -4237,6 +4319,11 @@ msgstr "清算済"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "受け取りを処理中..."
 msgid "Failed to load order data:"
 msgstr "注文データの読み込みに失敗しました:"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "ネットワーク"
@@ -4567,6 +4658,7 @@ msgstr "GM プール"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "損益"
 
@@ -5157,6 +5249,9 @@ msgstr "設定が更新されました"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "ショート"
 
@@ -5225,6 +5320,10 @@ msgstr "リンク"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "出金の最大貸出可能インパクトファクター"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} ショート Stop Market: 価格がトリガー価格を下
 msgid "Settings"
 msgstr "設定"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "編集アイコンをクリックして担保を調整してください
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Avalancheでステーク済"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "管理なしの安定リターン"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "スプレッド"
 
@@ -6602,6 +6710,10 @@ msgstr "昨年"
 msgid "per"
 msgstr "あたり"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "リザーブファクター（ロング）"
@@ -6766,6 +6878,7 @@ msgstr "入金するアセットを選択してください"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "オープンのポジションはありません"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "担保スワップのための流動性不足"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "ガバナンス"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -7742,6 +7859,10 @@ msgstr "提出"
 msgid "Claimed"
 msgstr "受け取り完了"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "1分未満"
@@ -7888,6 +8009,10 @@ msgstr "通知"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "トレーディングモード"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "オープン手数料"
 msgid "Edit referral code"
 msgstr "リファラルコードを編集"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "売却リクエストが送信されました"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "サイズを増加（TWAP）"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "更新"
 
@@ -8408,6 +8539,11 @@ msgstr "<0>{0}</0> を請求"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "受取"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "{nativeTokenSymbol} を移転"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "流動性 ショート"
@@ -8519,6 +8659,10 @@ msgstr "裏付け構成"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "請求可能なリベート"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "取引履歴"
 msgid "Exposure to backing tokens"
 msgstr "裏付けトークンへのエクスポージャー"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "タイプを検索"
@@ -9047,6 +9199,10 @@ msgstr "エクスプレス + ワンクリック"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "GMトークンは、単一のGMXマーケットの流動性プールにおけるシェアを表します。GMを購入して流動性を提供し、そのマーケットにおけるレバレッジ取引、スワップ、マーケットメイキング活動から手数料を獲得できます。すべての報酬は自動的に複利運用されます。"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel}の売却は成功しましたが、Baseへのブリッジ
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "ロング"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "TP/SLボタンを使用してTP/SL注文を設定してください。"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "One-Click Trading の承認が無効です。チェーンの切り替え
 msgid "GLP to GM airdrop"
 msgstr "GLP から GM へのエアドロップ"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "売却注文がキャンセルされました"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "エントリー価格"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "キャンセル済み"
 
@@ -10887,6 +11052,7 @@ msgstr "複数の資産クラス"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "クローズ"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -23,6 +23,8 @@ msgstr "슬리피지 초과"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "설정"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "토큰 선택"
 msgid "Image generation failed. Refresh and try again."
 msgstr "이미지 생성에 실패했습니다. 새로고침 후 다시 시도하십시오."
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "언스테이킹 중..."
@@ -602,9 +610,17 @@ msgstr "GMX 커뮤니티에서 개발한 프로젝트입니다. <0/>모든 앱�
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "추가 기회"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "알 수 없는 오류"
 msgid "Market Swap"
 msgstr "마켓 스왑"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "상세 보기"
@@ -925,6 +945,10 @@ msgstr "수수료 값은 수익 발생 시점에 계산됩니다. 인센티브�
 msgid "TVL in vaults and pools"
 msgstr "금고 및 풀의 TVL"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1위"
 msgid "Caption"
 msgstr "Caption"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "체결 시 {0}이(가) {1}(으)로 스왑됩니다"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "미실현 PnL"
 
@@ -1432,6 +1458,8 @@ msgstr "개요"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "담보"
 
@@ -1600,6 +1628,10 @@ msgstr "적게 표시"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "베스트"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "계정 전송 완료"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "아이콘 및 이미지"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "가격 영향 리베이트를 청구하는 중…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "롱 미결제약정 준비금 비율"
 msgid "Layer 2"
 msgstr "레이어 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "{pendingReceiver}에게 <0>대기 중인 전송</0>이 있습니다"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "어떤 부분을 개선하면 좋겠습니까?"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "적격 보유 자산이 감지되지 않았습니다"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "GMX 개선에 도움을 주십시오. 보안을 위해 먼저 연락드리지 않습니다. 공식 계정으로 \"I have feedback\"를 보내주십시오:"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "기존 포지션이 {0} 담보를 사용합니다. 이 주문은 해당 포지션에 적용되지 않습니다. <0>{1} 담보로 전환</0>"
@@ -2632,6 +2682,8 @@ msgstr "{chainName}에서 GMX 구매"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "크기"
 
@@ -3021,6 +3073,10 @@ msgstr "주문 유형"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "담보 스프레드"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "중앙화 서비스에서 GMX 구매"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "유동성 부족. 유동성이 확보되면 주문이 체결됩니다."
 msgid "Your transfer is complete"
 msgstr "전송이 완료되었습니다"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "그리고"
@@ -3712,6 +3773,7 @@ msgstr "네트워크 기본 토큰 {0}에서는 Express Trading을 사용할 수
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "트레이드"
 
@@ -3937,6 +3999,10 @@ msgstr "자기 전송은 지원되지 않습니다"
 msgid "Generating session..."
 msgstr "세션 생성 중..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "GMX를 어떻게 시작하나요?"
@@ -3986,6 +4052,8 @@ msgstr "가상 마켓 ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "레버리지"
 
@@ -4009,6 +4077,10 @@ msgstr "허가 서명"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "{daysConsidered}일 수수료 수익"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "자동 취소 TP/SL 주문은 최대 5개까지 허용됩니다. 추가 
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "마켓"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "스마트 지갑은 Express Trading 또는 One-Click Trading에서 지원되지 않습니다"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "실행됨"
 
@@ -4115,6 +4189,10 @@ msgstr "언제든지 언스테이킹할 수 있나요?"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "최대 수익 한도에 도달했습니다"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "스왑 제출 완료"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "변동성으로 인해 예상 체결가와 실제 체결가 사이의 차이입니다. 슬리피지가 최대치를 초과하면 주문이 체결되지 않습니다. 설정에서 기본값을 조정하십시오.<0/><1/>낮은 값(예: -{0} 미만)은 변동성이 큰 시기에 주문 실패를 초래할 수 있습니다.<2/><3/>슬리피지는 미결제약정 불균형에 기반한 가격 영향과 다릅니다. <4>자세히 보기</4>."
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "{0} 풀에 기존 포지션이 있지만 이 주문에 대한 유동성이 부족합니다"
@@ -4237,6 +4319,11 @@ msgstr "청산됨"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "수령 처리 중..."
 msgid "Failed to load order data:"
 msgstr "주문 데이터 로드 실패:"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "네트워크"
@@ -4567,6 +4658,7 @@ msgstr "GM 풀"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "설정이 업데이트되었습니다"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "숏"
 
@@ -5225,6 +5320,10 @@ msgstr "링크"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "출금 시 최대 대출 가능 영향 계수"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} 숏 Stop Market: 가격이 조건가 이하일 때 숏 포�
 msgid "Settings"
 msgstr "설정"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "편집 아이콘을 클릭하여 담보를 조정하십시오."
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Avalanche에서 스테이킹됨"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "관리 없이 안정적인 수익"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "스프레드"
 
@@ -6602,6 +6710,10 @@ msgstr "작년"
 msgid "per"
 msgstr "당"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "롱 준비금 비율"
@@ -6766,6 +6878,7 @@ msgstr "입금할 자산을 선택하십시오"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "열려 있는 포지션 없음"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "담보 스왑을 위한 유동성 부족"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "거버넌스"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "취소"
 
@@ -7742,6 +7859,10 @@ msgstr "제출"
 msgid "Claimed"
 msgstr "수령 완료"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "1분 미만"
@@ -7888,6 +8009,10 @@ msgstr "알림"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "거래 모드"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "개시 수수료"
 msgid "Edit referral code"
 msgstr "추천 코드 편집"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "판매 요청이 전송되었습니다"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "규모 증가 (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "새로고침"
 
@@ -8408,6 +8539,11 @@ msgstr "<0>{0}</0> 수령"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "수령"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "{nativeTokenSymbol} 전송"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "유동성 숏"
@@ -8519,6 +8659,10 @@ msgstr "담보 구성"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "청구 가능한 리베이트"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "거래 내역"
 msgid "Exposure to backing tokens"
 msgstr "기초 담보 토큰에 대한 익스포저"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "유형 검색"
@@ -9047,6 +9199,10 @@ msgstr "익스프레스 + 원클릭"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "GM 토큰은 단일 GMX 시장의 유동성 풀 지분을 나타냅니다. GM을 구매하여 유동성을 제공하고 해당 시장의 레버리지 거래, 스왑, 마켓 메이킹 활동에서 발생하는 수수료를 받으십시오. 모든 보상은 자동으로 재투자됩니다."
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} 매도가 완료되었으나 Base로의 브릿지가 실�
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "롱"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "TP/SL 버튼을 사용하여 TP/SL 주문을 설정하십시오."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "One-Click Trading 승인이 유효하지 않습니다. 체인 전환 또
 msgid "GLP to GM airdrop"
 msgstr "GLP에서 GM 에어드롭"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "판매 주문이 취소되었습니다"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "진입가"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "취소됨"
 
@@ -10887,6 +11052,7 @@ msgstr "다중 자산 클래스"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "종료"
 

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -23,6 +23,8 @@ msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr ""
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr ""
 msgid "Image generation failed. Refresh and try again."
 msgstr ""
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr ""
@@ -602,8 +610,16 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
+msgstr ""
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
 msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
@@ -778,6 +794,10 @@ msgstr ""
 msgid "Market Swap"
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr ""
@@ -925,6 +945,10 @@ msgstr ""
 msgid "TVL in vaults and pools"
 msgstr ""
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr ""
 msgid "Caption"
 msgstr ""
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr ""
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr ""
 
@@ -1432,6 +1458,8 @@ msgstr ""
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr ""
 
@@ -1599,6 +1627,10 @@ msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
+msgstr ""
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
 msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
@@ -1786,6 +1818,10 @@ msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
 msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
@@ -1996,6 +2032,11 @@ msgstr ""
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
+msgstr ""
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
 msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
@@ -2397,6 +2438,7 @@ msgstr ""
 msgid "Layer 2"
 msgstr ""
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2439,6 +2481,10 @@ msgstr ""
 
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
+msgstr ""
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
 msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
@@ -2571,6 +2617,10 @@ msgstr ""
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr ""
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr ""
@@ -2632,6 +2682,8 @@ msgstr ""
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr ""
 
@@ -3021,6 +3073,10 @@ msgstr ""
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr ""
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr ""
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr ""
 msgid "Your transfer is complete"
 msgstr ""
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr ""
@@ -3712,6 +3773,7 @@ msgstr ""
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr ""
 
@@ -3937,6 +3999,10 @@ msgstr ""
 msgid "Generating session..."
 msgstr ""
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr ""
@@ -3986,6 +4052,8 @@ msgstr ""
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr ""
 
@@ -4008,6 +4076,10 @@ msgstr ""
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
 msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
@@ -4056,6 +4128,7 @@ msgstr ""
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr ""
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr ""
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr ""
 
@@ -4114,6 +4188,10 @@ msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
 msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -4207,6 +4285,10 @@ msgstr ""
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr ""
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr ""
@@ -4236,6 +4318,11 @@ msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
+msgstr ""
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
 msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
@@ -4536,6 +4623,10 @@ msgstr ""
 msgid "Failed to load order data:"
 msgstr ""
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr ""
@@ -4567,6 +4658,7 @@ msgstr ""
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr ""
 
@@ -5157,6 +5249,9 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr ""
 
@@ -5224,6 +5319,10 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
+msgstr ""
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
@@ -5511,6 +5610,10 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr ""
@@ -5663,6 +5766,10 @@ msgstr ""
 
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
 msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr ""
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr ""
 
@@ -6602,6 +6710,10 @@ msgstr ""
 msgid "per"
 msgstr ""
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr ""
@@ -6766,6 +6878,7 @@ msgstr ""
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr ""
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr ""
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr ""
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr ""
 
@@ -7742,6 +7859,10 @@ msgstr ""
 msgid "Claimed"
 msgstr ""
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr ""
@@ -7887,6 +8008,10 @@ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
+msgstr ""
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
 msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
@@ -8327,6 +8452,11 @@ msgstr ""
 msgid "Edit referral code"
 msgstr ""
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr ""
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr ""
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr ""
 
@@ -8407,6 +8538,11 @@ msgstr ""
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
+msgstr ""
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
 msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
@@ -8465,6 +8601,10 @@ msgstr ""
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr ""
@@ -8518,6 +8658,10 @@ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
 msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr ""
 msgid "Exposure to backing tokens"
 msgstr ""
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr ""
@@ -9046,6 +9198,10 @@ msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
+msgstr ""
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
 msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
@@ -9110,6 +9266,9 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr ""
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr ""
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr ""
 msgid "GLP to GM airdrop"
 msgstr ""
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr ""
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr ""
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr ""
 
@@ -10887,6 +11052,7 @@ msgstr ""
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr ""
 

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -23,6 +23,8 @@ msgstr "Проскальзывание превышено"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "настройки"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "Выберите токен"
 msgid "Image generation failed. Refresh and try again."
 msgstr "Не удалось сгенерировать изображение. Обновите страницу и попробуйте снова."
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "Снятие со стейкинга..."
@@ -602,9 +610,17 @@ msgstr "Проекты, разработанные сообществом GMX. <
 msgid "ADDRESS"
 msgstr "АДРЕС"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "Дополнительные возможности"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "Неизвестная ошибка"
 msgid "Market Swap"
 msgstr "Рыночный обмен"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Подробнее"
@@ -925,6 +945,10 @@ msgstr "Значения комиссий рассчитываются на мо
 msgid "TVL in vaults and pools"
 msgstr "TVL в хранилищах и пулах"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "1-е место"
 msgid "Caption"
 msgstr "Caption"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "{0} будет обменено на {1} при исполнении"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "Нереализованная PnL"
 
@@ -1432,6 +1458,8 @@ msgstr "Обзор"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "Залог"
 
@@ -1600,6 +1628,10 @@ msgstr "Показать меньше"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "Вестинг"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "Завершение перевода аккаунта"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "Иконки и изображения"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "Запрос возвратов за влияние на цену…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "Резервный фактор открытого интереса дл
 msgid "Layer 2"
 msgstr "Layer 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "У вас есть <0>ожидающий перевод</0> для {pend
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "Как мы можем решить ваши проблемы?"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "Подходящие активы не обнаружены"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "Помогите нам улучшить GMX. В целях безопасности мы не свяжемся с вами первыми. Отправьте \"I have feedback\" на наш официальный аккаунт:"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "Существующая позиция использует обеспечение {0}. Данный ордер не будет к ней применён. <0>Переключить на обеспечение {1}</0>"
@@ -2632,6 +2682,8 @@ msgstr "Купить GMX на {chainName}"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "Размер"
 
@@ -3021,6 +3073,10 @@ msgstr "Тип ордера"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Спред обеспечения"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "Купить GMX на централизованных сервисах"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "Недостаточная ликвидность. Ордер будет
 msgid "Your transfer is complete"
 msgstr "Ваш перевод завершён"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "и"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading недоступен с нативным токеном 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "Торговля"
 
@@ -3937,6 +3999,10 @@ msgstr "Самоперевод не поддерживается"
 msgid "Generating session..."
 msgstr "Генерация сессии..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "Как начать на GMX?"
@@ -3986,6 +4052,8 @@ msgstr "Виртуальный ID рынка"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Плечо"
 
@@ -4009,6 +4077,10 @@ msgstr "Подписать разрешение"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "Комиссии за {daysConsidered}д"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "Допускается максимум 5 автоотменяемых �
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "Рынок"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "Смарт-кошельки не поддерживаются в Express Trading и One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "Исполнено"
 
@@ -4115,6 +4189,10 @@ msgstr "Могу ли я вывести из стейкинга в любой м
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "Достигнут лимит максимальной прибыли"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "Своп отправлен"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Разница между ожидаемой и фактической ценой исполнения из-за волатильности. Ордера не будут исполнены, если проскальзывание превысит ваш максимум. Настройте значение по умолчанию в настройках.<0/><1/>Низкое значение (например, менее -{0}) может привести к неисполнению ордеров при волатильности.<2/><3/>Проскальзывание отличается от влияния на цену, которое основано на дисбалансе открытого интереса. <4>Подробнее</4>."
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "Существующая позиция в пуле {0}, но недостаточно ликвидности для этого ордера"
@@ -4237,6 +4319,11 @@ msgstr "Ликвидировано"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "Обработка получения..."
 msgid "Failed to load order data:"
 msgstr "Не удалось загрузить данные ордера:"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "Сеть"
@@ -4567,6 +4658,7 @@ msgstr "GM пулы"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "Настройки обновлены"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "Шорт"
 
@@ -5225,6 +5320,10 @@ msgstr "Ссылки"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "Макс. фактор влияния заёмных средств для выводов"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} Short Stop Market: {0} шорт-позицию, когда 
 msgid "Settings"
 msgstr "Настройки"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "Нажмите на значок редактирования для и�
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "Стейкано на Avalanche"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "Стабильная доходность без управления"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "Спред"
 
@@ -6602,6 +6710,10 @@ msgstr "Последний год"
 msgid "per"
 msgstr "за"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "Резервный фактор лонгов"
@@ -6766,6 +6878,7 @@ msgstr "Выберите актив для депозита"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "Нет открытых позиций"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "Недостаточная ликвидность для обмена залога"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "Управление"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Отменить"
 
@@ -7742,6 +7859,10 @@ msgstr "Подать"
 msgid "Claimed"
 msgstr "Получено"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "меньше минуты"
@@ -7888,6 +8009,10 @@ msgstr "Уведомления"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "Режим торговли"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "Комиссия за открытие"
 msgid "Edit referral code"
 msgstr "Редактирование реферального кода"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "Запрос на продажу отправлен"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "Увеличить размер (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -8408,6 +8539,11 @@ msgstr "Запросить <0>{0}</0>"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "Получение"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "Перевести {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "ЛИКВИДНОСТЬ ШОРТ"
@@ -8519,6 +8659,10 @@ msgstr "Структура обеспечения"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "Доступные к получению скидки"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "История сделок"
 msgid "Exposure to backing tokens"
 msgstr "Экспозиция к обеспечивающим токенам"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "Поиск типа"
@@ -9047,6 +9199,10 @@ msgstr "Express + One-Click"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "Токены GM представляют собой доли в пуле ликвидности для отдельного рынка GMX. Покупайте GM, чтобы предоставлять ликвидность и получать комиссии от торговли с кредитным плечом, свопов и маркетмейкерской деятельности на этом рынке. Все вознаграждения реинвестируются автоматически."
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} успешно продан, но мост на Base не
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "Лонг"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "Используйте кнопку TP/SL для установки TP/SL ордеров."
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "Подтверждение One-Click Trading недействитель�
 msgid "GLP to GM airdrop"
 msgstr "GLP to GM аирдроп"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "Ордер на продажу отменён"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "Цена входа"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "Отменено"
 
@@ -10887,6 +11052,7 @@ msgstr "множество классов активов"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "Закрыть"
 

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -23,6 +23,8 @@ msgstr "滑點超出限制"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "設定"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "選擇代幣"
 msgid "Image generation failed. Refresh and try again."
 msgstr "圖片生成失敗。請重新整理後再試一次。"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "解除質押中..."
@@ -602,9 +610,17 @@ msgstr "由 GMX 社群開發的項目。<0/>與任何應用程式互動時請謹
 msgid "ADDRESS"
 msgstr "地址"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "更多機會"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "未知錯誤"
 msgid "Market Swap"
 msgstr "Market Swap"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "查看詳情"
@@ -925,6 +945,10 @@ msgstr "費用數值在賺取時計算。不包含獎勵。"
 msgid "TVL in vaults and pools"
 msgstr "金庫與池中的 TVL"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "第 1 名"
 msgid "Caption"
 msgstr "Caption"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "執行時 {0} 將兌換為 {1}"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "未實現盈虧"
 
@@ -1432,6 +1458,8 @@ msgstr "概覽"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "抵押品"
 
@@ -1600,6 +1628,10 @@ msgstr "收起"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "歸屬"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "完成帳戶轉移"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "圖示與圖片"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "正在領取價格影響回饋..."
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "做多未平倉量儲備因子"
 msgid "Layer 2"
 msgstr "Layer 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "您有一筆<0>待處理的轉帳</0>至 {pendingReceiver}"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "我們如何改善您的疑慮？"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "未偵測到符合條件的持倉"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "幫助我們改善 GMX。為了安全，我們不會主動聯絡您。請發送「I have feedback」至我們的官方帳號："
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "現有倉位使用 {0} 抵押品。此訂單將不會套用於該倉位。<0>切換至 {1} 抵押品</0>"
@@ -2632,6 +2682,8 @@ msgstr "在 {chainName} 上買入 GMX"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "規模"
 
@@ -3021,6 +3073,10 @@ msgstr "訂單類型"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "抵押品價差"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "從中心化服務購買 GMX"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "流動性不足。當流動性可用時將執行訂單。"
 msgid "Your transfer is complete"
 msgstr "您的轉帳已完成"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "和"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading 不支援網路原生代幣 {0}。請考慮改用 {1}。
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "交易"
 
@@ -3937,6 +3999,10 @@ msgstr "不支援自行轉帳"
 msgid "Generating session..."
 msgstr "正在生成會話..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "如何在 GMX 上開始使用？"
@@ -3986,6 +4052,8 @@ msgstr "虛擬市場 ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "槓桿"
 
@@ -4009,6 +4077,10 @@ msgstr "簽署授權"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "{daysConsidered} 天已賺取費用"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "最多允許 5 個自動取消 TP/SL 訂單。額外的訂單需要手�
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "市場"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "智能錢包不支援 Express Trading 或 One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "已執行"
 
@@ -4115,6 +4189,10 @@ msgstr "我可以隨時解除質押嗎？"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "已達最大利潤上限"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "兌換已提交"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "預期成交價格與實際成交價格之間因波動性產生的差異。若滑點超過您設定的最大值，訂單將不會執行。可在設定中調整預設值。<0/><1/>過低的值（例如低於 -{0}）可能導致訂單在波動時失敗。<2/><3/>滑點不同於價格影響，後者基於未平倉量的不平衡。<4>閱讀更多</4>。"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "在 {0} 池中有現有倉位，但該池流動性不足以執行此訂單"
@@ -4237,6 +4319,11 @@ msgstr "已清算"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "領取處理中..."
 msgid "Failed to load order data:"
 msgstr "無法載入訂單資料："
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "網路"
@@ -4567,6 +4658,7 @@ msgstr "GM 池"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "設定已更新"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "做空"
 
@@ -5225,6 +5320,10 @@ msgstr "連結"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "提取最大可借出影響因子"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} Short Stop Market：當價格低於觸發價格時{0}做空
 msgid "Settings"
 msgstr "設定"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "點擊編輯圖示以調整抵押品。"
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "已在 Avalanche 上質押"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "無需管理的穩定收益"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "價差"
 
@@ -6602,6 +6710,10 @@ msgstr "過去一年"
 msgid "per"
 msgstr "每"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "做多儲備因子"
@@ -6766,6 +6878,7 @@ msgstr "選擇要存入的資產"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "沒有未平倉倉位"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "流動性不足，無法兌換抵押品"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "治理"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "取消"
 
@@ -7742,6 +7859,10 @@ msgstr "提交"
 msgid "Claimed"
 msgstr "已領取"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "不到一分鐘"
@@ -7888,6 +8009,10 @@ msgstr "通知"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "交易模式"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "開倉費用"
 msgid "Edit referral code"
 msgstr "編輯推薦碼"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "賣出請求已發送"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "增加倉位（TWAP）"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -8408,6 +8539,11 @@ msgstr "領取 <0>{0}</0>"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "收到"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "轉帳 {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "做空流動性"
@@ -8519,6 +8659,10 @@ msgstr "支撐組成"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "可領取的返利"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "交易歷史記錄"
 msgid "Exposure to backing tokens"
 msgstr "支撐代幣的曝險"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "搜尋類型"
@@ -9047,6 +9199,10 @@ msgstr "Express + One-Click"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "GM 代幣代表單一 GMX 市場流動性池的份額。購買 GM 以提供流動性，並從該特定市場的槓桿交易、兌換和做市活動中賺取手續費。所有獎勵均自動複投。"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} 賣出成功，但跨鏈橋接至 Base 失敗。您的資
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "做多"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "使用 TP/SL 按鈕設定 TP/SL 訂單。"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "One-Click Trading 授權無效。這可能在切換鏈或更改支付代
 msgid "GLP to GM airdrop"
 msgstr "GLP 轉 GM 空投"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "賣出訂單已取消"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "入場價格"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -10887,6 +11052,7 @@ msgstr "多種資產類別"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "平倉"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -23,6 +23,8 @@ msgstr "滑点超限"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/trade/useVantageTrade.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -316,6 +318,8 @@ msgid "settings"
 msgstr "设置"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
 msgstr ""
 
@@ -505,6 +509,10 @@ msgstr "选择代币"
 msgid "Image generation failed. Refresh and try again."
 msgstr "图片生成失败。请刷新后重试。"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Positions"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
 msgstr "取消质押中..."
@@ -602,9 +610,17 @@ msgstr "由 GMX 社区开发的项目。<0/>与任何应用交互时请保持谨
 msgid "ADDRESS"
 msgstr "地址"
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Bid"
+msgstr ""
+
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
 msgstr "更多机会"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Avg Entry"
+msgstr ""
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -778,6 +794,10 @@ msgstr "未知错误"
 msgid "Market Swap"
 msgstr "市场交换"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Loading positions…"
+msgstr ""
+
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "查看详情"
@@ -925,6 +945,10 @@ msgstr "费用值在获得时计算。不包含激励。"
 msgid "TVL in vaults and pools"
 msgstr "金库和池中的 TVL"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Clear completed"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -961,6 +985,7 @@ msgstr "第1名"
 msgid "Caption"
 msgstr "说明文字"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
 msgstr ""
@@ -1206,6 +1231,7 @@ msgstr "执行时 {0} 将兑换为 {1}"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "未实现盈亏"
 
@@ -1432,6 +1458,8 @@ msgstr "概述"
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Collateral"
 msgstr "抵押品"
 
@@ -1600,6 +1628,10 @@ msgstr "显示更少"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 msgid "Vest"
 msgstr "归属"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Connect wallet to see positions"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1787,6 +1819,10 @@ msgstr "完成账户转账"
 #: src/pages/UiPage/UiPage.tsx
 msgid "Icons & images"
 msgstr "图标与图像"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Approved"
+msgstr ""
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2033,11 @@ msgstr ""
 #: src/domain/synthetics/claimHistory/claimPriceImpactRebate.ts
 msgid "Claiming price impact rebates..."
 msgstr "正在领取价格影响返还…"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/TradePage.tsx
+msgid "Close Position"
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2397,6 +2438,7 @@ msgstr "做多未平仓量储备因子"
 msgid "Layer 2"
 msgstr "Layer 2"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
@@ -2440,6 +2482,10 @@ msgstr "您有一笔 <0>待处理的转账</0> 至 {pendingReceiver}"
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "How can we address your concerns?"
 msgstr "我们如何解决您的顾虑？"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Closing Size"
+msgstr ""
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2571,6 +2617,10 @@ msgstr "未检测到符合条件的持仓"
 msgid "Help us improve GMX. For security, we won't contact you first. Send \"I have feedback\" to our official account:"
 msgstr "帮助我们改进 GMX。出于安全考虑，我们不会主动联系您。请向我们的官方帐号发送\"I have feedback\"："
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Slippage"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
 msgstr "现有仓位使用 {0} 抵押品。此订单不会影响该仓位。<0>切换至 {1} 抵押品</0>"
@@ -2632,6 +2682,8 @@ msgstr "在 {chainName} 上购买 GMX"
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Size"
 msgstr "规模"
 
@@ -3021,6 +3073,10 @@ msgstr "订单类型"
 msgid "Transaction submitted"
 msgstr ""
 
+#: src/pages/Trade/components/SpreadBadge.tsx
+msgid "Ask"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "抵押品价差"
@@ -3142,6 +3198,7 @@ msgid "Buy GMX from centralized services"
 msgstr "从中心化服务购买 GMX"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
 msgstr ""
 
@@ -3482,6 +3539,10 @@ msgstr "流动性不足。订单将在流动性可用时成交。"
 msgid "Your transfer is complete"
 msgstr "您的转账已完成"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Custom %"
+msgstr ""
+
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
 msgstr "和"
@@ -3712,6 +3773,7 @@ msgstr "Express Trading 不支持网络原生代币 {0}。请考虑使用 {1} �
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Trade"
 msgstr "交易"
 
@@ -3937,6 +3999,10 @@ msgstr "不支持自转账"
 msgid "Generating session..."
 msgstr "生成会话中..."
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Close request submitted — waiting for Keeper execution"
+msgstr ""
+
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "How do I get started on GMX?"
 msgstr "如何在 GMX 上入门？"
@@ -3986,6 +4052,8 @@ msgstr "虚拟市场 ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "杠杆"
 
@@ -4009,6 +4077,10 @@ msgstr "签署授权"
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "{daysConsidered}d earned fees"
 msgstr "{daysConsidered}天已赚取费用"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expires"
+msgstr ""
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4056,6 +4128,7 @@ msgstr "最多允许 5 个自动取消的 TP/SL 订单。超出的订单需手�
 #: src/components/TradeBox/tradeboxConstants.tsx
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 #: src/domain/synthetics/positions/utils.ts
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Market"
 msgstr "市场"
 
@@ -4083,6 +4156,7 @@ msgid "Smart wallets are not supported on Express Trading or One-Click Trading"
 msgstr "智能钱包不支持 Express Trading 或 One-Click Trading"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Executed"
 msgstr "已执行"
 
@@ -4115,6 +4189,10 @@ msgstr "可以随时解除质押吗？"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached"
 msgstr "已达到最大利润上限"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending Requests"
+msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4207,6 +4285,10 @@ msgstr "兑换已提交"
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum. Adjust the default in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Slippage differs from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "由于波动性导致的预期成交价格与实际成交价格之间的差异。如果滑点超过您设置的最大值，订单将不会执行。请在设置中调整默认值。<0/><1/>较低的值（例如低于 -{0}）可能导致在波动期间订单失败。<2/><3/>滑点与价格影响不同，价格影响基于未平仓量的不平衡。<4>了解更多</4>。"
 
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Expired"
+msgstr ""
+
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
 msgstr "在 {0} 池中存在现有仓位，但该池流动性不足以执行此订单"
@@ -4237,6 +4319,11 @@ msgstr "已清算"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Submitting…"
+msgstr ""
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4536,6 +4623,10 @@ msgstr "正在处理领取..."
 msgid "Failed to load order data:"
 msgstr "加载订单数据失败："
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Decrease request cancelled"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 msgid "Network"
 msgstr "网络"
@@ -4567,6 +4658,7 @@ msgstr "GM 池"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "PnL"
 msgstr "PnL"
 
@@ -5157,6 +5249,9 @@ msgstr "设置已更新"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Short"
 msgstr "做空"
 
@@ -5225,6 +5320,10 @@ msgstr "链接"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max lendable impact factor for withdrawals"
 msgstr "提取最大可借出影响因子"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+msgid "Reduce Position ({closePct}%)"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5511,6 +5610,10 @@ msgstr "{typeString} 做空止损市价单：当价格低于触发价格时{0}�
 msgid "Settings"
 msgstr "设置"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Increase request cancelled"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -5664,6 +5767,10 @@ msgstr "点击编辑图标以调整抵押品。"
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "Staked on Avalanche"
 msgstr "在 Avalanche 上质押"
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6259,6 +6366,7 @@ msgid "Steady returns without management"
 msgstr "无需管理的稳定回报"
 
 #: src/components/TradeBox/TradeBoxRows/SwapSpreadRow.tsx
+#: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Spread"
 msgstr "价差"
 
@@ -6602,6 +6710,10 @@ msgstr "去年"
 msgid "per"
 msgstr "每"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Position Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Reserve factor longs"
 msgstr "做多储备因子"
@@ -6766,6 +6878,7 @@ msgstr "选择要存入的资产"
 #: src/components/PositionList/PositionList.tsx
 #: src/components/PositionList/PositionList.tsx
 #: src/pages/Jobs/Jobs.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "No open positions"
 msgstr "无开放头寸"
 
@@ -6952,6 +7065,8 @@ msgid "Insufficient liquidity to swap collateral"
 msgstr "流动性不足以交换抵押品"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
 msgstr ""
 
@@ -6998,6 +7113,8 @@ msgstr "治理"
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "取消"
 
@@ -7742,6 +7859,10 @@ msgstr "提交"
 msgid "Claimed"
 msgstr "已领取"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Connect wallet to trade"
+msgstr ""
+
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
 msgstr "不到一分钟"
@@ -7888,6 +8009,10 @@ msgstr "通知"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "交易模式"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Back"
+msgstr ""
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8327,6 +8452,11 @@ msgstr "开仓费用"
 msgid "Edit referral code"
 msgstr "编辑推荐码"
 
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Acceptable Price"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
 msgstr "卖出请求已发送"
@@ -8379,6 +8509,7 @@ msgid "Increase size (TWAP)"
 msgstr "增加规模 (TWAP)"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Refresh"
 msgstr "刷新"
 
@@ -8408,6 +8539,11 @@ msgstr "领取 <0>{0}</0>"
 #: src/components/TradeBox/TradeBox.tsx
 msgid "Receive"
 msgstr "接收"
+
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Execution Fee"
+msgstr ""
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -8465,6 +8601,10 @@ msgstr "转移 {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Side"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
 msgstr "流动性做空"
@@ -8519,6 +8659,10 @@ msgstr "支撑资产构成"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Claimable rebates"
 msgstr "可领取返佣"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Slippage Tolerance"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -8991,6 +9135,14 @@ msgstr "交易历史记录"
 msgid "Exposure to backing tokens"
 msgstr "底层支撑代币的敞口"
 
+#: src/domain/vantage/trade/usePositionRouterTrade.ts
+msgid "Request submitted — waiting for Keeper execution"
+msgstr ""
+
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
+msgid "No pending requests"
+msgstr ""
+
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
 msgstr "搜索类型"
@@ -9047,6 +9199,10 @@ msgstr "快速 + 一键"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
 msgstr "GM 代币代表单个 GMX 市场流动性池中的份额。购买 GM 以提供流动性，并从该特定市场的杠杆交易、兑换和做市活动中赚取费用。所有奖励均自动复利。"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "Open Long / Short positions via PositionRouter."
+msgstr ""
 
 #: src/components/Earn/AdditionalOpportunities/useOpportunities.tsx
 msgid "Lend GLV or GM tokens, borrow against them, or use LP strategies to maximize yield"
@@ -9110,6 +9266,9 @@ msgstr "{gmOrGlvLabel} 已成功卖出，但跨链桥至 Base 失败。您的资
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
+#: src/pages/Trade/components/PositionListPanel.tsx
+#: src/pages/Trade/TradePage.tsx
 msgid "Long"
 msgstr "做多"
 
@@ -9623,6 +9782,7 @@ msgid "Use the TP/SL button to set TP/SL orders."
 msgstr "使用 TP/SL 按钮设置 TP/SL 订单。"
 
 #: src/components/TVChartContainer/TVChartContainer.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
 msgstr ""
 
@@ -10170,6 +10330,10 @@ msgstr "One-Click Trading 授权无效。切换链或更改支付代币时可能
 msgid "GLP to GM airdrop"
 msgstr "GLP 至 GM 空投"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Pending Orders"
+msgstr ""
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell order cancelled"
 msgstr "卖出订单已取消"
@@ -10366,6 +10530,7 @@ msgid "Entry price"
 msgstr "入场价格"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
+#: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -10887,6 +11052,7 @@ msgstr "多个资产类别"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
+#: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Close"
 msgstr "关闭"
 

--- a/src/pages/Trade/TradePage.tsx
+++ b/src/pages/Trade/TradePage.tsx
@@ -1,0 +1,172 @@
+/**
+ * TradePage.tsx
+ *
+ * Route: /trade
+ *
+ * Layout:
+ *   Left  — TradeBox (Long / Short tabs → OpenPositionPanel)
+ *            When a position is selected: ClosePositionPanel replaces the open form
+ *   Right — PositionListPanel + PendingRequestsPanel
+ */
+
+import { t } from "@lingui/macro";
+import { useState } from "react";
+
+import { useVantagePositions } from "domain/vantage/positions/useVantagePositions";
+import { usePositionRequests } from "domain/vantage/trade/usePositionRequests";
+import { usePositionRouterTrade } from "domain/vantage/trade/usePositionRouterTrade";
+import { useSpread } from "domain/vantage/trade/useSpread";
+import { useChainId } from "lib/chains";
+import useWallet from "lib/wallets/useWallet";
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
+
+import { ClosePositionPanel } from "./components/ClosePositionPanel";
+import { OpenPositionPanel } from "./components/OpenPositionPanel";
+import { PendingRequestsPanel } from "./components/PendingRequestsPanel";
+import { PositionListPanel } from "./components/PositionListPanel";
+
+// Default tokens for localhost
+const d = localhostDeployment.addresses as {
+  tokens?: { USDC?: string; ETH?: string; WETH?: string };
+};
+const USDC_ADDRESS = d.tokens?.USDC ?? "";
+const WETH_ADDRESS = d.tokens?.WETH ?? "";
+
+export default function TradePage() {
+  const { account } = useWallet();
+  const { chainId } = useChainId();
+
+  const [activeTab, setActiveTab] = useState<"long" | "short">("long");
+  const [selectedPositionKey, setSelectedPositionKey] = useState<string | null>(null);
+
+  const { positions, isLoading: positionsLoading, refetch } = useVantagePositions(account, chainId);
+  const trade = usePositionRouterTrade();
+  const requests = usePositionRequests();
+  const spread = useSpread(WETH_ADDRESS || undefined);
+
+  const selectedPosition = positions.find((p) => p.key === selectedPositionKey) ?? null;
+  const isLong = activeTab === "long";
+
+  function handleCancelRequest(requestKey: string, type: "increase" | "decrease") {
+    if (type === "increase") {
+      trade.cancelIncreasePosition(requestKey).then(() => requests.markCancelled(requestKey));
+    } else {
+      trade.cancelDecreasePosition(requestKey).then(() => requests.markCancelled(requestKey));
+    }
+  }
+
+  return (
+    <div className="default-container page-layout">
+      <div className="mx-auto mt-24 max-w-[1100px]">
+        {/* Header */}
+        <div className="mb-20">
+          <h1 className="text-h1">{t`Trade`}</h1>
+          <p className="text-body-medium mt-4 text-slate-400">{t`Open Long / Short positions via PositionRouter.`}</p>
+        </div>
+
+        <div className="flex gap-16 lg:items-start">
+          {/* ── Left: TradeBox ─────────────────────────────────────────────────── */}
+          <div className="w-full max-w-[360px] flex-shrink-0">
+            <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary">
+              {/* Tab header */}
+              {!selectedPosition && (
+                <div className="flex border-b border-stroke-primary">
+                  <button
+                    onClick={() => setActiveTab("long")}
+                    className={`flex-1 py-14 text-14 font-semibold transition-colors ${
+                      activeTab === "long"
+                        ? "border-b-2 border-green-400 text-green-400"
+                        : "text-slate-400 hover:text-white"
+                    }`}
+                  >
+                    {t`Long`}
+                  </button>
+                  <button
+                    onClick={() => setActiveTab("short")}
+                    className={`flex-1 py-14 text-14 font-semibold transition-colors ${
+                      activeTab === "short"
+                        ? "border-b-2 border-red-400 text-red-400"
+                        : "text-slate-400 hover:text-white"
+                    }`}
+                  >
+                    {t`Short`}
+                  </button>
+                </div>
+              )}
+
+              <div className="p-16">
+                {selectedPosition ? (
+                  <>
+                    <div className="mb-12 flex items-center gap-8">
+                      <button
+                        onClick={() => setSelectedPositionKey(null)}
+                        className="text-12 text-slate-400 hover:text-white"
+                      >
+                        ← {t`Back`}
+                      </button>
+                      <span className="text-14 font-semibold text-white">{t`Close Position`}</span>
+                    </div>
+                    <ClosePositionPanel
+                      position={selectedPosition}
+                      spread={spread}
+                      trade={trade}
+                      requests={requests}
+                      account={account ?? ""}
+                      onClose={() => {
+                        setSelectedPositionKey(null);
+                        setTimeout(refetch, 2000);
+                      }}
+                    />
+                  </>
+                ) : (
+                  <OpenPositionPanel
+                    isLong={isLong}
+                    indexToken={WETH_ADDRESS}
+                    collateralToken={USDC_ADDRESS}
+                    spread={spread}
+                    trade={trade}
+                    requests={requests}
+                    onSuccess={() => setTimeout(refetch, 2000)}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* ── Right: Positions + Pending ──────────────────────────────────────── */}
+          <div className="flex min-w-0 flex-1 flex-col gap-16">
+            {/* Open positions */}
+            <div>
+              <div className="mb-10 flex items-center justify-between">
+                <h2 className="text-14 font-semibold text-white">{t`Open Positions`}</h2>
+                <button onClick={refetch} className="hover:text-slate-300 text-12 text-slate-500">
+                  {t`Refresh`}
+                </button>
+              </div>
+              {!account ? (
+                <div className="rounded-4 border border-stroke-primary py-24 text-center text-13 text-slate-400">
+                  {t`Connect wallet to see positions`}
+                </div>
+              ) : (
+                <PositionListPanel
+                  positions={positions}
+                  isLoading={positionsLoading}
+                  selectedKey={selectedPositionKey}
+                  onSelect={(key) => {
+                    setSelectedPositionKey(key);
+                  }}
+                />
+              )}
+            </div>
+
+            {/* Pending requests */}
+            <div>
+              <h2 className="mb-10 text-14 font-semibold text-white">{t`Pending Orders`}</h2>
+              <PendingRequestsPanel requests={requests} onCancel={handleCancelRequest} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Trade/components/ClosePositionPanel.tsx
+++ b/src/pages/Trade/components/ClosePositionPanel.tsx
@@ -1,0 +1,184 @@
+/**
+ * ClosePositionPanel.tsx
+ *
+ * Form for partially or fully closing a selected open position.
+ * Submitted via PositionRouter.createDecreasePosition.
+ */
+
+import { t } from "@lingui/macro";
+import { formatEther } from "ethers";
+import { useState } from "react";
+
+import type { VantagePosition } from "domain/vantage/positions/types";
+import { formatVantageUsd } from "domain/vantage/positions/utils";
+import type { UsePositionRequestsResult } from "domain/vantage/trade/usePositionRequests";
+import type { PositionRouterTradeResult } from "domain/vantage/trade/usePositionRouterTrade";
+import { DEFAULT_SLIPPAGE_BPS } from "domain/vantage/trade/usePositionRouterTrade";
+import type { SpreadData } from "domain/vantage/trade/useSpread";
+import { calcAcceptablePrice } from "domain/vantage/trade/utils";
+
+import Button from "components/Button/Button";
+
+import { SpreadBadge } from "./SpreadBadge";
+
+type Props = {
+  position: VantagePosition;
+  spread: SpreadData;
+  trade: PositionRouterTradeResult;
+  requests: UsePositionRequestsResult;
+  account: string;
+  onClose?: () => void;
+};
+
+export function ClosePositionPanel({ position, spread, trade, requests, account, onClose }: Props) {
+  const [closePct, setClosePct] = useState(100); // percentage of position to close
+  const [slippageBps, setSlippageBps] = useState(DEFAULT_SLIPPAGE_BPS);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const sizeDelta = (position.size * BigInt(closePct)) / 100n;
+  const collateralDelta = (position.collateral * BigInt(closePct)) / 100n;
+  const markPrice = position.isLong ? spread.bidPrice : spread.askPrice;
+  const acceptablePrice = calcAcceptablePrice(markPrice, slippageBps, position.isLong, false);
+
+  async function handleClose() {
+    if (!account || sizeDelta === 0n) return;
+    setIsSubmitting(true);
+    try {
+      const now = Date.now();
+      const expiresAtMs = trade.maxTimeDelay > 0 ? now + trade.maxTimeDelay * 1000 : 0;
+
+      const requestKey = await trade.createDecreasePosition({
+        collateralToken: position.collateralToken,
+        indexToken: position.indexToken,
+        collateralDelta,
+        sizeDelta,
+        isLong: position.isLong,
+        receiver: account,
+        markPrice,
+        slippageBps,
+      });
+
+      if (requestKey) {
+        requests.addRequest({
+          requestKey,
+          type: "decrease",
+          createdAtMs: now,
+          expiresAtMs,
+          indexToken: position.indexToken,
+          isLong: position.isLong,
+          sizeDelta,
+        });
+        onClose?.();
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const feeEth = parseFloat(formatEther(trade.minExecutionFee)).toFixed(5);
+
+  return (
+    <div className="flex flex-col gap-12">
+      <SpreadBadge spread={spread} />
+
+      {/* Position summary */}
+      <div className="rounded-4 border border-stroke-primary bg-cold-blue-900 px-16 py-12 text-12">
+        <div className="mb-8 font-semibold text-white">{position.isLong ? t`Long` : t`Short`}</div>
+        <div className="flex justify-between text-slate-400">
+          <span>{t`Size`}</span>
+          <span className="text-white">{formatVantageUsd(position.size)}</span>
+        </div>
+        <div className="flex justify-between text-slate-400">
+          <span>{t`Collateral`}</span>
+          <span className="text-white">{formatVantageUsd(position.collateral)}</span>
+        </div>
+        <div className="flex justify-between text-slate-400">
+          <span>{t`Avg Entry`}</span>
+          <span className="text-white">${parseFloat(formatEther(position.averagePrice)).toFixed(4)}</span>
+        </div>
+        <div className="flex justify-between text-slate-400">
+          <span>{t`Unrealized PnL`}</span>
+          <span className={position.pendingPnl >= 0n ? "text-green-400" : "text-red-400"}>
+            {position.pendingPnl >= 0n ? "+" : ""}
+            {formatVantageUsd(position.pendingPnl < 0n ? -position.pendingPnl : position.pendingPnl)}
+          </span>
+        </div>
+      </div>
+
+      {/* Close % slider */}
+      <div>
+        <div className="mb-6 flex items-center justify-between text-12">
+          <span className="text-slate-400">{t`Close`}</span>
+          <span className="font-semibold text-white">{closePct}%</span>
+        </div>
+        <input
+          type="range"
+          min={1}
+          max={100}
+          step={1}
+          value={closePct}
+          onChange={(e) => setClosePct(Number(e.target.value))}
+          className="w-full accent-blue-500"
+        />
+        <div className="mt-2 flex justify-between text-11 text-slate-500">
+          {[25, 50, 75, 100].map((p) => (
+            <button
+              key={p}
+              onClick={() => setClosePct(p)}
+              className={`px-6 py-2 text-11 transition-colors ${
+                closePct === p ? "text-blue-400" : "hover:text-slate-300 text-slate-500"
+              }`}
+            >
+              {p}%
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Size to close */}
+      <div className="flex items-center justify-between text-12">
+        <span className="text-slate-400">{t`Closing Size`}</span>
+        <span className="text-white">{formatVantageUsd(sizeDelta)}</span>
+      </div>
+
+      {/* Slippage */}
+      <div className="flex items-center gap-8 text-12">
+        <span className="text-slate-400">{t`Slippage`}</span>
+        {[10, 30, 50].map((bps) => (
+          <button
+            key={bps}
+            onClick={() => setSlippageBps(bps)}
+            className={`rounded-4 px-10 py-4 transition-colors ${
+              slippageBps === bps ? "bg-blue-600 text-white" : "bg-cold-blue-900 text-slate-400 hover:text-white"
+            }`}
+          >
+            {bps / 100}%
+          </button>
+        ))}
+      </div>
+
+      {/* Accept price */}
+      {acceptablePrice > 0n && (
+        <div className="flex items-center justify-between text-12">
+          <span className="text-slate-400">{t`Acceptable Price`}</span>
+          <span className="text-slate-300">${parseFloat(formatEther(acceptablePrice)).toFixed(4)}</span>
+        </div>
+      )}
+
+      {/* Execution fee */}
+      <div className="flex items-center justify-between text-12">
+        <span className="text-slate-400">{t`Execution Fee`}</span>
+        <span className="text-slate-300">{feeEth} ETH</span>
+      </div>
+
+      {/* Submit */}
+      <Button variant="primary" className="w-full" onClick={handleClose} disabled={isSubmitting || sizeDelta === 0n}>
+        {isSubmitting ? t`Submitting…` : closePct === 100 ? t`Close Position` : t`Reduce Position (${closePct}%)`}
+      </Button>
+
+      <Button variant="secondary" className="w-full" onClick={onClose}>
+        {t`Cancel`}
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/Trade/components/OpenPositionPanel.tsx
+++ b/src/pages/Trade/components/OpenPositionPanel.tsx
@@ -1,0 +1,315 @@
+/**
+ * OpenPositionPanel.tsx
+ *
+ * Form for opening a new Long / Short position via PositionRouter.
+ *
+ * Features:
+ *   - Collateral token selection: USDC (ERC-20) or native ETH
+ *   - Size input (USD) + Leverage slider (1×–50×)
+ *   - Slippage selector (0.1% / 0.3% / 0.5% / custom)
+ *   - Bid/Ask spread display
+ *   - Approve + Submit buttons with correct state management
+ */
+
+import { t } from "@lingui/macro";
+import { Contract, MaxUint256, formatEther, parseUnits } from "ethers";
+import { useMemo, useState } from "react";
+
+import type { UsePositionRequestsResult } from "domain/vantage/trade/usePositionRequests";
+import type { PositionRouterTradeResult } from "domain/vantage/trade/usePositionRouterTrade";
+import { DEFAULT_SLIPPAGE_BPS } from "domain/vantage/trade/usePositionRouterTrade";
+import type { SpreadData } from "domain/vantage/trade/useSpread";
+import { useChainId } from "lib/chains";
+import { helperToast } from "lib/helperToast";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+import TokenAbi from "sdk/abis/Token";
+import { getVantageContractAddress } from "vantage/contracts";
+
+import Button from "components/Button/Button";
+
+import { SpreadBadge } from "./SpreadBadge";
+
+// Tokens available for trade on localhost
+const COLLATERAL_OPTIONS = [
+  { label: "USDC", decimals: 6, isNative: false },
+  { label: "ETH", decimals: 18, isNative: true },
+] as const;
+
+const SLIPPAGE_PRESETS = [10, 30, 50] as const; // bps
+
+type Props = {
+  isLong: boolean;
+  indexToken: string;
+  collateralToken: string;
+  spread: SpreadData;
+  trade: PositionRouterTradeResult;
+  requests: UsePositionRequestsResult;
+  onSuccess?: () => void;
+};
+
+export function OpenPositionPanel({ isLong, indexToken, collateralToken, spread, trade, requests, onSuccess }: Props) {
+  const { account, signer } = useWallet();
+  const { chainId } = useChainId();
+  const provider = useMemo(() => getProvider(undefined, chainId), [chainId]);
+
+  const [collateralInput, setCollateralInput] = useState("");
+  const [leverage, setLeverage] = useState(2); // ×
+  const [slippageBps, setSlippageBps] = useState<number>(DEFAULT_SLIPPAGE_BPS);
+  const [customSlippage, setCustomSlippage] = useState("");
+  const [useNativeEth, setUseNativeEth] = useState(false);
+  const [allowance, setAllowance] = useState<bigint>(0n);
+  const [allowanceLoaded, setAllowanceLoaded] = useState(false);
+  const [isApproving, setIsApproving] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const collateralDecimals = useNativeEth ? 18 : 6;
+
+  // Parse collateral amount
+  const amountIn = useMemo(() => {
+    try {
+      if (!collateralInput || parseFloat(collateralInput) <= 0) return 0n;
+      return parseUnits(collateralInput, collateralDecimals);
+    } catch {
+      return 0n;
+    }
+  }, [collateralInput, collateralDecimals]);
+
+  // USD value of collateral (using ask price for long, bid for short)
+  const collateralUsd = useMemo(() => {
+    const price = isLong ? spread.askPrice : spread.bidPrice;
+    if (useNativeEth) {
+      return (amountIn * price) / 10n ** 18n;
+    }
+    // USDC: 1 USDC = $1 (6 decimals → WAD)
+    return amountIn * 10n ** 12n; // 6 dec → 18 dec
+  }, [amountIn, useNativeEth, spread, isLong]);
+
+  const sizeDelta = collateralUsd * BigInt(leverage);
+
+  // Mark price for acceptablePrice calculation
+  const markPrice = isLong ? spread.askPrice : spread.bidPrice;
+
+  // Allowance check (ERC-20 only)
+  useMemo(() => {
+    if (useNativeEth || !account) {
+      setAllowanceLoaded(true);
+      return;
+    }
+    setAllowanceLoaded(false);
+    const positionRouterAddr = getVantageContractAddress(chainId, "PositionRouter");
+    const token = new Contract(collateralToken, TokenAbi, provider);
+    token
+      .allowance(account, positionRouterAddr)
+      .then((v: bigint) => {
+        setAllowance(v);
+        setAllowanceLoaded(true);
+      })
+      .catch(() => setAllowanceLoaded(true));
+  }, [account, collateralToken, chainId, provider, useNativeEth]);
+
+  const needsApproval = !useNativeEth && allowanceLoaded && amountIn > 0n && allowance < amountIn;
+
+  async function handleApprove() {
+    if (!signer || !account) return;
+    setIsApproving(true);
+    try {
+      const positionRouterAddr = getVantageContractAddress(chainId, "PositionRouter");
+      const token = new Contract(collateralToken, TokenAbi, signer);
+      const tx = await token.approve(positionRouterAddr, MaxUint256);
+      await tx.wait();
+      setAllowance(MaxUint256);
+      helperToast.success(t`Approved`);
+    } catch (err: unknown) {
+      helperToast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsApproving(false);
+    }
+  }
+
+  async function handleSubmit() {
+    if (!account || sizeDelta === 0n) return;
+    setIsSubmitting(true);
+    try {
+      const now = Date.now();
+      const expiresAtMs = trade.maxTimeDelay > 0 ? now + trade.maxTimeDelay * 1000 : 0;
+
+      const requestKey = await trade.createIncreasePosition({
+        collateralToken,
+        indexToken,
+        amountIn,
+        sizeDelta,
+        isLong,
+        markPrice,
+        slippageBps,
+        useNativeEth,
+      });
+
+      if (requestKey) {
+        requests.addRequest({
+          requestKey,
+          type: "increase",
+          createdAtMs: now,
+          expiresAtMs,
+          indexToken,
+          isLong,
+          sizeDelta,
+        });
+        setCollateralInput("");
+        onSuccess?.();
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const activeSlippage = customSlippage ? Math.round(parseFloat(customSlippage) * 100) : slippageBps;
+
+  const feeEth = parseFloat(formatEther(trade.minExecutionFee)).toFixed(5);
+
+  return (
+    <div className="flex flex-col gap-12">
+      {/* Spread display */}
+      <SpreadBadge spread={spread} />
+
+      {/* Collateral type toggle */}
+      <div className="flex gap-8">
+        {COLLATERAL_OPTIONS.map((opt) => (
+          <button
+            key={opt.label}
+            onClick={() => setUseNativeEth(opt.isNative)}
+            className={`rounded-4 px-12 py-6 text-12 font-medium transition-colors ${
+              useNativeEth === opt.isNative
+                ? "bg-blue-600 text-white"
+                : "bg-cold-blue-900 text-slate-400 hover:text-white"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Collateral input */}
+      <div className="rounded-4 border border-stroke-primary bg-cold-blue-900 px-16 py-12">
+        <div className="mb-4 flex items-center justify-between text-12 text-slate-400">
+          <span>{t`Collateral`}</span>
+          <span>{useNativeEth ? "ETH" : "USDC"}</span>
+        </div>
+        <input
+          type="number"
+          min="0"
+          placeholder="0.00"
+          value={collateralInput}
+          onChange={(e) => setCollateralInput(e.target.value)}
+          className="bg-transparent w-full text-20 font-semibold text-white outline-none placeholder:text-slate-600"
+        />
+        {collateralUsd > 0n && (
+          <div className="mt-4 text-12 text-slate-400">≈ ${parseFloat(formatEther(collateralUsd)).toFixed(2)} USD</div>
+        )}
+      </div>
+
+      {/* Leverage slider */}
+      <div>
+        <div className="mb-6 flex items-center justify-between text-12">
+          <span className="text-slate-400">{t`Leverage`}</span>
+          <span className="font-semibold text-white">{leverage}×</span>
+        </div>
+        <input
+          type="range"
+          min={1}
+          max={50}
+          step={1}
+          value={leverage}
+          onChange={(e) => setLeverage(Number(e.target.value))}
+          className="w-full accent-blue-500"
+        />
+        <div className="mt-2 flex justify-between text-11 text-slate-500">
+          <span>1×</span>
+          <span>10×</span>
+          <span>25×</span>
+          <span>50×</span>
+        </div>
+      </div>
+
+      {/* Size preview */}
+      {sizeDelta > 0n && (
+        <div className="flex items-center justify-between rounded-4 bg-cold-blue-900 px-12 py-8 text-12">
+          <span className="text-slate-400">{t`Position Size`}</span>
+          <span className="font-medium text-white">${parseFloat(formatEther(sizeDelta)).toFixed(2)}</span>
+        </div>
+      )}
+
+      {/* Slippage */}
+      <div>
+        <div className="mb-6 text-12 text-slate-400">{t`Slippage Tolerance`}</div>
+        <div className="flex items-center gap-6">
+          {SLIPPAGE_PRESETS.map((bps) => (
+            <button
+              key={bps}
+              onClick={() => {
+                setSlippageBps(bps);
+                setCustomSlippage("");
+              }}
+              className={`rounded-4 px-10 py-5 text-12 transition-colors ${
+                !customSlippage && slippageBps === bps
+                  ? "bg-blue-600 text-white"
+                  : "bg-cold-blue-900 text-slate-400 hover:text-white"
+              }`}
+            >
+              {bps / 100}%
+            </button>
+          ))}
+          <input
+            type="number"
+            min="0"
+            placeholder={t`Custom %`}
+            value={customSlippage}
+            onChange={(e) => setCustomSlippage(e.target.value)}
+            className="w-20 rounded-4 border border-stroke-primary bg-cold-blue-900 px-8 py-5 text-12 text-white outline-none placeholder:text-slate-600"
+          />
+        </div>
+      </div>
+
+      {/* Execution fee */}
+      <div className="flex items-center justify-between text-12">
+        <span className="text-slate-400">{t`Execution Fee`}</span>
+        <span className="text-slate-300">{feeEth} ETH</span>
+      </div>
+
+      {/* Accept price */}
+      {markPrice > 0n && (
+        <div className="flex items-center justify-between text-12">
+          <span className="text-slate-400">{t`Acceptable Price`}</span>
+          <span className="text-slate-300">
+            $
+            {parseFloat(
+              formatEther(
+                isLong
+                  ? (markPrice * (10_000n + BigInt(activeSlippage))) / 10_000n
+                  : (markPrice * (10_000n - BigInt(activeSlippage))) / 10_000n
+              )
+            ).toFixed(4)}
+          </span>
+        </div>
+      )}
+
+      {/* CTA buttons */}
+      {!account ? (
+        <div className="py-8 text-center text-13 text-slate-400">{t`Connect wallet to trade`}</div>
+      ) : needsApproval ? (
+        <Button variant="primary" className="w-full" onClick={handleApprove} disabled={isApproving}>
+          {isApproving ? t`Approving…` : t`Approve USDC`}
+        </Button>
+      ) : (
+        <Button
+          variant="primary"
+          className="w-full"
+          onClick={handleSubmit}
+          disabled={isSubmitting || sizeDelta === 0n || !trade.isReady}
+        >
+          {isSubmitting ? t`Submitting…` : isLong ? t`Open Long` : t`Open Short`}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Trade/components/PendingRequestsPanel.tsx
+++ b/src/pages/Trade/components/PendingRequestsPanel.tsx
@@ -1,0 +1,93 @@
+/**
+ * PendingRequestsPanel.tsx
+ *
+ * Shows pending PositionRouter requests and their execution status.
+ */
+
+import { t } from "@lingui/macro";
+
+import { formatVantageUsd } from "domain/vantage/positions/utils";
+import type { PositionRequest, UsePositionRequestsResult } from "domain/vantage/trade/usePositionRequests";
+
+function shortenKey(key: string) {
+  return `${key.slice(0, 8)}…${key.slice(-6)}`;
+}
+
+function StatusBadge({ status }: { status: PositionRequest["status"] }) {
+  const map: Record<PositionRequest["status"], { label: string; cls: string }> = {
+    pending: { label: t`Pending`, cls: "bg-yellow-900/40 text-yellow-300" },
+    executed: { label: t`Executed`, cls: "bg-green-900/40 text-green-300" },
+    cancelled: { label: t`Cancelled`, cls: "bg-slate-700 text-slate-400" },
+    expired: { label: t`Expired`, cls: "bg-red-900/40 text-red-300" },
+  };
+  const { label, cls } = map[status];
+  return <span className={`rounded-full px-8 py-2 text-11 font-medium ${cls}`}>{label}</span>;
+}
+
+type Props = {
+  requests: UsePositionRequestsResult;
+  onCancel: (requestKey: string, type: "increase" | "decrease") => void;
+};
+
+export function PendingRequestsPanel({ requests, onCancel }: Props) {
+  const { requests: list, clearCompleted } = requests;
+
+  if (list.length === 0) {
+    return <div className="py-20 text-center text-13 text-slate-400">{t`No pending requests`}</div>;
+  }
+
+  const hasCompleted = list.some((r) => r.status !== "pending");
+
+  return (
+    <div className="flex flex-col gap-0 overflow-hidden rounded-4 border border-stroke-primary">
+      {/* Header */}
+      <div className="bg-cold-blue-950 flex items-center justify-between border-b border-stroke-primary px-16 py-10">
+        <span className="text-slate-300 text-12 font-semibold">{t`Pending Requests`}</span>
+        {hasCompleted && (
+          <button onClick={clearCompleted} className="hover:text-slate-300 text-11 text-slate-500">
+            {t`Clear completed`}
+          </button>
+        )}
+      </div>
+
+      {list.map((req) => (
+        <div
+          key={req.requestKey}
+          className="flex items-center justify-between border-b border-stroke-primary px-16 py-12 last:border-0"
+        >
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-8">
+              <span className={`text-12 font-medium ${req.isLong ? "text-green-400" : "text-red-400"}`}>
+                {req.type === "increase"
+                  ? req.isLong
+                    ? t`Open Long`
+                    : t`Open Short`
+                  : req.isLong
+                    ? t`Close Long`
+                    : t`Close Short`}
+              </span>
+              <StatusBadge status={req.status} />
+            </div>
+            <div className="text-11 text-slate-500">
+              {formatVantageUsd(req.sizeDelta)} · {shortenKey(req.requestKey)}
+            </div>
+            {req.status === "pending" && req.expiresAtMs > 0 && (
+              <div className="text-11 text-slate-600">
+                {t`Expires`} {new Date(req.expiresAtMs).toLocaleTimeString()}
+              </div>
+            )}
+          </div>
+
+          {(req.status === "pending" || req.status === "expired") && (
+            <button
+              onClick={() => onCancel(req.requestKey, req.type)}
+              className="rounded-4 px-10 py-5 text-12 text-slate-400 transition-colors hover:bg-slate-700 hover:text-white"
+            >
+              {t`Cancel`}
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Trade/components/PositionListPanel.tsx
+++ b/src/pages/Trade/components/PositionListPanel.tsx
@@ -1,0 +1,75 @@
+/**
+ * PositionListPanel.tsx
+ *
+ * Shows all open positions for the connected wallet.
+ * Clicking a row selects it for the ClosePositionPanel.
+ */
+
+import { t } from "@lingui/macro";
+
+import type { VantagePosition } from "domain/vantage/positions/types";
+import { formatVantageUsd } from "domain/vantage/positions/utils";
+
+function shortenAddr(addr: string) {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function leverageLabel(size: bigint, collateral: bigint): string {
+  if (collateral === 0n) return "—";
+  return `${(Number(size) / Number(collateral)).toFixed(1)}×`;
+}
+
+type Props = {
+  positions: VantagePosition[];
+  isLoading: boolean;
+  selectedKey: string | null;
+  onSelect: (key: string | null) => void;
+};
+
+export function PositionListPanel({ positions, isLoading, selectedKey, onSelect }: Props) {
+  return (
+    <div className="overflow-hidden rounded-4 border border-stroke-primary">
+      {/* Header */}
+      <div className="bg-cold-blue-950 grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr] border-b border-stroke-primary px-16 py-10 text-11 text-slate-400">
+        <div>{t`Market`}</div>
+        <div className="text-right">{t`Side`}</div>
+        <div className="text-right">{t`Size`}</div>
+        <div className="text-right">{t`Leverage`}</div>
+        <div className="text-right">{t`PnL`}</div>
+      </div>
+
+      {isLoading && <div className="py-24 text-center text-13 text-slate-400">{t`Loading positions…`}</div>}
+
+      {!isLoading && positions.length === 0 && (
+        <div className="py-24 text-center text-13 text-slate-400">{t`No open positions`}</div>
+      )}
+
+      {positions.map((pos) => {
+        const isSelected = pos.key === selectedKey;
+        const pnlColor = pos.pendingPnl >= 0n ? "text-green-400" : "text-red-400";
+        const pnlSign = pos.pendingPnl >= 0n ? "+" : "";
+
+        return (
+          <div
+            key={pos.key}
+            onClick={() => onSelect(isSelected ? null : pos.key)}
+            className={`grid cursor-pointer grid-cols-[1.5fr_1fr_1fr_1fr_1fr] items-center border-b border-stroke-primary px-16 py-12 text-13 transition-colors last:border-0 hover:bg-slate-800/40 ${
+              isSelected ? "bg-blue-900/20 ring-1 ring-inset ring-blue-600" : ""
+            }`}
+          >
+            <div className="font-medium text-white">{shortenAddr(pos.indexToken)}</div>
+            <div className={`text-right font-medium ${pos.isLong ? "text-green-400" : "text-red-400"}`}>
+              {pos.isLong ? t`Long` : t`Short`}
+            </div>
+            <div className="text-right text-white">{formatVantageUsd(pos.size)}</div>
+            <div className="text-slate-300 text-right">{leverageLabel(pos.size, pos.collateral)}</div>
+            <div className={`text-right font-medium ${pnlColor}`}>
+              {pnlSign}
+              {formatVantageUsd(pos.pendingPnl < 0n ? -pos.pendingPnl : pos.pendingPnl)}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/Trade/components/SpreadBadge.tsx
+++ b/src/pages/Trade/components/SpreadBadge.tsx
@@ -1,0 +1,42 @@
+/**
+ * SpreadBadge.tsx
+ *
+ * Displays Bid / Ask prices and the spread in basis points.
+ */
+
+import { t } from "@lingui/macro";
+import { formatEther } from "ethers";
+
+import type { SpreadData } from "domain/vantage/trade/useSpread";
+
+function fmtPrice(wad: bigint): string {
+  return `$${parseFloat(formatEther(wad)).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}`;
+}
+
+export function SpreadBadge({ spread }: { spread: SpreadData }) {
+  if (spread.isLoading || spread.askPrice === 0n) return null;
+
+  const spreadColor =
+    spread.spreadBps < 10 ? "text-green-400" : spread.spreadBps < 50 ? "text-yellow-400" : "text-red-400";
+
+  return (
+    <div className="flex items-center justify-between rounded-4 border border-stroke-primary bg-cold-blue-900 px-12 py-8 text-12">
+      <div className="flex gap-16">
+        <span>
+          <span className="text-slate-400">{t`Bid`} </span>
+          <span className="font-medium text-white">{fmtPrice(spread.bidPrice)}</span>
+        </span>
+        <span>
+          <span className="text-slate-400">{t`Ask`} </span>
+          <span className="font-medium text-white">{fmtPrice(spread.askPrice)}</span>
+        </span>
+      </div>
+      <span className={`font-medium ${spreadColor}`}>
+        {t`Spread`} {spread.spreadBps} bps
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #151 Phase 2b — PositionRouter を使ったポジションオープン・クローズ UI の実装。

- **usePositionRouterTrade**: 2-step 非同期フロー（createIncrease/Decrease, cancel, minExecutionFee 取得）
- **usePositionRequests**: localStorage 永続化・イベントポーリング（8s）・expiry タイマーによるリクエスト追跡
- **useSpread**: `Vault.getMaxPrice / getMinPrice` から Bid/Ask スプレッドを取得（10s ポーリング）
- **TradePage** (`/trade`): Long/Short タブ、ポジション一覧からのクローズ選択、ペンディングオーダーパネル
- **OpenPositionPanel**: USDC / ETH コラテラル切替、レバレッジスライダー（1×–50×）、スリッページプリセット、ERC-20 承認フロー
- **ClosePositionPanel**: クローズ比率スライダー（1–100%）、スリッページ選択、 acceptablePrice プレビュー
- **PositionListPanel**: Market / Side / Size / Leverage / PnL グリッド、行クリックでクローズ選択
- **PendingRequestsPanel**: ステータスバッジ（Pending / Executed / Cancelled / Expired）、キャンセルボタン
- **SpreadBadge**: Bid/Ask 価格 + カラーコード付きスプレッド bps 表示
- **MainRoutes**: `/trade` ルート追加

## テスト計画

- [ ] ウォレット接続後、`/trade` でページが表示されること
- [ ] Long / Short タブ切替が機能すること
- [ ] USDC コラテラルで `createIncreasePosition` が送信され、requestKey が追跡されること
- [ ] ETH コラテラル（`useNativeEth=true`）で `increasePositionETH` が呼ばれること
- [ ] ポジション一覧の行クリックで ClosePositionPanel に切り替わること
- [ ] クローズ比率スライダーが `sizeDelta` / `collateralDelta` に正しく反映されること
- [ ] Keeper 実行後にリクエストステータスが `executed` に更新されること
- [ ] キャンセルボタンで `cancelIncreasePosition` / `cancelDecreasePosition` が呼ばれること
- [ ] SpreadBadge が Bid/Ask/Spread を正しく表示すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)