### PR TITLE
feat(trade): リアルタイムチャート実装 — ローソク足 / OI / Funding Rate (#153)

### DIFF
--- a/docs/realtime-chart.md
+++ b/docs/realtime-chart.md
@@ -1,0 +1,212 @@
+# Realtime Chart — 実装ガイド
+
+Trade ページの全幅チャートパネル（Issue #153）の設計・実装・本番対応手順をまとめたドキュメント。
+
+---
+
+## 概要
+
+TradeBox の上に配置された全幅パネルで、以下の 3 タブをリアルタイムで表示する。
+
+| タブ | 内容 | チャート種別 |
+|---|---|---|
+| Price | ローソク足（OHLCV）| Candlestick |
+| OI | Long / Short Open Interest | Line × 2 |
+| Funding Rate | 年率 Funding Rate (%) | Line |
+
+---
+
+## データフロー
+
+```
+Vault コントラクト
+    │
+    ├─ queryFilter (過去ログ)         ← useTradeHistory.ts
+    │      IncreasePosition
+    │      DecreasePosition
+    │      CumulativeFundingUpdated
+    │
+    └─ WebSocket イベント購読 (リアルタイム)  ← useVaultEvents.ts
+           IncreasePosition
+           DecreasePosition
+           LiquidatePosition
+           CumulativeFundingUpdated
+                │
+                ▼
+        ChartPanel.tsx
+        ├── allTrades = [...historicalTrades, ...realtimeTrades]
+        └── allFunding = [...historicalFunding, ...realtimeFunding]
+                │
+                ▼
+        candleUtils.ts (純粋関数で集計)
+        ├── buildCandles()       → CandlestickData[]
+        ├── buildOIData()        → { longOI, shortOI }: LineData[]
+        └── buildFundingRateData() → LineData[]
+                │
+                ▼
+        lightweight-charts v5 で描画
+        PriceChart / OIChart / FundingRateChart
+```
+
+---
+
+## ファイル構成
+
+```
+src/
+├── domain/vantage/chart/
+│   ├── types.ts            — TimeFrame / TradeEvent / FundingRateEvent 型定義
+│   ├── candleUtils.ts      — 集計ロジック (純粋関数)
+│   ├── useTradeHistory.ts  — 過去データ一括取得 (queryFilter)
+│   └── useVaultEvents.ts   — リアルタイム WebSocket 購読
+│
+└── pages/Trade/components/
+    ├── ChartPanel.tsx       — タブ管理 + WebSocket 接続の共有
+    ├── PriceChart.tsx       — ローソク足チャート
+    ├── OIChart.tsx          — Long / Short OI チャート
+    └── FundingRateChart.tsx — Funding Rate チャート
+```
+
+---
+
+## 現在の対応ネットワーク
+
+| ネットワーク | 過去データ | リアルタイム |
+|---|---|---|
+| localhost (31337) | queryFilter (RPC) | WebSocket (ws://localhost:8545) |
+| その他 | **未対応（空配列）** | **未対応（接続しない）** |
+
+---
+
+## 本番化手順（Option A: WebSocket RPC）
+
+### 1. WebSocket エンドポイントを環境変数で設定する
+
+`useVaultEvents.ts` の `getWsUrl` 関数に TODO コメントが書いてある箇所がそのまま拡張ポイント。
+
+```ts
+// src/domain/vantage/chart/useVaultEvents.ts
+function getWsUrl(chainId: number): string | null {
+  if (chainId === LOCALHOST_CHAIN_ID) return "ws://localhost:8545";
+
+  // ↓ この行のコメントアウトを外す
+  return import.meta.env[`VITE_WS_URL_${chainId}`] ?? null;
+}
+```
+
+### 2. `.env` ファイルに WSS URL を追加する
+
+Alchemy / Infura / QuickNode など WebSocket 対応の RPC プロバイダーの URL を設定する。
+
+```env
+# Base Sepolia (chainId 84532)
+VITE_WS_URL_84532=wss://base-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+
+# Base Mainnet (chainId 8453)
+VITE_WS_URL_8453=wss://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY
+```
+
+### 3. 過去データの取得元を追加する（useTradeHistory.ts）
+
+現在 localhost 以外では空配列を返す。本番では下記いずれかを追加する。
+
+**Option A-1: 同じ RPC の `queryFilter` を使う**
+
+ブロック数が多いとタイムアウトするため、直近 N ブロック（例: 直近 7 日分）に絞る。
+
+```ts
+// useTradeHistory.ts の fetchLocalhost を汎用化した例
+const HISTORY_BLOCK_RANGE = 50_400; // ≈ 7 days on Base (2s block)
+
+const latestBlock = await provider.getBlockNumber();
+const fromBlock = Math.max(0, latestBlock - HISTORY_BLOCK_RANGE);
+vault.queryFilter(filter, fromBlock, "latest");
+```
+
+**Option A-2: The Graph (Subgraph) から GraphQL クエリで取得する**
+
+リアルタイム部分は引き続き WebSocket RPC を使い、過去データのみ Subgraph に移行する構成。
+`useTradeHistory.ts` の `else` ブロック（現在空配列を返している箇所）に GraphQL クライアントのコードを追加する。
+
+---
+
+## 実装の注意点
+
+### lightweight-charts v5 の API 変更
+
+v4 以前と v5 では API が破壊的に変更されている。
+
+```ts
+// v4 以前（廃止）
+chart.addCandlestickSeries({ ... });
+chart.addLineSeries({ ... });
+
+// v5 以降（現在の実装）
+import { CandlestickSeries, LineSeries } from "lightweight-charts";
+chart.addSeries(CandlestickSeries, { ... });
+chart.addSeries(LineSeries, { ... });
+```
+
+### WebSocket 自動再接続
+
+`useVaultEvents.ts` は接続断 (`close` イベント) を検知して 3 秒後に自動再接続する。
+`cancelled` フラグでコンポーネントアンマウント後の再接続を防いでいる。
+
+```ts
+underlyingWs.addEventListener("close", () => {
+  if (!cancelled) reconnectTimer = setTimeout(connect, 3_000);
+});
+```
+
+### WebSocket 接続の共有
+
+WebSocket は `ChartPanel` が 1 本だけ保持し、3 つのチャートコンポーネントに props 経由でデータを渡す。
+タブを切り替えても接続は維持されるため、バックグラウンドでデータが蓄積され続ける。
+
+### OI / Funding Rate のタイムスタンプ重複回避
+
+`lightweight-charts` は同一タイムスタンプを持つ 2 点を受け取るとエラーになる。
+`buildOIData` / `buildFundingRateData` では `seen: Set<number>` でインクリメントして回避している。
+
+### `callbacksRef` パターン
+
+`useVaultEvents` は WebSocket コールバックを `useRef` で保持する。
+これにより `useEffect` を再実行せずに最新のコールバック関数を参照できる（stale closure 防止）。
+
+```ts
+const callbacksRef = useRef(callbacks);
+callbacksRef.current = callbacks; // 毎レンダーで最新に更新
+```
+
+### ethers v6 の filter 引数
+
+ethers v6 では `queryFilter` / `vault.on` のフィルター引数に `null` は使えない。
+ワイルドカードには `undefined` を使う。
+
+```ts
+// NG（v5 スタイル）
+vault.filters.IncreasePosition(null, null, null, indexToken)
+
+// OK（v6）
+vault.filters.IncreasePosition(undefined, undefined, undefined, indexToken)
+```
+
+---
+
+## WAD 精度について
+
+Vault コントラクトの USD 値はすべて 1e18 スケール（WAD）。
+フロント側では `formatEther(bigint)` で `float` に変換してチャートに渡す。
+
+| 変数 | 精度 |
+|---|---|
+| `price` | 1e18 WAD → `formatEther` → float |
+| `sizeDelta` | 1e18 WAD → `formatEther` → float |
+| `annualRateBps` | bps (整数) → `/100` → % |
+
+---
+
+## 関連 Issue / PR
+
+- Issue #153: リアルタイムチャート実装
+- PR #21: feat(trade): リアルタイムチャート実装 — ローソク足 / OI / Funding Rate

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "hex-to-rgba": "2.0.1",
     "html-to-image": "^1.10.8",
     "immer": "10.1.1",
+    "lightweight-charts": "^5.1.0",
     "lodash": "4.17.23",
     "qrcode.react": "^3.1.0",
     "query-string": "7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       immer:
         specifier: 10.1.1
         version: 10.1.1
+      lightweight-charts:
+        specifier: ^5.1.0
+        version: 5.1.0
       lodash:
         specifier: 4.17.23
         version: 4.17.23
@@ -4955,6 +4958,9 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5719,6 +5725,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightweight-charts@5.1.0:
+    resolution: {integrity: sha512-jEAYR4ODYeyNZcWUigsoLTl52rbPmgXnvd5FLIv/ZoA/2sSDw63YKnef8n4yhzum7W926yHeFwlm7ididKb7YQ==}
 
   lilconfig@2.0.4:
     resolution: {integrity: sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==}
@@ -14493,6 +14502,8 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.4.0: {}
@@ -15313,6 +15324,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightweight-charts@5.1.0:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   lilconfig@2.0.4: {}
 

--- a/src/domain/vantage/chart/candleUtils.ts
+++ b/src/domain/vantage/chart/candleUtils.ts
@@ -1,0 +1,93 @@
+/**
+ * candleUtils.ts
+ *
+ * Pure functions for aggregating trade events into chart data structures.
+ * All inputs use seconds-precision Unix timestamps.
+ */
+
+import type { CandlestickData, LineData, Time } from "lightweight-charts";
+
+import type { FundingRateEvent, TimeFrame, TradeEvent } from "./types";
+import { TIME_FRAME_SECONDS } from "./types";
+
+/**
+ * Aggregate an array of trade events into OHLCV candlestick bars.
+ * Events are bucketed into fixed-width time windows.
+ */
+export function buildCandles(events: TradeEvent[], timeFrame: TimeFrame): CandlestickData[] {
+  const intervalSec = TIME_FRAME_SECONDS[timeFrame];
+  // bucket time → { open, high, low, close }
+  const buckets = new Map<number, { open: number; high: number; low: number; close: number }>();
+
+  for (const e of events) {
+    const bucket = Math.floor(e.timestamp / intervalSec) * intervalSec;
+    const existing = buckets.get(bucket);
+    if (!existing) {
+      buckets.set(bucket, { open: e.price, high: e.price, low: e.price, close: e.price });
+    } else {
+      existing.high = Math.max(existing.high, e.price);
+      existing.low = Math.min(existing.low, e.price);
+      existing.close = e.price;
+    }
+  }
+
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([time, bar]) => ({ time: time as Time, ...bar }));
+}
+
+/**
+ * Derive Long OI and Short OI time series from trade events.
+ * Returns two line series: longOI and shortOI (in USD).
+ */
+export function buildOIData(events: TradeEvent[]): { longOI: LineData[]; shortOI: LineData[] } {
+  let longOI = 0;
+  let shortOI = 0;
+  const longPoints: LineData[] = [];
+  const shortPoints: LineData[] = [];
+
+  // Deduplicate timestamps (keep the last value per second)
+  const seen = new Set<number>();
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+
+  for (const e of sorted) {
+    if (e.type === "increase") {
+      if (e.isLong) longOI += e.sizeDelta;
+      else shortOI += e.sizeDelta;
+    } else {
+      // decrease or liquidate
+      if (e.isLong) longOI = Math.max(0, longOI - e.sizeDelta);
+      else shortOI = Math.max(0, shortOI - e.sizeDelta);
+    }
+
+    // Use unique second-precision timestamps to satisfy lightweight-charts requirement
+    let t = Math.floor(e.timestamp);
+    while (seen.has(t)) t++;
+    seen.add(t);
+
+    longPoints.push({ time: t as Time, value: longOI });
+    shortPoints.push({ time: t as Time, value: shortOI });
+  }
+
+  return { longOI: longPoints, shortOI: shortPoints };
+}
+
+/**
+ * Convert funding rate events into a line series.
+ * Deduplicates on timestamp (last value wins per second).
+ */
+export function buildFundingRateData(events: FundingRateEvent[]): LineData[] {
+  if (events.length === 0) return [];
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+  const seen = new Set<number>();
+  const result: LineData[] = [];
+
+  for (const e of sorted) {
+    let t = Math.floor(e.timestamp);
+    while (seen.has(t)) t++;
+    seen.add(t);
+    result.push({ time: t as Time, value: e.annualRateBps / 100 }); // bps → %
+  }
+
+  return result;
+}

--- a/src/domain/vantage/chart/types.ts
+++ b/src/domain/vantage/chart/types.ts
@@ -1,0 +1,32 @@
+/**
+ * types.ts — Shared types for Vantage realtime chart data.
+ */
+
+export type TimeFrame = "1m" | "5m" | "15m" | "1h" | "4h" | "1d";
+
+export const TIME_FRAMES: TimeFrame[] = ["1m", "5m", "15m", "1h", "4h", "1d"];
+
+export const TIME_FRAME_SECONDS: Record<TimeFrame, number> = {
+  "1m": 60,
+  "5m": 300,
+  "15m": 900,
+  "1h": 3_600,
+  "4h": 14_400,
+  "1d": 86_400,
+};
+
+/** A single trade event (Increase or Decrease position). */
+export type TradeEvent = {
+  price: number; // USD (converted from WAD)
+  sizeDelta: number; // USD
+  isLong: boolean;
+  timestamp: number; // Unix seconds
+  type: "increase" | "decrease" | "liquidate";
+};
+
+/** A single CumulativeFundingUpdated event. */
+export type FundingRateEvent = {
+  /** Annual funding rate in basis points (signed; negative = longs pay shorts). */
+  annualRateBps: number;
+  timestamp: number; // Unix seconds
+};

--- a/src/domain/vantage/chart/useTradeHistory.ts
+++ b/src/domain/vantage/chart/useTradeHistory.ts
@@ -1,0 +1,123 @@
+/**
+ * useTradeHistory.ts
+ *
+ * Fetches historical trade events for a given index token.
+ *
+ * Data source strategy:
+ *   localhost (chainId 31337): vault.queryFilter() — no Subgraph required
+ *   other networks:            TODO — replace with Subgraph query
+ *
+ * Returns arrays of TradeEvent and FundingRateEvent sorted by timestamp ascending.
+ */
+
+import { formatEther } from "ethers";
+import { useEffect, useState } from "react";
+
+import { getProvider } from "lib/rpc";
+import { getVantageContractAddress } from "vantage/contracts";
+import { Vault__factory } from "vantage/types";
+
+import type { FundingRateEvent, TradeEvent } from "./types";
+
+const LOCALHOST_CHAIN_ID = 31337;
+
+type UseTradeHistoryResult = {
+  tradeEvents: TradeEvent[];
+  fundingRateEvents: FundingRateEvent[];
+  isLoading: boolean;
+};
+
+export function useTradeHistory(chainId: number, indexToken: string): UseTradeHistoryResult {
+  const [tradeEvents, setTradeEvents] = useState<TradeEvent[]>([]);
+  const [fundingRateEvents, setFundingRateEvents] = useState<FundingRateEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!indexToken) return;
+
+    let cancelled = false;
+
+    async function fetchLocalhost() {
+      setIsLoading(true);
+      try {
+        const provider = getProvider(undefined, chainId);
+        const vaultAddr = getVantageContractAddress(chainId, "Vault");
+        const vault = Vault__factory.connect(vaultAddr, provider);
+
+        // --- Trade events (IncreasePosition + DecreasePosition) ---
+        const [increaseRaw, decreaseRaw] = await Promise.all([
+          vault.queryFilter(vault.filters.IncreasePosition(undefined, undefined, undefined, indexToken), 0, "latest"),
+          vault.queryFilter(vault.filters.DecreasePosition(undefined, undefined, undefined, indexToken), 0, "latest"),
+        ]);
+
+        // Collect unique block numbers for batch timestamp fetch
+        const blockNums = [...new Set([...increaseRaw, ...decreaseRaw].map((e) => e.blockNumber))];
+        const blocks = await Promise.all(blockNums.map((n) => provider.getBlock(n)));
+        const blockTsMap = new Map(
+          blocks.filter((b): b is NonNullable<typeof b> => b !== null).map((b) => [b.number, Number(b.timestamp)])
+        );
+
+        const increaseEvents: TradeEvent[] = increaseRaw.map((e) => ({
+          price: parseFloat(formatEther(e.args.price)),
+          sizeDelta: parseFloat(formatEther(e.args.sizeDelta)),
+          isLong: e.args.isLong,
+          timestamp: blockTsMap.get(e.blockNumber) ?? Date.now() / 1000,
+          type: "increase",
+        }));
+
+        const decreaseEvents: TradeEvent[] = decreaseRaw.map((e) => ({
+          price: parseFloat(formatEther(e.args.price)),
+          sizeDelta: parseFloat(formatEther(e.args.sizeDelta)),
+          isLong: e.args.isLong,
+          timestamp: blockTsMap.get(e.blockNumber) ?? Date.now() / 1000,
+          type: "decrease",
+        }));
+
+        const allTrades = [...increaseEvents, ...decreaseEvents].sort((a, b) => a.timestamp - b.timestamp);
+
+        // --- Funding rate events (CumulativeFundingUpdated) ---
+        const fundingRaw = await vault.queryFilter(vault.filters.CumulativeFundingUpdated(indexToken), 0, "latest");
+
+        const fundingBlockNums = [...new Set(fundingRaw.map((e) => e.blockNumber))];
+        const fundingBlocks = await Promise.all(fundingBlockNums.map((n) => provider.getBlock(n)));
+        const fundingTsMap = new Map(
+          fundingBlocks
+            .filter((b): b is NonNullable<typeof b> => b !== null)
+            .map((b) => [b.number, Number(b.timestamp)])
+        );
+
+        const fundingEvents: FundingRateEvent[] = fundingRaw.map((e) => ({
+          annualRateBps: Number(e.args.annualRate), // int256 bps
+          timestamp: fundingTsMap.get(e.blockNumber) ?? Date.now() / 1000,
+        }));
+
+        if (!cancelled) {
+          setTradeEvents(allTrades);
+          setFundingRateEvents(fundingEvents.sort((a, b) => a.timestamp - b.timestamp));
+        }
+      } catch {
+        // Non-critical — chart will show empty state
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    // TODO: Add Subgraph query for non-localhost networks
+    // const fetchSubgraph = async () => { ... };
+
+    if (chainId === LOCALHOST_CHAIN_ID) {
+      fetchLocalhost();
+    } else {
+      // Subgraph not yet deployed — show empty chart with TODO notice
+      setTradeEvents([]);
+      setFundingRateEvents([]);
+      setIsLoading(false);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chainId, indexToken]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { tradeEvents, fundingRateEvents, isLoading };
+}

--- a/src/domain/vantage/chart/useVaultEvents.ts
+++ b/src/domain/vantage/chart/useVaultEvents.ts
@@ -1,0 +1,143 @@
+/**
+ * useVaultEvents.ts
+ *
+ * Subscribes to Vault contract events via WebSocket for realtime chart updates.
+ *
+ * Supported networks:
+ *   localhost (chainId 31337): ws://localhost:8545  (Hardhat)
+ *   other networks:            TODO — set VITE_WS_URL_{CHAIN_ID} env vars
+ *
+ * Auto-reconnect: if the WebSocket closes unexpectedly, reconnects after 3 seconds.
+ */
+
+import { WebSocketProvider, formatEther } from "ethers";
+import { useEffect, useRef } from "react";
+
+import { getVantageContractAddress } from "vantage/contracts";
+import { Vault__factory } from "vantage/types";
+
+import type { FundingRateEvent, TradeEvent } from "./types";
+
+const LOCALHOST_CHAIN_ID = 31337;
+
+/** Returns a WebSocket URL for the given chainId, or null if not configured. */
+function getWsUrl(chainId: number): string | null {
+  if (chainId === LOCALHOST_CHAIN_ID) return "ws://localhost:8545";
+
+  // TODO: configure WebSocket URLs for testnet / mainnet via environment variables
+  // Example: return import.meta.env[`VITE_WS_URL_${chainId}`] ?? null;
+  return null;
+}
+
+type VaultEventCallbacks = {
+  onTradeEvent: (event: TradeEvent) => void;
+  onFundingRateEvent: (event: FundingRateEvent) => void;
+};
+
+/**
+ * Subscribes to Vault events via WebSocket.
+ * Calls the provided callbacks whenever new events arrive.
+ * Automatically reconnects if the connection drops.
+ */
+export function useVaultEvents(chainId: number, indexToken: string, callbacks: VaultEventCallbacks): void {
+  // Stable ref for callbacks so reconnect always uses latest handlers
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
+
+  useEffect(() => {
+    const wsUrl = getWsUrl(chainId);
+    if (!wsUrl || !indexToken) return;
+
+    const vaultAddr = getVantageContractAddress(chainId, "Vault");
+    if (!vaultAddr || vaultAddr === "0x0000000000000000000000000000000000000000") return;
+
+    let provider: WebSocketProvider | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+
+    function connect() {
+      if (cancelled) return;
+
+      try {
+        provider = new WebSocketProvider(wsUrl!);
+        const vault = Vault__factory.connect(vaultAddr, provider);
+
+        // IncreasePosition: price chart + OI
+        vault.on(
+          vault.filters.IncreasePosition(undefined, undefined, undefined, indexToken),
+          (key, account, _ct, _idx, _cd, sizeDelta, isLong, price) => {
+            callbacksRef.current.onTradeEvent({
+              price: parseFloat(formatEther(price as bigint)),
+              sizeDelta: parseFloat(formatEther(sizeDelta as bigint)),
+              isLong: isLong as boolean,
+              timestamp: Math.floor(Date.now() / 1000),
+              type: "increase",
+            });
+          }
+        );
+
+        // DecreasePosition: price chart + OI
+        vault.on(
+          vault.filters.DecreasePosition(undefined, undefined, undefined, indexToken),
+          (key, account, _ct, _idx, _cd, sizeDelta, isLong, price) => {
+            callbacksRef.current.onTradeEvent({
+              price: parseFloat(formatEther(price as bigint)),
+              sizeDelta: parseFloat(formatEther(sizeDelta as bigint)),
+              isLong: isLong as boolean,
+              timestamp: Math.floor(Date.now() / 1000),
+              type: "decrease",
+            });
+          }
+        );
+
+        // LiquidatePosition: OI reduction
+        vault.on(
+          vault.filters.LiquidatePosition(undefined, undefined, undefined, indexToken),
+          (key, account, _ct, _idx, isLong, size, _col, price) => {
+            callbacksRef.current.onTradeEvent({
+              price: parseFloat(formatEther(price as bigint)),
+              sizeDelta: parseFloat(formatEther(size as bigint)),
+              isLong: isLong as boolean,
+              timestamp: Math.floor(Date.now() / 1000),
+              type: "liquidate",
+            });
+          }
+        );
+
+        // CumulativeFundingUpdated: funding rate chart
+        vault.on(vault.filters.CumulativeFundingUpdated(indexToken), (_token, annualRate) => {
+          callbacksRef.current.onFundingRateEvent({
+            annualRateBps: Number(annualRate as bigint),
+            timestamp: Math.floor(Date.now() / 1000),
+          });
+        });
+
+        // Auto-reconnect on WebSocket close
+        const underlyingWs = (provider as unknown as { websocket: WebSocket }).websocket;
+        if (underlyingWs && typeof underlyingWs.addEventListener === "function") {
+          underlyingWs.addEventListener("close", () => {
+            if (!cancelled) {
+              reconnectTimer = setTimeout(connect, 3_000);
+            }
+          });
+        }
+      } catch {
+        // Provider creation failed — retry after 3 s
+        if (!cancelled) {
+          reconnectTimer = setTimeout(connect, 3_000);
+        }
+      }
+    }
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (provider) {
+        provider.removeAllListeners();
+        provider.destroy();
+      }
+    };
+  }, [chainId, indexToken]); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "Limitpreis unter Markpreis"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "Long OI"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "Tauschgebührfaktor (negativer PI)"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "GUTHABEN"
 msgid "GMX market token price chart"
 msgstr "GMX Markttoken-Preisdiagramm"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "LP Belohnungen insgesamt"
@@ -4471,6 +4480,10 @@ msgstr "Alle"
 msgid "Request Market Increase"
 msgstr "Markterhöhungsanfrage"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "GMX {VERSION_NAME} {networkName} Aktionen für alle Konten"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "Minimaler Einflusspool-Betrag"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "Noch keine Trades"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "Preisänderung bis zur Liquidation"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "Letzte 180 Tage"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "Positive Finanzierungsgebühren"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "Short OI"
 
@@ -6587,6 +6614,7 @@ msgstr "Auslösepreis für die Order"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "Preis"
 
@@ -6645,6 +6673,10 @@ msgstr "TP/SL-Orders überschreiten die Position"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "zahlen"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "Governance"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Abbrechen"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "GMX kaufen"
 msgid "Copy error"
 msgstr "Kopierfehler"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "TRACKER"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Netzwerk auswählen"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "Guthaben wird übertragen nach..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Netzwerkgebühr"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "Limit price below mark price"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "Long OI"
 
@@ -1125,6 +1126,10 @@ msgstr "Creating order"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "Swap fee factor (negative PI)"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr "OI"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "BALANCE"
 msgid "GMX market token price chart"
 msgstr "GMX market token price chart"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr "No position data yet"
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "Lifetime LP rewards"
@@ -4471,6 +4480,10 @@ msgstr "All"
 msgid "Request Market Increase"
 msgstr "Request Market Increase"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr "No funding rate data yet"
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "GMX {VERSION_NAME} {networkName} actions for all accounts"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "Min impact pool amount"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr "Annual Funding Rate"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "No trades yet"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "Price change to liquidation"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr "No trade data yet. Open a position to see the chart."
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "Last 180d"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "Positive funding fees"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr "Loading…"
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "Short OI"
 
@@ -6587,6 +6614,7 @@ msgstr "Trigger price for the order"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "Price"
 
@@ -6645,6 +6673,10 @@ msgstr "TP/SL orders exceed the position"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "pay"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr "Funding Rate"
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "Governance"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Cancel"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr "Live"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "Buy GMX"
 msgid "Copy error"
 msgstr "Copy error"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr "Loading chart data…"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "TRACKER"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Select network"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr "NAV synced"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "Funds bridging to..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Network fee"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr "Sync NAV"
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "Precio límite por debajo del precio de referencia"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "OI largo"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "Factor de comisión de intercambio (PI negativo)"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "SALDO"
 msgid "GMX market token price chart"
 msgstr "Gráfico de precios de tokens de mercado de GMX"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "Recompensas LP acumuladas"
@@ -4471,6 +4480,10 @@ msgstr "Todos"
 msgid "Request Market Increase"
 msgstr "Solicitar Aumento de Mercado"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "Acciones de GMX {VERSION_NAME} en {networkName} para todas las cuentas"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "Cantidad mínima del pool de impacto"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "No hay operaciones todavía"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "Cambio de precio hasta la liquidación"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "Últimos 180d"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "Comisiones de financiación positivas"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "OI corto"
 
@@ -6587,6 +6614,7 @@ msgstr "Precio de activación de la orden"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "Precio"
 
@@ -6645,6 +6673,10 @@ msgstr "Órdenes TP/SL exceden la posición"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "pagar"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "Gobernanza"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Cancelar"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "Comprar GMX"
 msgid "Copy error"
 msgstr "Error de copia"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "TRACKER"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Seleccionar red"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "Fondos transfiriéndose a..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Comisión de red"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "Prix limite en dessous du prix mark"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "OI Long"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "Facteur de frais d'échange (PI négatif)"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "SOLDE"
 msgid "GMX market token price chart"
 msgstr "Graphique des prix des tokens de marché GMX"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "Récompenses LP cumulées"
@@ -4471,6 +4480,10 @@ msgstr "Tous"
 msgid "Request Market Increase"
 msgstr "Demander une augmentation du marché"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "Actions GMX {VERSION_NAME} {networkName} pour tous les comptes"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "Montant minimum du pool d'impact"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "Pas encore d'échanges"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "Variation de prix jusqu'à la liquidation"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "Derniers 180j"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "Frais de financement positifs"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "Short OI"
 
@@ -6587,6 +6614,7 @@ msgstr "Prix de déclenchement de l'ordre"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "Prix"
 
@@ -6645,6 +6673,10 @@ msgstr "Les ordres TP/SL dépassent la position"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "payer"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "Gouvernance"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Annuler"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "Acheter GMX"
 msgid "Copy error"
 msgstr "Erreur de copie"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "TRACKER"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Sélectionner le réseau"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "Transfert des fonds vers..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Frais de réseau"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "指値価格がマーク価格を下回っています"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "ロングOI"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "スワップ手数料係数（マイナスPI）"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "残高"
 msgid "GMX market token price chart"
 msgstr "GMXマーケットトークン価格チャート"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "累計LP報酬"
@@ -4471,6 +4480,10 @@ msgstr "すべて"
 msgid "Request Market Increase"
 msgstr "マーケット増加リクエスト"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "GMX {VERSION_NAME} {networkName} 全アカウントのアクション"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "最小インパクトプール量"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "トレード履歴はありません"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "清算までの価格変動"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "過去180日"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "正のファンディング手数料"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "ショート OI"
 
@@ -6587,6 +6614,7 @@ msgstr "注文のトリガー価格"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "価格"
 
@@ -6645,6 +6673,10 @@ msgstr "TP/SL注文がポジションを超過"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "支払い"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "ガバナンス"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "キャンセル"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "GMXを購入"
 msgid "Copy error"
 msgstr "コピーエラー"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "TRACKER"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "ネットワークを選択"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "ブリッジ送金中..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "ネットワーク手数料"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "지정가 가격이 마크 가격 미만"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "롱 OI"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "스왑 수수료 계수 (음의 PI)"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "잔액"
 msgid "GMX market token price chart"
 msgstr "GMX 마켓 토큰 가격 차트"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "누적 LP 보상"
@@ -4471,6 +4480,10 @@ msgstr "모두"
 msgid "Request Market Increase"
 msgstr "마켓 증가 요청"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "모든 계정의 GMX {VERSION_NAME} {networkName} 활동"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "최소 영향 풀 수량"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "거래가 아직 없습니다"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "청산까지 가격 변동"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "최근 180일"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "양의 펀딩 수수료"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "숏 OI"
 
@@ -6587,6 +6614,7 @@ msgstr "주문 조건가"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "가격"
 
@@ -6645,6 +6673,10 @@ msgstr "TP/SL 주문이 포지션을 초과합니다"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "지불"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "거버넌스"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "취소"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "GMX 구매"
 msgid "Copy error"
 msgstr "복사 오류"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "트래커"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "네트워크 선택"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "자금 브릿징 중..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "네트워크 수수료"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr ""
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr ""
 
@@ -1124,6 +1125,10 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
+msgstr ""
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
 msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
@@ -2897,6 +2902,10 @@ msgstr ""
 msgid "GMX market token price chart"
 msgstr ""
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr ""
@@ -4471,6 +4480,10 @@ msgstr ""
 msgid "Request Market Increase"
 msgstr ""
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr ""
@@ -4495,6 +4508,10 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
+msgstr ""
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -4541,6 +4558,10 @@ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
+msgstr ""
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
 msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
@@ -4978,6 +4999,11 @@ msgstr ""
 
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
+msgstr ""
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr ""
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr ""
 
@@ -6587,6 +6614,7 @@ msgstr ""
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr ""
 
@@ -6644,6 +6672,10 @@ msgstr ""
 #: src/components/MarketNetFee/MarketNetFee.tsx
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
+msgstr ""
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
 msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
@@ -7135,6 +7167,10 @@ msgstr ""
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
+msgstr ""
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -8722,6 +8758,10 @@ msgstr ""
 msgid "Copy error"
 msgstr ""
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr ""
@@ -9663,10 +9703,6 @@ msgstr ""
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr ""
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr ""
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr ""
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "Лимитная цена ниже рыночной цены"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "OI лонг"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "Фактор комиссии за обмен (отрицательное влияние на цену)"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "БАЛАНС"
 msgid "GMX market token price chart"
 msgstr "График цены маркет-токена GMX"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "Совокупные вознаграждения LP"
@@ -4471,6 +4480,10 @@ msgstr "Все"
 msgid "Request Market Increase"
 msgstr "Запрос на Рыночное Увеличение"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "Действия GMX {VERSION_NAME} {networkName} для всех аккаунтов"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "Мин. сумма пула влияния"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "Пока нет сделок"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "Изменение цены до ликвидации"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "Последние 180д"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "Положительные комиссии за финансирование"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "Шорт OI"
 
@@ -6587,6 +6614,7 @@ msgstr "Цена активации ордера"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "Цена"
 
@@ -6645,6 +6673,10 @@ msgstr "Ордера TP/SL превышают позицию"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "оплатить"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "Управление"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "Отменить"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "Купить GMX"
 msgid "Copy error"
 msgstr "Ошибка копирования"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "ТРЕКЕР"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "Выберите сеть"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "Перевод средств в..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Комиссия сети"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "限價低於標記價格"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "做多 OI"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "兌換手續費因子（負價格影響）"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "餘額"
 msgid "GMX market token price chart"
 msgstr "GMX 市場代幣價格圖表"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "累計 LP 獎勵"
@@ -4471,6 +4480,10 @@ msgstr "全部"
 msgid "Request Market Increase"
 msgstr "Request Market Increase"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "所有帳戶的 GMX {VERSION_NAME} {networkName} 操作紀錄"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "最小影響池數量"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "尚無交易記錄"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "距清算價格變動"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "近 180 天"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "正向資金費用"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "做空 OI"
 
@@ -6587,6 +6614,7 @@ msgstr "訂單的觸發價格"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "價格"
 
@@ -6645,6 +6673,10 @@ msgstr "TP/SL 訂單超過倉位"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "支付"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "治理"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "取消"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "買入 GMX"
 msgid "Copy error"
 msgstr "複製錯誤"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "追蹤器"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "選擇網路"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "資金正在跨鏈至..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "網路費用"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -581,6 +581,7 @@ msgid "Limit price below mark price"
 msgstr "限价低于标记价格"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Long OI"
 msgstr "做多 OI"
 
@@ -1125,6 +1126,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap fee factor (negative PI)"
 msgstr "兑换手续费因子（负价格影响）"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "OI"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -2897,6 +2902,10 @@ msgstr "余额"
 msgid "GMX market token price chart"
 msgstr "GMX 市场代币价格图表"
 
+#: src/pages/Trade/components/OIChart.tsx
+msgid "No position data yet"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
 msgstr "累计 LP 奖励"
@@ -4471,6 +4480,10 @@ msgstr "全部"
 msgid "Request Market Increase"
 msgstr "请求市场增加"
 
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "No funding rate data yet"
+msgstr ""
+
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
 msgstr "GMX {VERSION_NAME} {networkName} 所有账户的操作"
@@ -4496,6 +4509,10 @@ msgstr "TWAP"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min impact pool amount"
 msgstr "最小影响池金额"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+msgid "Annual Funding Rate"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4542,6 +4559,10 @@ msgstr "暂无交易"
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Price change to liquidation"
 msgstr "距清算价格变动"
+
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "No trade data yet. Open a position to see the chart."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "possibilities in total"
@@ -4979,6 +5000,11 @@ msgstr "过去 180 天"
 #: src/components/Claims/ClaimableCardUI.tsx
 msgid "Positive funding fees"
 msgstr "正向资金费率"
+
+#: src/pages/Trade/components/FundingRateChart.tsx
+#: src/pages/Trade/components/OIChart.tsx
+msgid "Loading…"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
@@ -5685,6 +5711,7 @@ msgid "/"
 msgstr "/"
 
 #: src/components/TVChart/components/OpenInterestTooltip.tsx
+#: src/pages/Trade/components/OIChart.tsx
 msgid "Short OI"
 msgstr "做空 OI"
 
@@ -6587,6 +6614,7 @@ msgstr "订单的触发价格"
 #: src/components/SwapCard/SwapCard.tsx
 #: src/components/TVChart/Chart.tsx
 #: src/pages/Dashboard/GmxCard.tsx
+#: src/pages/Trade/components/ChartPanel.tsx
 msgid "Price"
 msgstr "价格"
 
@@ -6645,6 +6673,10 @@ msgstr "TP/SL 订单超过头寸"
 #: src/components/MarketNetFee/MarketNetFee.tsx
 msgid "pay"
 msgstr "支付"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Funding Rate"
+msgstr ""
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7136,6 +7168,10 @@ msgstr "治理"
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Cancel"
 msgstr "取消"
+
+#: src/pages/Trade/components/ChartPanel.tsx
+msgid "Live"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -8722,6 +8758,10 @@ msgstr "购买 GMX"
 msgid "Copy error"
 msgstr "复制错误"
 
+#: src/pages/Trade/components/PriceChart.tsx
+msgid "Loading chart data…"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
 msgstr "Saulius GMX analytics"
@@ -9663,10 +9703,6 @@ msgstr "追踪器"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Select network"
 msgstr "选择网络"
-
-#: src/domain/vantage/vaults/useVaultActions.ts
-#~ msgid "NAV synced"
-#~ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "No loss of fund ownership"
@@ -10909,10 +10945,6 @@ msgstr "资金正在跨链转移至..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "网络费用"
-
-#: src/pages/VaultDetail/VaultDetailPage.tsx
-#~ msgid "Sync NAV"
-#~ msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/pages/Trade/TradePage.tsx
+++ b/src/pages/Trade/TradePage.tsx
@@ -4,6 +4,7 @@
  * Route: /trade
  *
  * Layout:
+ *   Top   — ChartPanel (full-width: Price / OI / Funding Rate tabs)
  *   Left  — TradeBox (Long / Short tabs → OpenPositionPanel)
  *            When a position is selected: ClosePositionPanel replaces the open form
  *   Right — ADL risk banner (when Hub cover < 130%) + PositionListPanel + PendingRequestsPanel
@@ -23,6 +24,7 @@ import useWallet from "lib/wallets/useWallet";
 import { getVantageContractAddress } from "vantage/contracts";
 import localhostDeployment from "vantage/deployments/frontend-localhost.json";
 
+import { ChartPanel } from "./components/ChartPanel";
 import { ClosePositionPanel } from "./components/ClosePositionPanel";
 import { OpenPositionPanel } from "./components/OpenPositionPanel";
 import { PendingRequestsPanel } from "./components/PendingRequestsPanel";
@@ -76,6 +78,13 @@ export default function TradePage() {
           <h1 className="text-h1">{t`Trade`}</h1>
           <p className="text-body-medium mt-4 text-slate-400">{t`Open Long / Short positions via PositionRouter.`}</p>
         </div>
+
+        {/* ── Top: Full-width chart panel ─────────────────────────────────────── */}
+        {WETH_ADDRESS && (
+          <div className="mb-16">
+            <ChartPanel chainId={chainId} indexToken={WETH_ADDRESS} />
+          </div>
+        )}
 
         <div className="flex gap-16 lg:items-start">
           {/* ── Left: TradeBox ─────────────────────────────────────────────────── */}

--- a/src/pages/Trade/components/ChartPanel.tsx
+++ b/src/pages/Trade/components/ChartPanel.tsx
@@ -1,0 +1,108 @@
+/**
+ * ChartPanel.tsx
+ *
+ * Full-width chart container for the Trade page.
+ * Manages a single WebSocket connection shared across all chart tabs.
+ *
+ * Tabs:
+ *   Price    — Candlestick chart with time frame selector
+ *   OI       — Long / Short Open Interest line chart
+ *   Funding  — Annual funding rate line chart
+ */
+
+import { t } from "@lingui/macro";
+import { useCallback, useMemo, useState } from "react";
+
+import type { FundingRateEvent, TimeFrame, TradeEvent } from "domain/vantage/chart/types";
+import { useTradeHistory } from "domain/vantage/chart/useTradeHistory";
+import { useVaultEvents } from "domain/vantage/chart/useVaultEvents";
+
+import { FundingRateChart } from "./FundingRateChart";
+import { OIChart } from "./OIChart";
+import { PriceChart } from "./PriceChart";
+
+type Tab = "price" | "oi" | "funding";
+
+type Props = {
+  chainId: number;
+  indexToken: string;
+};
+
+export function ChartPanel({ chainId, indexToken }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("price");
+  const [timeFrame, setTimeFrame] = useState<TimeFrame>("1h");
+
+  // Historical data (one-time fetch on mount)
+  const {
+    tradeEvents: historicalTrades,
+    fundingRateEvents: historicalFunding,
+    isLoading,
+  } = useTradeHistory(chainId, indexToken);
+
+  // Realtime events accumulated in state
+  const [realtimeTrades, setRealtimeTrades] = useState<TradeEvent[]>([]);
+  const [realtimeFunding, setRealtimeFunding] = useState<FundingRateEvent[]>([]);
+
+  const handleTradeEvent = useCallback((e: TradeEvent) => {
+    setRealtimeTrades((prev) => [...prev, e]);
+  }, []);
+
+  const handleFundingRateEvent = useCallback((e: FundingRateEvent) => {
+    setRealtimeFunding((prev) => [...prev, e]);
+  }, []);
+
+  // Single WebSocket connection shared by all chart tabs
+  useVaultEvents(chainId, indexToken, {
+    onTradeEvent: handleTradeEvent,
+    onFundingRateEvent: handleFundingRateEvent,
+  });
+
+  // Merge historical + realtime (memoized to avoid new array on every render)
+  const allTrades = useMemo(() => [...historicalTrades, ...realtimeTrades], [historicalTrades, realtimeTrades]);
+  const allFunding = useMemo(() => [...historicalFunding, ...realtimeFunding], [historicalFunding, realtimeFunding]);
+
+  return (
+    <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary p-16">
+      {/* Tab bar */}
+      <div className="mb-16 flex items-center gap-0 border-b border-stroke-primary">
+        <button
+          onClick={() => setActiveTab("price")}
+          className={`mr-16 pb-10 text-13 font-medium transition-colors ${
+            activeTab === "price" ? "border-b-2 border-blue-400 text-blue-400" : "text-slate-400 hover:text-white"
+          }`}
+        >
+          {t`Price`}
+        </button>
+        <button
+          onClick={() => setActiveTab("oi")}
+          className={`mr-16 pb-10 text-13 font-medium transition-colors ${
+            activeTab === "oi" ? "border-b-2 border-blue-400 text-blue-400" : "text-slate-400 hover:text-white"
+          }`}
+        >
+          {t`OI`}
+        </button>
+        <button
+          onClick={() => setActiveTab("funding")}
+          className={`mr-16 pb-10 text-13 font-medium transition-colors ${
+            activeTab === "funding" ? "border-b-2 border-blue-400 text-blue-400" : "text-slate-400 hover:text-white"
+          }`}
+        >
+          {t`Funding Rate`}
+        </button>
+
+        {/* Realtime indicator */}
+        <div className="ml-auto flex items-center gap-6 pb-10 text-11 text-slate-500">
+          <span className="inline-block h-6 w-6 animate-pulse rounded-full bg-green-500" />
+          {t`Live`}
+        </div>
+      </div>
+
+      {/* Chart area */}
+      {activeTab === "price" && (
+        <PriceChart events={allTrades} timeFrame={timeFrame} onTimeFrameChange={setTimeFrame} isLoading={isLoading} />
+      )}
+      {activeTab === "oi" && <OIChart events={allTrades} isLoading={isLoading} />}
+      {activeTab === "funding" && <FundingRateChart events={allFunding} isLoading={isLoading} />}
+    </div>
+  );
+}

--- a/src/pages/Trade/components/FundingRateChart.tsx
+++ b/src/pages/Trade/components/FundingRateChart.tsx
@@ -1,0 +1,112 @@
+/**
+ * FundingRateChart.tsx
+ *
+ * Annual funding rate (%) over time — line chart.
+ * Positive = longs pay shorts, negative = shorts pay longs.
+ */
+
+import { t } from "@lingui/macro";
+import { ColorType, LineSeries, createChart } from "lightweight-charts";
+import type { IChartApi, ISeriesApi } from "lightweight-charts";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+
+import { buildFundingRateData } from "domain/vantage/chart/candleUtils";
+import type { FundingRateEvent } from "domain/vantage/chart/types";
+
+const CHART_HEIGHT = 200;
+const CHART_STYLE = { height: CHART_HEIGHT } as const;
+
+type Props = {
+  events: FundingRateEvent[];
+  isLoading: boolean;
+};
+
+export function FundingRateChart({ events, isLoading }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<"Line"> | null>(null);
+
+  const lineData = useMemo(() => buildFundingRateData(events), [events]);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+
+    const chart = createChart(containerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: "transparent" },
+        textColor: "#94a3b8",
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: "#1e293b" },
+        horzLines: { color: "#1e293b" },
+      },
+      rightPriceScale: { borderColor: "#1e293b" },
+      timeScale: { borderColor: "#1e293b", timeVisible: true, secondsVisible: false },
+      width: containerRef.current.clientWidth,
+      height: CHART_HEIGHT,
+    });
+
+    const series = chart.addSeries(LineSeries, {
+      color: "#60a5fa", // blue-400
+      lineWidth: 2,
+      title: "Annual %",
+    });
+
+    chartRef.current = chart;
+    seriesRef.current = series;
+
+    const observer = new ResizeObserver(() => {
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({ width: containerRef.current.clientWidth });
+      }
+    });
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+      chart.remove();
+      chartRef.current = null;
+      seriesRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    seriesRef.current?.setData(lineData);
+    if (lineData.length > 0) {
+      chartRef.current?.timeScale().fitContent();
+    }
+  }, [lineData]);
+
+  const isEmpty = !isLoading && events.length === 0;
+  const latestRate = events.length > 0 ? events[events.length - 1].annualRateBps / 100 : null;
+
+  return (
+    <div>
+      {/* Current rate badge */}
+      <div className="mb-6 flex items-center gap-8 text-11">
+        <span className="text-slate-400">{t`Annual Funding Rate`}</span>
+        {latestRate !== null && (
+          <span className={`font-medium ${latestRate >= 0 ? "text-green-400" : "text-red-400"}`}>
+            {latestRate >= 0 ? "+" : ""}
+            {latestRate.toFixed(2)}%
+          </span>
+        )}
+      </div>
+
+      <div className="relative">
+        <div ref={containerRef} className="w-full" style={CHART_STYLE} />
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center text-13 text-slate-400" style={CHART_STYLE}>
+            {t`Loading…`}
+          </div>
+        )}
+        {isEmpty && (
+          <div className="absolute inset-0 flex items-center justify-center text-13 text-slate-500" style={CHART_STYLE}>
+            {t`No funding rate data yet`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Trade/components/OIChart.tsx
+++ b/src/pages/Trade/components/OIChart.tsx
@@ -1,0 +1,121 @@
+/**
+ * OIChart.tsx
+ *
+ * Open Interest chart: Long OI (green) and Short OI (red) as two line series.
+ */
+
+import { t } from "@lingui/macro";
+import { ColorType, LineSeries, createChart } from "lightweight-charts";
+import type { IChartApi, ISeriesApi } from "lightweight-charts";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+
+import { buildOIData } from "domain/vantage/chart/candleUtils";
+import type { TradeEvent } from "domain/vantage/chart/types";
+
+const CHART_HEIGHT = 200;
+const CHART_STYLE = { height: CHART_HEIGHT } as const;
+
+type Props = {
+  events: TradeEvent[];
+  isLoading: boolean;
+};
+
+export function OIChart({ events, isLoading }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const longSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
+  const shortSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
+
+  const { longOI, shortOI } = useMemo(() => buildOIData(events), [events]);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+
+    const chart = createChart(containerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: "transparent" },
+        textColor: "#94a3b8",
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: "#1e293b" },
+        horzLines: { color: "#1e293b" },
+      },
+      rightPriceScale: { borderColor: "#1e293b" },
+      timeScale: { borderColor: "#1e293b", timeVisible: true, secondsVisible: false },
+      width: containerRef.current.clientWidth,
+      height: CHART_HEIGHT,
+    });
+
+    const longSeries = chart.addSeries(LineSeries, {
+      color: "#4ade80",
+      lineWidth: 2,
+      title: "Long OI",
+    });
+
+    const shortSeries = chart.addSeries(LineSeries, {
+      color: "#f87171",
+      lineWidth: 2,
+      title: "Short OI",
+    });
+
+    chartRef.current = chart;
+    longSeriesRef.current = longSeries;
+    shortSeriesRef.current = shortSeries;
+
+    const observer = new ResizeObserver(() => {
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({ width: containerRef.current.clientWidth });
+      }
+    });
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+      chart.remove();
+      chartRef.current = null;
+      longSeriesRef.current = null;
+      shortSeriesRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    longSeriesRef.current?.setData(longOI);
+    shortSeriesRef.current?.setData(shortOI);
+    if (longOI.length > 0 || shortOI.length > 0) {
+      chartRef.current?.timeScale().fitContent();
+    }
+  }, [longOI, shortOI]);
+
+  const isEmpty = !isLoading && events.length === 0;
+
+  return (
+    <div className="relative">
+      {/* Legend */}
+      <div className="mb-6 flex items-center gap-12 text-11">
+        <span className="flex items-center gap-4 text-green-400">
+          <span className="rounded inline-block h-2 w-12 bg-green-400" />
+          {t`Long OI`}
+        </span>
+        <span className="flex items-center gap-4 text-red-400">
+          <span className="rounded inline-block h-2 w-12 bg-red-400" />
+          {t`Short OI`}
+        </span>
+      </div>
+
+      <div className="relative">
+        <div ref={containerRef} className="w-full" style={CHART_STYLE} />
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center text-13 text-slate-400" style={CHART_STYLE}>
+            {t`Loading…`}
+          </div>
+        )}
+        {isEmpty && (
+          <div className="absolute inset-0 flex items-center justify-center text-13 text-slate-500" style={CHART_STYLE}>
+            {t`No position data yet`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Trade/components/PriceChart.tsx
+++ b/src/pages/Trade/components/PriceChart.tsx
@@ -1,0 +1,126 @@
+/**
+ * PriceChart.tsx
+ *
+ * Candlestick price chart powered by TradingView Lightweight Charts.
+ * Renders OHLCV bars aggregated from trade events.
+ */
+
+import { t } from "@lingui/macro";
+import { CandlestickSeries, ColorType, CrosshairMode, createChart } from "lightweight-charts";
+import type { IChartApi, ISeriesApi } from "lightweight-charts";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+
+import { buildCandles } from "domain/vantage/chart/candleUtils";
+import type { TimeFrame, TradeEvent } from "domain/vantage/chart/types";
+import { TIME_FRAMES } from "domain/vantage/chart/types";
+
+const CHART_HEIGHT = 280;
+const CHART_STYLE = { height: CHART_HEIGHT } as const;
+
+type Props = {
+  events: TradeEvent[];
+  timeFrame: TimeFrame;
+  onTimeFrameChange: (tf: TimeFrame) => void;
+  isLoading: boolean;
+};
+
+export function PriceChart({ events, timeFrame, onTimeFrameChange, isLoading }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<"Candlestick"> | null>(null);
+
+  const candles = useMemo(() => buildCandles(events, timeFrame), [events, timeFrame]);
+
+  // Initialize chart once on mount
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+
+    const chart = createChart(containerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: "transparent" },
+        textColor: "#94a3b8",
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: "#1e293b" },
+        horzLines: { color: "#1e293b" },
+      },
+      crosshair: { mode: CrosshairMode.Normal },
+      rightPriceScale: { borderColor: "#1e293b" },
+      timeScale: { borderColor: "#1e293b", timeVisible: true, secondsVisible: false },
+      width: containerRef.current.clientWidth,
+      height: CHART_HEIGHT,
+    });
+
+    const series = chart.addSeries(CandlestickSeries, {
+      upColor: "#4ade80",
+      downColor: "#f87171",
+      borderUpColor: "#4ade80",
+      borderDownColor: "#f87171",
+      wickUpColor: "#4ade80",
+      wickDownColor: "#f87171",
+    });
+
+    chartRef.current = chart;
+    seriesRef.current = series;
+
+    const observer = new ResizeObserver(() => {
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({ width: containerRef.current.clientWidth });
+      }
+    });
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+      chart.remove();
+      chartRef.current = null;
+      seriesRef.current = null;
+    };
+  }, []);
+
+  // Update series data whenever candles change
+  useEffect(() => {
+    if (!seriesRef.current) return;
+    seriesRef.current.setData(candles);
+    if (candles.length > 0) {
+      chartRef.current?.timeScale().fitContent();
+    }
+  }, [candles]);
+
+  const isEmpty = !isLoading && events.length === 0;
+
+  return (
+    <div>
+      {/* Time frame selector */}
+      <div className="mb-8 flex gap-4">
+        {TIME_FRAMES.map((tf) => (
+          <button
+            key={tf}
+            onClick={() => onTimeFrameChange(tf)}
+            className={`rounded-4 px-8 py-3 text-11 font-medium transition-colors ${
+              timeFrame === tf ? "bg-blue-600 text-white" : "bg-cold-blue-900 text-slate-400 hover:text-white"
+            }`}
+          >
+            {tf}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart container */}
+      <div className="relative">
+        <div ref={containerRef} className="w-full" style={CHART_STYLE} />
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center text-13 text-slate-400" style={CHART_STYLE}>
+            {t`Loading chart data…`}
+          </div>
+        )}
+        {isEmpty && (
+          <div className="absolute inset-0 flex items-center justify-center text-13 text-slate-500" style={CHART_STYLE}>
+            {t`No trade data yet. Open a position to see the chart.`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #153 の実装。Trade ページに全幅リアルタイムチャートパネルを追加。

## 変更内容

### 新規ファイル

- **`src/domain/vantage/chart/types.ts`** — `TimeFrame` / `TradeEvent` / `FundingRateEvent` 型定義
- **`src/domain/vantage/chart/candleUtils.ts`** — `buildCandles` / `buildOIData` / `buildFundingRateData` 集計ロジック
- **`src/domain/vantage/chart/useTradeHistory.ts`** — `queryFilter` による過去イベント一括取得（localhost 31337 のみ、Subgraph 統合は TODO）
- **`src/domain/vantage/chart/useVaultEvents.ts`** — WebSocket リアルタイム購読 + 3秒自動再接続
- **`src/pages/Trade/components/PriceChart.tsx`** — TradingView lightweight-charts v5 ローソク足チャート
- **`src/pages/Trade/components/OIChart.tsx`** — Long / Short OI ライン チャート
- **`src/pages/Trade/components/FundingRateChart.tsx`** — 年率 Funding Rate ライン チャート
- **`src/pages/Trade/components/ChartPanel.tsx`** — タブ切替（Price / OI / Funding Rate）+ Live インジケーター

### 既存ファイル変更

- **`src/pages/Trade/TradePage.tsx`** — TradeBox 上部（全幅）に `ChartPanel` を挿入
- **`package.json` / `pnpm-lock.yaml`** — `lightweight-charts@5.1.0` 追加
- **`src/locales/*/messages.po`** — `lingui extract` による新規 i18n 文字列追加

## 技術仕様

- **WebSocket**: 単一接続を全タブで共有（ChartPanel が管理）
- **データ結合**: 過去データ（queryFilter）+ リアルタイム（WebSocket）を `useMemo` でマージ
- **lightweight-charts v5 API**: `chart.addSeries(CandlestickSeries, {...})` / `chart.addSeries(LineSeries, {...})`
- **対応ネットワーク**: localhost (chainId 31337) のみ。他ネットワークは空配列を返し TODO コメントを残す
- **自動再接続**: WebSocket `close` イベント → 3秒後に再接続（`cancelled` フラグでクリーンアップ管理）
- **レスポンシブ**: `ResizeObserver` でコンテナ幅変更に追従

## テスト方法

1. `pnpm dev` でローカルサーバー起動
2. Hardhat ノード起動 + デプロイ済みコントラクトが存在する状態で Trade ページにアクセス
3. Price / OI / Funding Rate タブ切替の動作確認
4. ポジションを開いてリアルタイムでチャートが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)