### PR TITLE
feat(trade): ポジション一覧にリアルタイム PnL・清算価格・ADL リスク表示を追加 (#152)

### DIFF
--- a/src/domain/vantage/positions/types.ts
+++ b/src/domain/vantage/positions/types.ts
@@ -24,6 +24,10 @@ export type VantagePosition = {
   lastUpdatedAt: bigint;
   /** Unrealized PnL in USD, 1e18 precision (from VaultReader.getPendingPnL) */
   pendingPnl: bigint;
+  /** Current oracle price of the index token, 1e18 precision (from Vault.getMinPrice) */
+  currentPrice: bigint;
+  /** Maintenance margin in basis points from AssetRegistry (e.g. 100 = 1%). 0 if registry unavailable. */
+  maintenanceMarginBps: bigint;
 };
 
 export type VantageAccountSummary = {

--- a/src/domain/vantage/positions/useVantagePositions.ts
+++ b/src/domain/vantage/positions/useVantagePositions.ts
@@ -11,6 +11,8 @@
  *   3. Filter out positions with size === 0 (closed / never opened)
  *   4. For each open position:
  *        vaultReader.getPendingPnL(...) → unrealized PnL
+ *        vault.getMinPrice(indexToken)  → currentPrice
+ *        assetRegistry.getAssetRiskInfo(indexToken) → maintenanceMarginBps (cached per token)
  *
  * NOTE: Individual RPC calls are used here (no Multicall yet).
  *       Future optimisation: inject a Multicall provider via the runnerOverride
@@ -19,14 +21,17 @@
  * NOTE: All USD values are in PRICE_PRECISION = 1e18 (WAD), not GMX's 1e30.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useVault } from "hooks/useVantageContracts";
 import { getProvider } from "lib/rpc";
 import { getVantageContractAddress } from "vantage/contracts";
-import { VaultReader__factory } from "vantage/types";
+import { AssetRegistry__factory, VaultReader__factory } from "vantage/types";
 
 import type { VantagePosition } from "./types";
+
+const POLL_INTERVAL_MS = 30_000;
+const ZERO = "0x0000000000000000000000000000000000000000";
 
 type UseVantagePositionsResult = {
   positions: VantagePosition[];
@@ -48,6 +53,9 @@ export function useVantagePositions(
 
   const vault = useVault(undefined, chainId);
 
+  // Cache maintenanceMarginBps per indexToken to avoid repeated RPC calls
+  const riskInfoCache = useRef<Map<string, bigint>>(new Map());
+
   const refetch = useCallback(() => setTick((t) => t + 1), []);
 
   useEffect(() => {
@@ -56,14 +64,19 @@ export function useVantagePositions(
       return;
     }
 
+    const provider = getProvider(undefined, chainId);
+
     // VaultReader may not be deployed on all networks (e.g. localhost).
-    // Create it lazily inside the effect so missing address doesn't throw.
-    const ZERO = "0x0000000000000000000000000000000000000000";
     const vaultReaderAddress = getVantageContractAddress(chainId, "VaultReader");
     const vaultReader =
       vaultReaderAddress && vaultReaderAddress !== ZERO
-        ? VaultReader__factory.connect(vaultReaderAddress, getProvider(undefined, chainId))
+        ? VaultReader__factory.connect(vaultReaderAddress, provider)
         : null;
+
+    // AssetRegistry may not be deployed on all networks (e.g. localhost).
+    const registryAddr = getVantageContractAddress(chainId, "AssetRegistry");
+    const assetRegistry =
+      registryAddr && registryAddr !== ZERO ? AssetRegistry__factory.connect(registryAddr, provider) : null;
 
     let cancelled = false;
 
@@ -79,8 +92,27 @@ export function useVantagePositions(
 
         for (const indexToken of assets) {
           // Candidate collateral tokens: caller-supplied list + the index token itself
-          // (GMX-style longs use collateral == index; our UI uses USDC for all positions).
           const collaterals = collateralTokens ? [...new Set([...collateralTokens, indexToken])] : [indexToken];
+
+          // Fetch current oracle price for this index token
+          let currentPrice = 0n;
+          try {
+            currentPrice = await vault.getMinPrice(indexToken);
+          } catch {
+            // price unavailable — skip health calculations for this token
+          }
+
+          // Fetch maintenanceMarginBps from AssetRegistry (with per-token cache)
+          let maintenanceMarginBps = riskInfoCache.current.get(indexToken) ?? 0n;
+          if (maintenanceMarginBps === 0n && assetRegistry) {
+            try {
+              const riskInfo = await assetRegistry.getAssetRiskInfo(indexToken);
+              maintenanceMarginBps = riskInfo.maintenanceMarginBps;
+              riskInfoCache.current.set(indexToken, maintenanceMarginBps);
+            } catch {
+              // AssetRegistry not configured for this token — leave as 0
+            }
+          }
 
           for (const collateralToken of collaterals) {
             for (const isLong of [true, false]) {
@@ -89,7 +121,6 @@ export function useVantagePositions(
               const key = await vault.getPositionKey(account!, collateralToken, indexToken, isLong);
               const raw = await vault.positions(key);
 
-              // Skip closed or never-opened positions
               if (raw.size === 0n) continue;
 
               // Fetch unrealized PnL (skipped when VaultReader is not deployed)
@@ -123,6 +154,8 @@ export function useVantagePositions(
                 entryFundingRate: raw.entryFundingRate,
                 lastUpdatedAt: raw.lastUpdatedAt,
                 pendingPnl,
+                currentPrice,
+                maintenanceMarginBps,
               });
             }
           }
@@ -143,8 +176,15 @@ export function useVantagePositions(
     }
 
     fetch();
+
+    // Poll every 30 seconds for real-time PnL and price updates
+    const intervalId = setInterval(() => {
+      if (!cancelled) fetch();
+    }, POLL_INTERVAL_MS);
+
     return () => {
       cancelled = true;
+      clearInterval(intervalId);
     };
   }, [account, chainId, vault, tick]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/domain/vantage/positions/utils.ts
+++ b/src/domain/vantage/positions/utils.ts
@@ -60,3 +60,47 @@ export function isDataStale(lastUpdatedAt: bigint, maxAgeSeconds = 300): boolean
   const nowSec = BigInt(Math.floor(Date.now() / 1000));
   return nowSec - lastUpdatedAt > BigInt(maxAgeSeconds);
 }
+
+/**
+ * Calculate the oracle price at which a position becomes liquidatable.
+ * All values in WAD (1e18) precision.
+ *
+ * Long:  liqPrice = averagePrice - (availableCollateral * averagePrice) / size
+ * Short: liqPrice = averagePrice + (availableCollateral * averagePrice) / size
+ *
+ * @param maintenanceMarginBps  from AssetRegistry.getAssetRiskInfo (e.g. 100 = 1%)
+ */
+export function calcLiquidationPrice(
+  size: bigint,
+  collateral: bigint,
+  averagePrice: bigint,
+  isLong: boolean,
+  maintenanceMarginBps: bigint
+): bigint {
+  if (size === 0n || averagePrice === 0n) return 0n;
+  const maintenanceMargin = (size * maintenanceMarginBps) / 10_000n;
+  const availableCollateral = collateral > maintenanceMargin ? collateral - maintenanceMargin : 0n;
+
+  if (isLong) {
+    const loss = (availableCollateral * averagePrice) / size;
+    return averagePrice > loss ? averagePrice - loss : 0n;
+  } else {
+    return averagePrice + (availableCollateral * averagePrice) / size;
+  }
+}
+
+/**
+ * Calculate how far (in bps) the current price is from the liquidation price.
+ * 10000 = fully safe (infinite distance), 0 = at liquidation price.
+ * Returns 0 when already liquidatable.
+ */
+export function calcHealthBps(currentPrice: bigint, liqPrice: bigint, isLong: boolean): number {
+  if (liqPrice === 0n || currentPrice === 0n) return 10_000;
+  if (isLong) {
+    if (currentPrice <= liqPrice) return 0;
+    return Number(((currentPrice - liqPrice) * 10_000n) / currentPrice);
+  } else {
+    if (currentPrice >= liqPrice) return 0;
+    return Number(((liqPrice - currentPrice) * 10_000n) / currentPrice);
+  }
+}

--- a/src/domain/vantage/useHubHealth.ts
+++ b/src/domain/vantage/useHubHealth.ts
@@ -1,0 +1,79 @@
+/**
+ * useHubHealth.ts
+ *
+ * Polls SharedPayoutHub.getHubHealth() to derive the Hub cover ratio.
+ * Used to display ADL risk warnings in the trade UI.
+ *
+ * Cover ratio thresholds:
+ *   ≥ 130% (13000 bps) → healthy (no warning)
+ *   110–130% (11000–13000 bps) → warning (ADL may trigger)
+ *   < 110% (11000 bps) → danger (ADL actively running)
+ */
+
+import { useEffect, useState } from "react";
+
+import { getProvider } from "lib/rpc";
+import { getVantageContractAddress } from "vantage/contracts";
+import { SharedPayoutHub__factory } from "vantage/types";
+
+const POLL_INTERVAL_MS = 30_000;
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+export type HubHealthStatus = "healthy" | "warning" | "danger";
+
+export type HubHealth = {
+  usdcBalance: bigint;
+  totalDebt: bigint;
+  /** Cover ratio in bps: e.g. 11000 = 110%. 99999 when totalDebt = 0. */
+  coverRatioBps: number;
+  status: HubHealthStatus;
+};
+
+function deriveStatus(coverRatioBps: number): HubHealthStatus {
+  if (coverRatioBps >= 13_000) return "healthy";
+  if (coverRatioBps >= 11_000) return "warning";
+  return "danger";
+}
+
+/**
+ * Polls SharedPayoutHub health for the given vault address.
+ * Returns null when the Hub contract is not configured (zero address).
+ */
+export function useHubHealth(chainId: number, vaultAddress: string): HubHealth | null {
+  const [health, setHealth] = useState<HubHealth | null>(null);
+
+  useEffect(() => {
+    const hubAddr = getVantageContractAddress(chainId, "SharedPayoutHub");
+    if (!hubAddr || hubAddr === ZERO || !vaultAddress || vaultAddress === ZERO) {
+      setHealth(null);
+      return;
+    }
+
+    const provider = getProvider(undefined, chainId);
+    const hub = SharedPayoutHub__factory.connect(hubAddr, provider);
+
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const [usdcBalance, totalDebt] = await hub.getHubHealth([vaultAddress]);
+        const coverRatioBps = totalDebt === 0n ? 99_999 : Number((usdcBalance * 10_000n) / totalDebt);
+
+        if (!cancelled) {
+          setHealth({ usdcBalance, totalDebt, coverRatioBps, status: deriveStatus(coverRatioBps) });
+        }
+      } catch {
+        // Hub not reachable — leave health as null (hide the widget)
+      }
+    }
+
+    poll();
+    const id = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [chainId, vaultAddress]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return health;
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3192,6 +3192,10 @@ msgstr "Gesamtwert der Token im GLP Pool"
 msgid "GLV vaults"
 msgstr "GLV Vaults"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "Virtuelle Markt-ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Hebelwirkung"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV verdient durch Handelsgebühren (Eröffnung, Schließung, Kreditaufn
 msgid "Failed Market Increase"
 msgstr "Fehlgeschlagene Markterhöhung"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "HEB."
@@ -5711,6 +5718,10 @@ msgstr "Übertragung bereits gestartet"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "Token suchen"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "GMX-Konto"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "Limitpreis"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3192,6 +3192,10 @@ msgstr "Total value of tokens in the GLP pool"
 msgid "GLV vaults"
 msgstr "GLV vaults"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "Virtual market ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Leverage"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV earns from trading fees (open, close, borrow, liquidations, swaps) a
 msgid "Failed Market Increase"
 msgstr "Failed Market Increase"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr "Liq. Price"
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "LEV."
@@ -5711,6 +5718,10 @@ msgstr "Transfer already initiated"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "Search token"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr "Health"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "GMX Account"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "Limit price"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3192,6 +3192,10 @@ msgstr "Valor total de los tokens en el pool de GLP"
 msgid "GLV vaults"
 msgstr "Bóvedas GLV"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "ID de mercado virtual"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Apalancamiento"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV genera ingresos a partir de comisiones de trading (apertura, cierre,
 msgid "Failed Market Increase"
 msgstr "Aumento de Mercado Fallido"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "APAL."
@@ -5711,6 +5718,10 @@ msgstr "Transferencia ya iniciada"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "Buscar token"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "Cuenta GMX"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "Precio límite"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3192,6 +3192,10 @@ msgstr "Valeur totale des tokens dans le pool GLP"
 msgid "GLV vaults"
 msgstr "GLV vaults"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "ID de marché virtuel"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Levier"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV génère des revenus à partir des frais de trading (ouverture, clô
 msgid "Failed Market Increase"
 msgstr "Augmentation de marché échouée"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "LEV."
@@ -5711,6 +5718,10 @@ msgstr "Transfert déjà initié"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "Rechercher un jeton"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "Compte GMX"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "Prix limite"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3192,6 +3192,10 @@ msgstr "GLPプール内のトークンの合計価値"
 msgid "GLV vaults"
 msgstr "GLVボールト"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "仮想マーケットID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "レバレッジ"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV は GM プール全体の取引手数料（オープン、クロー�
 msgid "Failed Market Increase"
 msgstr "マーケット増額失敗"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "LEV."
@@ -5711,6 +5718,10 @@ msgstr "転送は既に開始されています"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "トークンを検索"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "GMXアカウント"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "指値価格"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3192,6 +3192,10 @@ msgstr "GLP 풀 내 토큰의 총 가치"
 msgid "GLV vaults"
 msgstr "GLV 볼트"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "가상 마켓 ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "레버리지"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV는 GM 풀 전반의 거래 수수료(개설, 청산, 차입, 청산,
 msgid "Failed Market Increase"
 msgstr "시장 증가 실패"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "레버리지"
@@ -5711,6 +5718,10 @@ msgstr "이미 전송이 시작되었습니다"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "토큰 검색"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "GMX 계정"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "지정가"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -3192,6 +3192,10 @@ msgstr ""
 msgid "GLV vaults"
 msgstr ""
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr ""
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr ""
 
@@ -5291,6 +5294,10 @@ msgstr ""
 msgid "Failed Market Increase"
 msgstr ""
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr ""
@@ -5710,6 +5717,10 @@ msgstr ""
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
+msgstr ""
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
 msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -9624,6 +9635,10 @@ msgstr ""
 #: src/components/TradeboxMarginFields/PriceField.tsx
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
+msgstr ""
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
 msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -3192,6 +3192,10 @@ msgstr "Общая стоимость токенов в пуле GLP"
 msgid "GLV vaults"
 msgstr "Хранилища GLV"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "Виртуальный ID рынка"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "Плечо"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV получает доход от торговых комиссий (
 msgid "Failed Market Increase"
 msgstr "Неудачное Рыночное Увеличение"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "ПЛЕЧО"
@@ -5711,6 +5718,10 @@ msgstr "Перевод уже запущен"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "Поиск токена"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "Счет GMX"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "Лимитная цена"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -3192,6 +3192,10 @@ msgstr "GLP 池中代幣的總價值"
 msgid "GLV vaults"
 msgstr "GLV 金庫"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "虛擬市場 ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "槓桿"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV 從 GM 池的交易手續費（開倉、平倉、借貸、清算、�
 msgid "Failed Market Increase"
 msgstr "Market Increase 失敗"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "LEV."
@@ -5711,6 +5718,10 @@ msgstr "轉帳已發起"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "搜尋代幣"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "GMX Account"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "限價"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3192,6 +3192,10 @@ msgstr "GLP 池中代币的总价值"
 msgid "GLV vaults"
 msgstr "GLV 金库"
 
+#: src/pages/Trade/TradePage.tsx
+msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from centralized services"
@@ -4057,7 +4061,6 @@ msgstr "虚拟市场 ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
-#: src/pages/Trade/components/PositionListPanel.tsx
 msgid "Leverage"
 msgstr "杠杆"
 
@@ -5291,6 +5294,10 @@ msgstr "GLV 通过 GM 池中的交易费用（开仓、平仓、借款、清算�
 msgid "Failed Market Increase"
 msgstr "市场增加失败"
 
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Liq. Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
 msgstr "杠杆"
@@ -5711,6 +5718,10 @@ msgstr "转账已启动"
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 msgid "Search token"
 msgstr "搜索代币"
+
+#: src/pages/Trade/components/PositionListPanel.tsx
+msgid "Health"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -9625,6 +9636,10 @@ msgstr "GMX 账户"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Limit price"
 msgstr "限价"
+
+#: src/pages/Trade/TradePage.tsx
+msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"

--- a/src/pages/Trade/TradePage.tsx
+++ b/src/pages/Trade/TradePage.tsx
@@ -6,7 +6,7 @@
  * Layout:
  *   Left  — TradeBox (Long / Short tabs → OpenPositionPanel)
  *            When a position is selected: ClosePositionPanel replaces the open form
- *   Right — PositionListPanel + PendingRequestsPanel
+ *   Right — ADL risk banner (when Hub cover < 130%) + PositionListPanel + PendingRequestsPanel
  */
 
 import { t } from "@lingui/macro";
@@ -17,8 +17,10 @@ import { useVantagePositions } from "domain/vantage/positions/useVantagePosition
 import { usePositionRequests } from "domain/vantage/trade/usePositionRequests";
 import { usePositionRouterTrade } from "domain/vantage/trade/usePositionRouterTrade";
 import { useSpread } from "domain/vantage/trade/useSpread";
+import { useHubHealth } from "domain/vantage/useHubHealth";
 import { useChainId } from "lib/chains";
 import useWallet from "lib/wallets/useWallet";
+import { getVantageContractAddress } from "vantage/contracts";
 import localhostDeployment from "vantage/deployments/frontend-localhost.json";
 
 import { ClosePositionPanel } from "./components/ClosePositionPanel";
@@ -50,6 +52,10 @@ export default function TradePage() {
   const trade = usePositionRouterTrade();
   const requests = usePositionRequests();
   const spread = useSpread(WETH_ADDRESS || undefined);
+
+  // ADL risk monitoring via SharedPayoutHub
+  const vaultAddress = getVantageContractAddress(chainId, "Vault");
+  const hubHealth = useHubHealth(chainId, vaultAddress);
 
   const selectedPosition = positions.find((p) => p.key === selectedPositionKey) ?? null;
   const isLong = activeTab === "long";
@@ -142,6 +148,21 @@ export default function TradePage() {
 
           {/* ── Right: Positions + Pending ──────────────────────────────────────── */}
           <div className="flex min-w-0 flex-1 flex-col gap-16">
+            {/* ADL risk banner */}
+            {hubHealth && hubHealth.status !== "healthy" && (
+              <div
+                className={`rounded-4 border px-14 py-10 text-13 ${
+                  hubHealth.status === "danger"
+                    ? "border-red-500/40 bg-red-500/10 text-red-400"
+                    : "text-yellow-400 border-yellow-500/40 bg-yellow-500/10"
+                }`}
+              >
+                {hubHealth.status === "danger"
+                  ? t`ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: ${(hubHealth.coverRatioBps / 100).toFixed(0)}%`
+                  : t`Hub balance is low — ADL may trigger soon. Cover ratio: ${(hubHealth.coverRatioBps / 100).toFixed(0)}%`}
+              </div>
+            )}
+
             {/* Open positions */}
             <div>
               <div className="mb-10 flex items-center justify-between">

--- a/src/pages/Trade/components/PositionListPanel.tsx
+++ b/src/pages/Trade/components/PositionListPanel.tsx
@@ -2,13 +2,15 @@
  * PositionListPanel.tsx
  *
  * Shows all open positions for the connected wallet.
- * Clicking a row selects it for the ClosePositionPanel.
+ * Displays real-time PnL, liquidation price, and health indicator.
+ * Clicking the 詳細 button selects a position for the ClosePositionPanel.
  */
 
 import { t } from "@lingui/macro";
+import { formatEther } from "ethers";
 
 import type { VantagePosition } from "domain/vantage/positions/types";
-import { formatVantageUsd } from "domain/vantage/positions/utils";
+import { calcHealthBps, calcLiquidationPrice, formatVantageUsd } from "domain/vantage/positions/utils";
 
 function shortenAddr(addr: string) {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
@@ -17,6 +19,15 @@ function shortenAddr(addr: string) {
 function leverageLabel(size: bigint, collateral: bigint): string {
   if (collateral === 0n) return "—";
   return `${(Number(size) / Number(collateral)).toFixed(1)}×`;
+}
+
+/** Health color class and label derived from healthBps. */
+function healthInfo(healthBps: number): { colorClass: string; label: string; blink: boolean } {
+  if (healthBps > 1_500)
+    return { colorClass: "text-green-400", label: `${(healthBps / 100).toFixed(0)}%`, blink: false };
+  if (healthBps > 500)
+    return { colorClass: "text-yellow-400", label: `${(healthBps / 100).toFixed(0)}%`, blink: false };
+  return { colorClass: "text-red-400", label: `${(healthBps / 100).toFixed(0)}%`, blink: true };
 }
 
 type Props = {
@@ -30,11 +41,12 @@ export function PositionListPanel({ positions, isLoading, selectedKey, onSelect 
   return (
     <div className="overflow-hidden rounded-4 border border-stroke-primary">
       {/* Header */}
-      <div className="bg-cold-blue-950 grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr_auto] border-b border-stroke-primary px-16 py-10 text-11 text-slate-400">
+      <div className="bg-cold-blue-950 grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr_1fr_auto] border-b border-stroke-primary px-16 py-10 text-11 text-slate-400">
         <div>{t`Market`}</div>
         <div className="text-right">{t`Side`}</div>
         <div className="text-right">{t`Size`}</div>
-        <div className="text-right">{t`Leverage`}</div>
+        <div className="text-right">{t`Liq. Price`}</div>
+        <div className="text-right">{t`Health`}</div>
         <div className="text-right">{t`PnL`}</div>
         <div />
       </div>
@@ -50,19 +62,41 @@ export function PositionListPanel({ positions, isLoading, selectedKey, onSelect 
         const pnlColor = pos.pendingPnl >= 0n ? "text-green-400" : "text-red-400";
         const pnlSign = pos.pendingPnl >= 0n ? "+" : "";
 
+        const liqPrice = calcLiquidationPrice(
+          pos.size,
+          pos.collateral,
+          pos.averagePrice,
+          pos.isLong,
+          pos.maintenanceMarginBps
+        );
+
+        const health = pos.currentPrice > 0n ? healthInfo(calcHealthBps(pos.currentPrice, liqPrice, pos.isLong)) : null;
+
+        const liqPriceDisplay = liqPrice > 0n ? `$${parseFloat(formatEther(liqPrice)).toFixed(2)}` : "—";
+
         return (
           <div
             key={pos.key}
-            className={`grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr_auto] items-center border-b border-stroke-primary px-16 py-12 text-13 transition-colors last:border-0 ${
+            className={`grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr_1fr_auto] items-center border-b border-stroke-primary px-16 py-12 text-13 transition-colors last:border-0 ${
               isSelected ? "bg-blue-900/20 ring-1 ring-inset ring-blue-600" : "hover:bg-slate-800/40"
             }`}
           >
             <div className="font-medium text-white">{shortenAddr(pos.indexToken)}</div>
             <div className={`text-right font-medium ${pos.isLong ? "text-green-400" : "text-red-400"}`}>
               {pos.isLong ? t`Long` : t`Short`}
+              <div className="text-10 font-normal text-slate-500">{leverageLabel(pos.size, pos.collateral)}</div>
             </div>
             <div className="text-right text-white">{formatVantageUsd(pos.size)}</div>
-            <div className="text-slate-300 text-right">{leverageLabel(pos.size, pos.collateral)}</div>
+            <div className="text-slate-300 text-right">{liqPriceDisplay}</div>
+            <div className="text-right">
+              {health ? (
+                <span className={`font-medium ${health.colorClass} ${health.blink ? "animate-pulse" : ""}`}>
+                  {health.label}
+                </span>
+              ) : (
+                <span className="text-slate-500">—</span>
+              )}
+            </div>
             <div className={`text-right font-medium ${pnlColor}`}>
               {pnlSign}
               {formatVantageUsd(pos.pendingPnl < 0n ? -pos.pendingPnl : pos.pendingPnl)}


### PR DESCRIPTION
## 概要

Issue #152 の実装。トレード画面のポジション一覧に以下の情報を追加する。

- **リアルタイム PnL**: 30秒ポーリングで自動更新（手動 Refresh も引き続き有効）
- **清算価格（Liq. Price）**: オフチェーン計算式で各ポジションの清算価格を表示
- **ヘルスファクター（Health）**: 現在価格と清算価格の距離をパーセント表示＋カラーコーディング
- **ADL リスクバナー**: SharedPayoutHub のカバー率が低下したときにトレード画面上部にバナーを表示

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/domain/vantage/positions/utils.ts` | `calcLiquidationPrice`, `calcHealthBps` 追加 |
| `src/domain/vantage/positions/types.ts` | `VantagePosition` に `currentPrice`, `maintenanceMarginBps` フィールド追加 |
| `src/domain/vantage/positions/useVantagePositions.ts` | 30秒ポーリング・`getMinPrice`・`getAssetRiskInfo` 取得追加 |
| `src/domain/vantage/useHubHealth.ts` | 新規: `SharedPayoutHub.getHubHealth` ポーリングフック |
| `src/pages/Trade/components/PositionListPanel.tsx` | Liq. Price 列・Health カラーバッジ追加（7列に拡張） |
| `src/pages/Trade/TradePage.tsx` | ADL リスクバナー追加 |

## ヘルスファクターのカラーコーディング

| 値 | 色 | 意味 |
|----|-----|------|
| > 15% | 緑 | 安全 |
| 5〜15% | 黄 | 注意 |
| < 5% | 赤（点滅） | 危険 — 清算価格に接近 |

## ADL バナーの表示条件

| Hub カバー率 | 表示 |
|------------|------|
| ≥ 130% | 非表示（通常状態） |
| 110〜130% | 黄バナー「ADL may trigger soon」 |
| < 110% | 赤バナー「ADL is active」 |

## テスト

- `npx tsc --noEmit` → エラーなし
- `npx eslint` → エラーなし（警告なし）
- `vitest run` → 全テスト通過（517 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)