### PR TITLE
feat: Hedge UI — delta-neutral strategy list & detail pages (Issue #170)

### DIFF
--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -18,6 +18,7 @@ import EarnDiscoveryPage from "pages/Earn/EarnDiscoveryPage";
 import EarnDistributionsPage from "pages/Earn/EarnDistributionsPage";
 import EarnPortfolioPage from "pages/Earn/EarnPortfolioPage";
 import Ecosystem from "pages/Ecosystem/Ecosystem";
+import HedgeDetailPage from "pages/Hedge/HedgeDetailPage";
 import HedgePage from "pages/Hedge/HedgePage";
 import Jobs from "pages/Jobs/Jobs";
 import { CompetitionRedirect, LeaderboardPage } from "pages/LeaderboardPage/LeaderboardPage";
@@ -159,6 +160,9 @@ export function MainRoutes({ openSettings: _openSettings }: { openSettings: () =
       </Route>
       <Route exact path="/hedge">
         <HedgePage />
+      </Route>
+      <Route exact path="/hedge/:key">
+        <HedgeDetailPage />
       </Route>
       <Route exact path="/trade/:tradeType?">
         <TradePage />

--- a/src/domain/vantage/hedge/useHedgeActions.ts
+++ b/src/domain/vantage/hedge/useHedgeActions.ts
@@ -1,0 +1,255 @@
+/**
+ * useHedgeActions.ts
+ *
+ * Provides contract call hooks for HedgeController actions:
+ *   - createManagedHedge   (USDC margin)
+ *   - createManagedHedgeETH (ETH margin)
+ *   - createSelfCustodyHedge (USDC margin)
+ *   - createSelfCustodyHedgeETH (ETH margin)
+ *
+ * Each function:
+ *   1. Validates balances (returns an error string or null)
+ *   2. Calls ERC-20 approve if needed
+ *   3. Sends the tx and returns the tx hash
+ *
+ * Execution fee is currently hardcoded to 0 for local testing.
+ * Set EXECUTION_FEE_WEI for production use.
+ */
+
+import { Contract } from "ethers";
+import { useCallback, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { useEthersSigner } from "lib/wallets/useEthersSigner";
+import HedgeControllerAbi from "vantage/abis/HedgeController.json";
+import ERC20Abi from "vantage/abis/MockERC20.json";
+import { getVantageContractAddress } from "vantage/contracts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Set to a non-zero value for production (e.g. parseEther("0.001")) */
+const EXECUTION_FEE_WEI = 0n;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type HedgeMode = "managed" | "selfCustody";
+export type HedgeMarginToken = "usdc" | "eth";
+
+export type HedgeParams = {
+  /** RWA token address */
+  rwaToken: string;
+  /** Amount of RWA tokens to deposit (WAD, only for managed) */
+  rwaAmount: bigint;
+  /** Collateral token address (USDC address, only for USDC margin) */
+  collateralToken: string;
+  /** Collateral amount (in token decimals) */
+  collateralAmount: bigint;
+  /** Perp index token address */
+  indexToken: string;
+  /** Short position notional (WAD) */
+  sizeDelta: bigint;
+  /** Maximum acceptable entry price (0 = accept any) */
+  acceptablePrice: bigint;
+};
+
+export type HedgeActionResult = {
+  isSubmitting: boolean;
+  error: string | null;
+  txHash: string | null;
+  /** Validates inputs and returns an error message or null */
+  validate: (
+    mode: HedgeMode,
+    marginToken: HedgeMarginToken,
+    params: Omit<HedgeParams, "acceptablePrice">
+  ) => Promise<string | null>;
+  /** Executes the hedge transaction */
+  execute: (
+    mode: HedgeMode,
+    marginToken: HedgeMarginToken,
+    params: Omit<HedgeParams, "acceptablePrice">
+  ) => Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useHedgeActions(): HedgeActionResult {
+  const { chainId } = useChainId();
+  const signer = useEthersSigner({ chainId });
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  // ── Balance / allowance validation ────────────────────────────────────────
+
+  const validate = useCallback(
+    async (
+      mode: HedgeMode,
+      marginToken: HedgeMarginToken,
+      params: Omit<HedgeParams, "acceptablePrice">
+    ): Promise<string | null> => {
+      if (!signer) return "Wallet not connected";
+
+      const account = await signer.getAddress();
+
+      try {
+        // Managed mode: check RWA balance
+        if (mode === "managed" && params.rwaAmount > 0n) {
+          const rwa = new Contract(params.rwaToken, ERC20Abi, signer);
+          const rwaBalance: bigint = await rwa.balanceOf(account);
+          if (rwaBalance < params.rwaAmount) {
+            return `Insufficient RWA balance (have ${rwaBalance}, need ${params.rwaAmount})`;
+          }
+        }
+
+        // USDC margin: check USDC balance
+        if (marginToken === "usdc" && params.collateralAmount > 0n) {
+          const usdc = new Contract(params.collateralToken, ERC20Abi, signer);
+          const usdcBalance: bigint = await usdc.balanceOf(account);
+          if (usdcBalance < params.collateralAmount) {
+            return `Insufficient USDC balance`;
+          }
+        }
+
+        // ETH margin: check ETH balance (collateral + execution fee)
+        if (marginToken === "eth") {
+          const ethBalance: bigint = await signer.provider!.getBalance(account);
+          const required = params.collateralAmount + EXECUTION_FEE_WEI;
+          if (ethBalance < required) {
+            return `Insufficient ETH balance`;
+          }
+        }
+      } catch {
+        return "Failed to check balances";
+      }
+
+      return null;
+    },
+    [signer]
+  );
+
+  // ── Execute ───────────────────────────────────────────────────────────────
+
+  const execute = useCallback(
+    async (
+      mode: HedgeMode,
+      marginToken: HedgeMarginToken,
+      params: Omit<HedgeParams, "acceptablePrice">
+    ): Promise<void> => {
+      if (!signer) {
+        setError("Wallet not connected");
+        return;
+      }
+
+      setIsSubmitting(true);
+      setError(null);
+      setTxHash(null);
+
+      try {
+        const hedgeControllerAddress = getVantageContractAddress(chainId, "HedgeController");
+        const controller = new Contract(hedgeControllerAddress, HedgeControllerAbi, signer);
+
+        const acceptablePrice = 0n; // accept any price for now
+        const executionFee = EXECUTION_FEE_WEI;
+
+        if (mode === "managed") {
+          // Approve RWA
+          const rwa = new Contract(params.rwaToken, ERC20Abi, signer);
+          const rwaAllowance: bigint = await rwa.allowance(await signer.getAddress(), hedgeControllerAddress);
+          if (rwaAllowance < params.rwaAmount) {
+            const approveTx = await rwa.approve(hedgeControllerAddress, params.rwaAmount);
+            await approveTx.wait();
+          }
+
+          if (marginToken === "usdc") {
+            // Approve USDC
+            const usdc = new Contract(params.collateralToken, ERC20Abi, signer);
+            const usdcAllowance: bigint = await usdc.allowance(await signer.getAddress(), hedgeControllerAddress);
+            if (usdcAllowance < params.collateralAmount) {
+              const approveTx = await usdc.approve(hedgeControllerAddress, params.collateralAmount);
+              await approveTx.wait();
+            }
+
+            const tx = await controller.createManagedHedge(
+              params.rwaToken,
+              params.rwaAmount,
+              params.collateralToken,
+              params.collateralAmount,
+              params.indexToken,
+              params.sizeDelta,
+              acceptablePrice,
+              executionFee,
+              { value: executionFee }
+            );
+            const receipt = await tx.wait();
+            setTxHash(receipt.hash);
+          } else {
+            // ETH margin: collateralAmount is in wei, send as msg.value
+            const msgValue = params.collateralAmount + executionFee;
+            const tx = await controller.createManagedHedgeETH(
+              params.rwaToken,
+              params.rwaAmount,
+              params.indexToken,
+              params.sizeDelta,
+              acceptablePrice,
+              executionFee,
+              { value: msgValue }
+            );
+            const receipt = await tx.wait();
+            setTxHash(receipt.hash);
+          }
+        } else {
+          // Self-custody mode
+          if (marginToken === "usdc") {
+            // Approve USDC
+            const usdc = new Contract(params.collateralToken, ERC20Abi, signer);
+            const usdcAllowance: bigint = await usdc.allowance(await signer.getAddress(), hedgeControllerAddress);
+            if (usdcAllowance < params.collateralAmount) {
+              const approveTx = await usdc.approve(hedgeControllerAddress, params.collateralAmount);
+              await approveTx.wait();
+            }
+
+            const tx = await controller.createSelfCustodyHedge(
+              params.collateralToken,
+              params.collateralAmount,
+              params.indexToken,
+              params.sizeDelta,
+              acceptablePrice,
+              executionFee,
+              { value: executionFee }
+            );
+            const receipt = await tx.wait();
+            setTxHash(receipt.hash);
+          } else {
+            const msgValue = params.collateralAmount + executionFee;
+            const tx = await controller.createSelfCustodyHedgeETH(
+              params.indexToken,
+              params.sizeDelta,
+              acceptablePrice,
+              executionFee,
+              { value: msgValue }
+            );
+            const receipt = await tx.wait();
+            setTxHash(receipt.hash);
+          }
+        }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        // Surface readable reason from revert
+        const match = msg.match(/reason="([^"]+)"/);
+        setError(match ? match[1] : msg.slice(0, 120));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [signer, chainId]
+  );
+
+  return { isSubmitting, error, txHash, validate, execute };
+}

--- a/src/domain/vantage/hedge/useHedgeList.ts
+++ b/src/domain/vantage/hedge/useHedgeList.ts
@@ -1,0 +1,161 @@
+/**
+ * useHedgeList.ts
+ *
+ * Returns a combined list of hedge opportunities derived from VAULT_CONFIGS.
+ * Each entry exposes:
+ *   - Vault APY (RWA yield)
+ *   - Short funding rate (annualised, from Vault.cumulativeFundingRate)
+ *   - Net APY for Managed mode  = vaultApy + fundingApy
+ *   - Net APY for Self-Custody  = fundingApy only
+ *   - Vault AUM and capacity
+ */
+
+import { Contract } from "ethers";
+import { useEffect, useMemo, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
+import VaultAbi from "vantage/abis/Vault.json";
+
+import { useVaultApy } from "../vaults/useVaultApy";
+import { VAULT_CONFIGS } from "../vaults/vaultConfig";
+import type { AssetTypeId, VaultConfig } from "../vaults/vaultConfig";
+
+const POLL_MS = 30_000;
+
+export type HedgeListItem = {
+  key: string;
+  symbol: string;
+  name: string;
+  assetType: AssetTypeId;
+  vaultAddress: string;
+  indexToken: string;
+  /** RWA vault APY (null if unavailable) */
+  vaultApy: number | null;
+  /** Short funding rate annualised (null if unavailable) */
+  fundingApy: number | null;
+  /** Managed Net APY = vaultApy + fundingApy */
+  managedNetApy: number | null;
+  /** Self-Custody APY = fundingApy only */
+  selfCustodyApy: number | null;
+  /** Vault AUM in USD WAD */
+  aum: bigint;
+  isLoading: boolean;
+};
+
+/** Annualise hourly cumulative funding rate stored in the Vault. */
+function annualiseFunding(hourlyRateBps: bigint): number {
+  // cumulativeFundingRate is in BPS (1 BPS = 0.01%) per hour (Vault convention).
+  // Convert to decimal per year: (rate / 10_000) * 8760
+  const hourly = Number(hourlyRateBps) / 10_000;
+  return hourly * 8_760;
+}
+
+function useFundingApy(vaultAddress: string | undefined, indexToken: string | undefined): number | null {
+  const { chainId } = useChainId();
+  const [apy, setApy] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!vaultAddress || !indexToken) return;
+
+    const provider = getProvider(undefined, chainId);
+    const vault = new Contract(vaultAddress, VaultAbi, provider);
+
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        // cumulativeFundingRate(indexToken, isLong) → BPS per hour
+        const shortRate: bigint = await vault.cumulativeFundingRate(indexToken, false);
+        if (!cancelled) setApy(annualiseFunding(shortRate));
+      } catch {
+        // Funding rate unavailable — leave null
+      }
+    }
+
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [chainId, vaultAddress, indexToken]);
+
+  return apy;
+}
+
+function useVaultAum(vaultAddress: string | undefined): { aum: bigint; isLoading: boolean } {
+  const { chainId } = useChainId();
+  const [aum, setAum] = useState(0n);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!vaultAddress) return;
+    const provider = getProvider(undefined, chainId);
+    const vault = new Contract(vaultAddress, VaultAbi, provider);
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const result: bigint = await vault.getAUM();
+        if (!cancelled) {
+          setAum(result);
+          setIsLoading(false);
+        }
+      } catch {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [chainId, vaultAddress]);
+
+  return { aum, isLoading };
+}
+
+// ── Per-vault hook (stable order) ─────────────────────────────────────────────
+
+function useHedgeItem(cfg: VaultConfig): HedgeListItem {
+  const vaultApy = useVaultApy(cfg);
+  const fundingApy = useFundingApy(cfg.vaultAddress, cfg.tokenAddress);
+  const { aum, isLoading } = useVaultAum(cfg.vaultAddress);
+
+  return useMemo<HedgeListItem>(() => {
+    const managedNetApy = vaultApy !== null && fundingApy !== null ? vaultApy + fundingApy : null;
+    const selfCustodyApy = fundingApy;
+
+    return {
+      key: cfg.key,
+      symbol: cfg.symbol,
+      name: cfg.name,
+      assetType: cfg.assetType,
+      vaultAddress: cfg.vaultAddress ?? "",
+      indexToken: cfg.tokenAddress ?? "",
+      vaultApy,
+      fundingApy,
+      managedNetApy,
+      selfCustodyApy,
+      aum,
+      isLoading,
+    };
+  }, [cfg, vaultApy, fundingApy, aum, isLoading]);
+}
+
+// ── Public hook (fixed-order: hooks must not be conditional) ──────────────────
+
+const HEDGEABLE = VAULT_CONFIGS.filter((v) => v.tokenAddress && v.vaultAddress);
+
+export function useHedgeList(): HedgeListItem[] {
+  // Hooks called in fixed order — never inside map()
+  const item0 = useHedgeItem(HEDGEABLE[0] ?? VAULT_CONFIGS[0]);
+  const item1 = useHedgeItem(HEDGEABLE[1] ?? VAULT_CONFIGS[0]);
+  const item2 = useHedgeItem(HEDGEABLE[2] ?? VAULT_CONFIGS[0]);
+  const item3 = useHedgeItem(HEDGEABLE[3] ?? VAULT_CONFIGS[0]);
+
+  return useMemo(() => [item0, item1, item2, item3].slice(0, HEDGEABLE.length), [item0, item1, item2, item3]);
+}

--- a/src/domain/vantage/hedge/useHedgeSimulator.ts
+++ b/src/domain/vantage/hedge/useHedgeSimulator.ts
@@ -1,0 +1,84 @@
+/**
+ * useHedgeSimulator.ts
+ *
+ * Computes ±20% P&L simulation data for a delta-neutral hedge position.
+ *
+ * Given:
+ *   - spotPrice  : current oracle price per RWA token (USD, WAD)
+ *   - rwaAmount  : amount of RWA tokens held (WAD)
+ *   - sizeDelta  : notional value of the short position (USD, WAD)
+ *
+ * For each price change ratio r ∈ [-0.20, +0.20]:
+ *   - spotPnl  = rwaAmount × spotPrice × r  (long spot P&L)
+ *   - shortPnl = -(sizeDelta × r)           (short position P&L)
+ *   - netPnl   = spotPnl + shortPnl         (≈ 0 when sizeDelta = rwaAmount × spotPrice)
+ */
+
+import { useMemo } from "react";
+
+export type SimPoint = {
+  /** Price change ratio, e.g. -0.20 to +0.20 */
+  r: number;
+  /** Spot (RWA holding) P&L in USD */
+  spotPnl: number;
+  /** Short position P&L in USD */
+  shortPnl: number;
+  /** Net P&L in USD */
+  netPnl: number;
+};
+
+const STEPS = 41; // -20%, -19%, ..., 0%, ..., +19%, +20%
+
+/**
+ * Returns simulation data points.
+ *
+ * @param spotPriceUsd  Current RWA price in USD (plain number)
+ * @param rwaAmount     Number of RWA tokens held (plain number)
+ * @param sizeDelta     Notional value of the short in USD (plain number)
+ */
+export function useHedgeSimulator(
+  spotPriceUsd: number | null,
+  rwaAmount: number | null,
+  sizeDelta: number | null
+): SimPoint[] {
+  return useMemo(() => {
+    if (spotPriceUsd === null || rwaAmount === null || sizeDelta === null) return [];
+
+    const points: SimPoint[] = [];
+    for (let i = 0; i < STEPS; i++) {
+      const r = -0.2 + i * (0.4 / (STEPS - 1));
+      const spotPnl = rwaAmount * spotPriceUsd * r;
+      const shortPnl = -(sizeDelta * r);
+      const netPnl = spotPnl + shortPnl;
+      points.push({ r, spotPnl, shortPnl, netPnl });
+    }
+    return points;
+  }, [spotPriceUsd, rwaAmount, sizeDelta]);
+}
+
+/**
+ * Returns SVG path data for a P&L series scaled to the given viewport.
+ *
+ * @param points   SimPoint array from useHedgeSimulator
+ * @param key      Which series to plot: "spotPnl" | "shortPnl" | "netPnl"
+ * @param width    SVG viewport width in px
+ * @param height   SVG viewport height in px
+ */
+export function buildSvgPath(
+  points: SimPoint[],
+  key: "spotPnl" | "shortPnl" | "netPnl",
+  width: number,
+  height: number
+): string {
+  if (points.length < 2) return "";
+
+  const values = points.map((p) => p[key]);
+  const minV = Math.min(...values);
+  const maxV = Math.max(...values);
+  const range = maxV - minV || 1;
+
+  const toX = (i: number) => (i / (points.length - 1)) * width;
+  const toY = (v: number) => height - ((v - minV) / range) * height;
+
+  return points.map((p, i) => `${i === 0 ? "M" : "L"} ${toX(i).toFixed(1)} ${toY(p[key]).toFixed(1)}`).join(" ");
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -6033,6 +6033,10 @@ msgstr "{gasPaymentTokensText} einzahlen"
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portugiesisch)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "{balanceFormatted} auf das Hauptkonto abgehoben"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "Abrechnung von {positionName} fehlgeschlagen"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -258,6 +258,10 @@ msgstr "Limit fehlgeschlagen"
 msgid "Performance"
 msgstr "Leistung"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "Gesamtertrag"
@@ -759,6 +763,10 @@ msgstr "1CT aktivieren"
 msgid "Realized PnL"
 msgstr "Realisierter Gewinn/Verlust"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "Hohe externe Swap-Auswirkung"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {Order} other {# Orders}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "Ungültiger Sicherheitstoken. {tokenSymbol} wird nicht als Sicherheit unterstützt"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> zu </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "Die Codeverfügbarkeit auf {0} konnte nicht überprüft werden. Sie können den Code dennoch erstellen, er könnte jedoch bereits auf diesen Netzwerken vergeben sein."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "Kaufe {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "Kaufe GM: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (Angebot)"
@@ -1478,6 +1498,7 @@ msgstr "Übersicht"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "Einzahlung auf GMX-Konto"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "Einzahlungsfehler"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "Hohe Slippage eingestellt. Aktueller Tauscheinfluss: {0}."
 msgid "Instant"
 msgstr "Sofort"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "Offene Positionen"
@@ -2943,6 +2972,10 @@ msgstr "Es ist nur ein Wrap"
 msgid "Subscribe"
 msgstr "Abonnieren"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "Dashboard für dezentrale Finanzen"
@@ -3031,6 +3064,10 @@ msgstr "Erlaube, dass {0} ausgegeben wird"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "Staken gesendet"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "Virtuelle Markt-ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Hebelwirkung"
@@ -4367,6 +4407,7 @@ msgstr "Liquidiert"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero Scan"
 msgid "Borrow fee"
 msgstr "Leihgebühr"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "Tauscheinfluss"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "TWAP erstellen"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Slippage ist die Differenz zwischen deinem erwarteten und tatsächlichen Ausführungspreis aufgrund von Preisvolatilität. Orders werden nicht ausgeführt, wenn die Slippage dein erlaubtes Maximum überschreitet. Der Standardwert kann in den Einstellungen angepasst werden.<0/><1/>Ein niedriger Wert (z. B. weniger als -{0}) kann bei Volatilität zu fehlgeschlagenen Orders führen.<2/><3/>Hinweis: Slippage unterscheidet sich vom Preis-Impact, der auf Open-Interest-Ungleichgewichten basiert. <4>Mehr erfahren</4>."
@@ -5136,6 +5186,10 @@ msgstr "Die Position würde bei Ausführung sofort liquidiert werden. Versuchen 
 msgid "Create TP/SL"
 msgstr "TP/SL erstellen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "Zweck: {0} | öffentlich: {1}"
@@ -5268,6 +5322,10 @@ msgstr "Isolierte Liquidität pro Markt bereitstellen"
 msgid "Use open interest in tokens for balance"
 msgstr "Open Interest in Token für Guthaben verwenden"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "Nahtloser Handel"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "aus Ihrer Wallet"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "Einstellungen aktualisiert"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "Abhebungsgebühr"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "Ihre Gebührenersparnisse durch Empfehlungsrabatte"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "Empfohlen"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "Verringern"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "Eingesetztes Kapital"
 msgid "AVAILABLE LIQ."
 msgstr "VERFÜGB. LIQ."
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "Aktuelle Endpunkte ({0})"
@@ -6881,6 +6952,7 @@ msgstr "Orderfehler. Die Preise in diesem Markt sind volatil, versuchen Sie es e
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Asset"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Das Abheben von {0} nach {1} wird nicht unterstützt"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "Balance"
 msgid "Force failures"
 msgstr "Fehler erzwingen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "Handelsfehler"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "Ein- und Auszahlung vom GMX Account..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "Gestaktes GMX"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "Open Interest Reservefaktor Shorts"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "Swap {fromAmount} für {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Betrag"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "Einzahlung fehlgeschlagen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "GESCH. PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Benachrichtigungen"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "Betrag eingeben"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "SL-Preis über dem Limitpreis"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "Protokoll-Analytik"
 msgid "Show positions on chart"
 msgstr "Positionen im Chart anzeigen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "Positionsgröße übersteigt das verfügbare Open Interest. Delta: {usdD
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "Ja"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "Erhalten Sie Benachrichtigungen und Ankündigungen von GMX, um über Ihr
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} erfolgreich gekauft, aber die Bridge zu Base ist fehlgeschlagen. Ihre Mittel sind sicher in Ihrem GMX Account. Versuchen Sie die Bridge erneut oder gehen Sie zum {indexName}-Pool, um Ihre GM-Token abzuheben."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) ist die verbesserte Version von GLP in GMX V2. Es ist ein renditeoptimierender Kryptoindextoken, der:"
@@ -9959,6 +10076,10 @@ msgstr "{0} Token wurden aus den {1} für das Vesting eingezahlten esGMX in GMX 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Auslösepreis über dem Liquidationspreis"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "Als CSV herunterladen"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "Profitieren Sie von bis zu 100-fachem Hebel und garantierter On-Chain-Liquidität, die nicht von der Orderbuchtiefe abhängig ist"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 20-27 Mär"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "Mind. erforderliche Sicherheit"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "{orderText}-Aktualisierung fehlgeschlagen"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -258,6 +258,10 @@ msgstr "Failed Limit"
 msgid "Performance"
 msgstr "Performance"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr "Spot Value"
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "Total earned"
@@ -759,6 +763,10 @@ msgstr "Activate 1CT"
 msgid "Realized PnL"
 msgstr "Realized PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr "Managed Hedge"
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "High external swap impact"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {Order} other {# Orders}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr "No hedgeable vaults configured. Deploy contracts first."
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> to </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr "Short position requests are executed by Keepers (GMX V1 two-step flow)."
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "Buy {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "Buy GM: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr "±20% P&L Simulation"
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (Supply)"
@@ -1478,6 +1498,7 @@ msgstr "Overview"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "Deposit to GMX Account"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "Deposit error"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr "Spot (long)"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "High slippage set. Current swap impact: {0}."
 msgid "Instant"
 msgstr "Instant"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "Open positions"
@@ -2943,6 +2972,10 @@ msgstr "It's just a wrap"
 msgid "Subscribe"
 msgstr "Subscribe"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr "Asset not found."
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "Decentralized finance dashboard"
@@ -3031,6 +3064,10 @@ msgstr "Allow {0} to be spent"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "Stake submitted"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr "Net"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "Virtual market ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Leverage"
@@ -4367,6 +4407,7 @@ msgstr "Liquidated"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "Borrow fee"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr "Short Size"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "Swap impact"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "Create TWAP"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr "Hold RWA in your wallet, open short only"
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
@@ -5136,6 +5186,10 @@ msgstr "Position would be immediately liquidated upon execution. Try reducing th
 msgid "Create TP/SL"
 msgstr "Create TP/SL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr "Short Margin"
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "Purpose: {0} | public: {1}"
@@ -5268,6 +5322,10 @@ msgstr "Provide isolated liquidity per market"
 msgid "Use open interest in tokens for balance"
 msgstr "Use open interest in tokens for balance"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr "Deposit RWA to Vault + open short in one transaction"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "Seamless trading"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "from your wallet"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr "Delta-neutral strategy — coming soon."
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr "Delta-neutral strategy — coming soon."
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "Settings updated"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "Withdraw fee"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "Your fee savings from referral discounts"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr "Required"
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "Recommended"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "Decrease"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr "Price change"
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "Capital used"
 msgid "AVAILABLE LIQ."
 msgstr "AVAILABLE LIQ."
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "Current endpoints ({0})"
@@ -6881,6 +6952,7 @@ msgstr "Order error. Prices are volatile for this market, try again by <0>increa
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Asset"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Withdrawing {0} to {1} is not supported"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr "Back to Hedge"
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "Balance"
 msgid "Force failures"
 msgstr "Force failures"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr "1× = delta-neutral. Higher = partial hedge."
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "Trade errors"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "Depositing to and withdrawing from GMX Account..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr "Keep {0} in your wallet and open a short position only."
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "Staked GMX"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "Open interest reserve factor shorts"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr "Transaction submitted:"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "Swap {fromAmount} for {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Amount"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "Deposit failed"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr "Enter an amount to see the P&L simulation."
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "EST. PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Notifications"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr "Managed Net APY"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "Enter an amount"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "SL price above limit price"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr "Self-Custody"
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "Protocol analytics"
 msgid "Show positions on chart"
 msgstr "Show positions on chart"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr "Hedge"
@@ -8608,6 +8717,10 @@ msgstr "Position size exceeds available open interest. Delta: {usdDeltaText}, ma
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "Yes"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr "Self-Custody Hedge"
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "Get alerts and announcements from GMX to stay on top of your trades, liq
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
@@ -9959,6 +10076,10 @@ msgstr "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Trigger price above liquidation price"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr "Self-Custody APY"
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "Download as CSV"
 msgid "Set Short Stop Market @ {0}"
 msgstr "Set Short Stop Market @ {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr "Connect wallet to hedge"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 20-27 Mar"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr "Vault APY"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr "Managed"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "Min. required collateral"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "{orderText} update failed"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr "Mode"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -6033,6 +6033,10 @@ msgstr "Deposit {gasPaymentTokensText}"
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portuguese)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr "Oracle Price"
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "Withdrawn {balanceFormatted} to main account"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName} failed to settle"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr "Fetching price…"
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -258,6 +258,10 @@ msgstr "Límite Fallido"
 msgid "Performance"
 msgstr "Rendimiento"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "Total obtenido"
@@ -759,6 +763,10 @@ msgstr "Activar 1CT"
 msgid "Realized PnL"
 msgstr "PnL Realizado"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "Alto impacto de swap externo"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {Orden} other {# Órdenes}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "Token de garantía no válido. {tokenSymbol} no es compatible como garantía"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> a </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "No se ha podido verificar la disponibilidad del código en {0}. Aún puede crear el código, pero es posible que ya esté en uso en esas redes."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "Comprar {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "Comprar GM: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (Suministro)"
@@ -1478,6 +1498,7 @@ msgstr "Resumen"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "Depositar en Cuenta GMX"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "Error de depósito"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "Deslizamiento alto establecido. Impacto actual del intercambio: {0}."
 msgid "Instant"
 msgstr "Instantáneo"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "Posiciones abiertas"
@@ -2943,6 +2972,10 @@ msgstr "Es solo un wrap"
 msgid "Subscribe"
 msgstr "Suscribirse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "Panel de finanzas descentralizadas"
@@ -3031,6 +3064,10 @@ msgstr "Permitir gastar {0}"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "Stake enviado"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "ID de mercado virtual"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Apalancamiento"
@@ -4367,6 +4407,7 @@ msgstr "Liquidado"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "Comisión de préstamo"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "Impacto del intercambio"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "Crear TWAP"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "El deslizamiento es la diferencia entre el precio de ejecución esperado y el real debido a la volatilidad del precio. Las órdenes no se ejecutarán si el deslizamiento supera tu máximo permitido. El valor predeterminado puede ajustarse en la configuración.<0/><1/>Un valor bajo (por ejemplo, menos de -{0}) puede causar órdenes fallidas durante la volatilidad.<2/><3/>Nota: el deslizamiento es diferente del impacto en el precio, que se basa en desequilibrios del interés abierto. <4>Más información</4>."
@@ -5136,6 +5186,10 @@ msgstr "La posición sería liquidada inmediatamente tras la ejecución. Intente
 msgid "Create TP/SL"
 msgstr "Crear TP/SL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "Propósito: {0} | público: {1}"
@@ -5268,6 +5322,10 @@ msgstr "Proporcione liquidez aislada por mercado"
 msgid "Use open interest in tokens for balance"
 msgstr "Usar interés abierto en tokens para el saldo"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "Trading sin interrupciones"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "desde tu billetera"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "Configuración actualizada"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "Comisión de retirada"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "Su ahorro en comisiones por descuentos de referido"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "Recomendado"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "Reducir"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "Capital utilizado"
 msgid "AVAILABLE LIQ."
 msgstr "LIQ. DISPONIBLE"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "Endpoints actuales ({0})"
@@ -6881,6 +6952,7 @@ msgstr "Error de orden. Los precios son volátiles en este mercado, inténtelo d
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Activo"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "La retirada de {0} a {1} no está soportada"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "Balance"
 msgid "Force failures"
 msgstr "Forzar fallos"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "Errores de operación"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "Depositando y retirando de GMX Account..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "GMX en staking"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "Factor de reserva de interés abierto para cortos"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "Intercambiar {fromAmount} por {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Importe"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "Depósito fallido"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "PNL EST."
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Notificaciones"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "Introduzca una cantidad"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "Precio de SL por encima del precio límite"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "Análisis de datos del protocolo"
 msgid "Show positions on chart"
 msgstr "Mostrar posiciones en el gráfico"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "El tamaño de la posición excede el interés abierto disponible. Delta:
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "Sí"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "Reciba alertas y anuncios de GMX para estar al día de sus operaciones, 
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} comprado con éxito, pero el puente a Base ha fallado. Sus fondos están seguros en su GMX Account. Reintente el puente o vaya al pool {indexName} para retirar sus tokens GM."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) es la versión mejorada de GLP en GMX V2. Es un token de criptoíndice que optimiza el rendimiento y que:"
@@ -9959,6 +10076,10 @@ msgstr "{0} tokens convertidos a GMX de los {1} esGMX depositados para el period
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "El precio de activación está por encima del precio de liquidación"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "Descargar como CSV"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "Benefíciese de hasta 100x de apalancamiento y liquidez garantizada en cadena que no depende de la profundidad del libro de órdenes"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 20-27 Mar"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "Garantía mínima requerida"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "Error al actualizar {orderText}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -6033,6 +6033,10 @@ msgstr "Depositar {gasPaymentTokensText}"
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portugués)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "{balanceFormatted} retirados a la cuenta principal"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName} no se ha podido liquidar"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -258,6 +258,10 @@ msgstr "Limite échouée"
 msgid "Performance"
 msgstr "Performance"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "Total gagné"
@@ -759,6 +763,10 @@ msgstr "Activer 1CT"
 msgid "Realized PnL"
 msgstr "PnL réalisé"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "Impact d'échange externe élevé"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {Ordre} other {# Ordres}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "Token de garantie invalide. {tokenSymbol} n'est pas pris en charge comme garantie"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> à </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "Impossible de vérifier la disponibilité du code sur {0}. Vous pouvez tout de même créer le code, mais il est possible qu'il soit déjà pris sur ces réseaux."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "Acheter {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "Acheter GM : {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (Supply)"
@@ -1478,6 +1498,7 @@ msgstr "Aperçu"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "Dépôt sur le Compte GMX"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "Erreur de dépôt"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "Glissement élevé défini. Impact actuel de l'échange : {0}."
 msgid "Instant"
 msgstr "Instantané"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "Positions ouvertes"
@@ -2943,6 +2972,10 @@ msgstr "C'est un simple wrap"
 msgid "Subscribe"
 msgstr "S'abonner"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "Tableau de bord de la finance décentralisée"
@@ -3031,6 +3064,10 @@ msgstr "Autoriser {0} à être dépensé"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "Staking soumis"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "ID de marché virtuel"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Levier"
@@ -4367,6 +4407,7 @@ msgstr "Liquidé"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "Explorateur LayerZero"
 msgid "Borrow fee"
 msgstr "Frais d'emprunt"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "Impact du swap"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "Créer TWAP"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Le slippage est la différence entre le prix d'exécution attendu et réel due à la volatilité des prix. Les ordres ne s'exécuteront pas si le slippage dépasse votre maximum autorisé. La valeur par défaut peut être ajustée dans les paramètres.<0/><1/>Une valeur faible (par ex. moins de -{0}) peut entraîner des ordres échoués pendant la volatilité.<2/><3/>Note : le slippage est différent de l'impact sur le prix, qui est basé sur les déséquilibres de l'intérêt ouvert. <4>En savoir plus</4>."
@@ -5136,6 +5186,10 @@ msgstr "La position serait immédiatement liquidée à l'exécution. Essayez de 
 msgid "Create TP/SL"
 msgstr "Créer un Take-Profit/Stop-Loss"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "Objet : {0} | public : {1}"
@@ -5268,6 +5322,10 @@ msgstr "Fournir de la liquidité isolée par marché"
 msgid "Use open interest in tokens for balance"
 msgstr "Utiliser les positions ouvertes en tokens pour le solde"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "Trading fluide"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "depuis votre portefeuille"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "Paramètres mis à jour"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "Frais de retrait"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "Vos économies de frais grâce aux remises de parrainage"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "Recommandé"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "Diminuer"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "Capital utilisé"
 msgid "AVAILABLE LIQ."
 msgstr "LIQ. DISPONIBLE"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "Points de terminaison actuels ({0})"
@@ -6881,6 +6952,7 @@ msgstr "Erreur d'ordre. Les prix sont volatils pour ce marché, réessayez en <0
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Actif"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Le retrait de {0} vers {1} n'est pas pris en charge"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "Solde"
 msgid "Force failures"
 msgstr "Forcer les échecs"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "Erreurs de trading"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "Dépôt et retrait du GMX Account en cours..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "GMX stakés"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "Facteur de réserve des positions ouvertes pour les shorts"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "Échanger {fromAmount} pour {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Montant"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "Dépôt échoué"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "PNL EST."
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Notifications"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "Entrez un montant"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "Prix du SL au-dessus du prix limite"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "Analyses du protocole"
 msgid "Show positions on chart"
 msgstr "Afficher les positions sur le graphique"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "La taille de la position dépasse les positions ouvertes disponibles. De
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "Oui"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "Recevez des alertes et des annonces de GMX pour suivre vos transactions,
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} acheté avec succès, mais le pont vers Base a échoué. Vos fonds sont en sécurité dans votre GMX Account. Réessayez le pont ou accédez au pool {indexName} pour retirer vos jetons GM."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) est la version améliorée de GLP dans GMX V2. C'est un jeton crypto-indice optimisant le rendement qui :"
@@ -9959,6 +10076,10 @@ msgstr "{0} jetons convertis en GMX à partir des {1} esGMX déposés pour l'acq
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Prix de déclenchement supérieur au prix de liquidation"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "Télécharger en CSV"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "Bénéficiez d'un effet de levier jusqu'à 100x et d'une liquidité on-chain garantie, indépendante de la profondeur du carnet d'ordres"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 20-27 Mar"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "Garantie minimale requise"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "Échec de la mise à jour de {orderText}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -6033,6 +6033,10 @@ msgstr "Déposer {gasPaymentTokensText}"
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portugais)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "{balanceFormatted} retiré vers le compte principal"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "Le règlement de {positionName} a échoué"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -6033,6 +6033,10 @@ msgstr "{gasPaymentTokensText}を入金"
 msgid "GMX (Portuguese)"
 msgstr "GMX (ポルトガル語)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "{balanceFormatted}をメインアカウントに出金しました"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName}の決済に失敗しました"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -258,6 +258,10 @@ msgstr "指値失敗"
 msgid "Performance"
 msgstr "パフォーマンス"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "合計獲得額"
@@ -759,6 +763,10 @@ msgstr "1CTを有効化"
 msgid "Realized PnL"
 msgstr "実現PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "高い外部スワップ影響"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {注文} other {# 注文}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "無効な担保トークンです。{tokenSymbol}は担保としてサポートされていません"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> から </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "{0}でコードの利用可能性を確認できません。コードは作成できますが、それらのネットワークでは既に使用されている可能性があります。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "{operationTokenSymbol}を購入"
 msgid "Buy GM: {0}"
 msgstr "GMを購入: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (供給)"
@@ -1478,6 +1498,7 @@ msgstr "概要"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "GMXアカウントに入金"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "入金エラー"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "高いスリッページが設定されています。現在のスワッ
 msgid "Instant"
 msgstr "即時"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "オープンポジション"
@@ -2943,6 +2972,10 @@ msgstr "ラップのみです"
 msgid "Subscribe"
 msgstr "購読"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "分散型金融ダッシュボード"
@@ -3031,6 +3064,10 @@ msgstr "{0}の支出を許可"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "ステークが送信されました"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "仮想マーケットID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "レバレッジ"
@@ -4367,6 +4407,7 @@ msgstr "清算済"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "借入手数料"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "スワップへの影響"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "TWAPを作成"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "スリッページとは、価格変動により予想約定価格と実際の約定価格の差です。スリッページが許容最大値を超えると注文は約定されません。デフォルト値は設定で調整できます。<0/><1/>低い値（例：-{0}未満）は、ボラティリティ時に注文失敗の原因となる場合があります。<2/><3/>注：スリッページは、オープンインタレストの不均衡に基づく価格影響とは異なります。<4>詳細はこちら</4>。"
@@ -5136,6 +5186,10 @@ msgstr "ポジションは約定時に即座に清算されます。サイズを
 msgid "Create TP/SL"
 msgstr "テイクプロフィット/ストップロスを作成"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "用途: {0} | public: {1}"
@@ -5268,6 +5322,10 @@ msgstr "マーケットごとに独立した流動性を提供"
 msgid "Use open interest in tokens for balance"
 msgstr "残高に建玉をトークン単位で使用"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "シームレスな取引"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "ウォレットから"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "設定が更新されました"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "出金手数料"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "リファラル割引による手数料の節約額"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "おすすめ"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "減少"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "使用資本"
 msgid "AVAILABLE LIQ."
 msgstr "利用可能流動性"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "現在のエンドポイント ({0})"
@@ -6881,6 +6952,7 @@ msgstr "注文エラー。この市場の価格は不安定です。<0>許容ス
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "資産"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "{0}の{1}への出金はサポートされていません"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "残高"
 msgid "Force failures"
 msgstr "強制エラー"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "取引エラー"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "GMX Accountへの入金および出金中..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "ステーキング中のGMX"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "建玉リザーブファクター（ショート）"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "{fromAmount} を {toAmount} にスワップ"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金額"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "入金に失敗しました"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "予想PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "通知"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "額を入力"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "SL価格がリミット価格を上回っています"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "プロトコルの分析"
 msgid "Show positions on chart"
 msgstr "チャートにポジションを表示"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "ポジションサイズが利用可能な建玉を超えています。
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "はい"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "GMXからのアラートとお知らせを受け取り、取引や清算
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel}の購入は完了しましたが、Baseへのブリッジに失敗しました。資金はGMX Accountに安全に保管されています。ブリッジを再試行するか、{indexName}プールに移動してGMトークンを出金してください。"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) はGMX V2におけるGLPの改良版です。利回りを最適化する暗号資産インデックストークンであり:"
@@ -9959,6 +10076,10 @@ msgstr "ベスティング用に預け入れた{1} esGMXのうち、{0}トーク
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "トリガー価格が清算価格を上回っています"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "CSV としてダウンロード"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "最大100倍のレバレッジと、オーダーブックの厚みに依存しないオンチェーン流動性の保証を活用できます"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844、3月20-27日"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "最低必要担保"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "{orderText}の更新に失敗しました"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -6033,6 +6033,10 @@ msgstr "{gasPaymentTokensText} 입금"
 msgid "GMX (Portuguese)"
 msgstr "GMX (포르투갈어)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "메인 계좌로 {balanceFormatted} 출금 완료"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName} 정산 실패"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -258,6 +258,10 @@ msgstr "지정가 실패"
 msgid "Performance"
 msgstr "성과"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "총 수익"
@@ -759,6 +763,10 @@ msgstr "1CT 활성화"
 msgid "Realized PnL"
 msgstr "실현 PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "높은 외부 스왑 영향"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {주문} other {# 주문}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "유효하지 않은 담보 토큰입니다. {tokenSymbol}은(는) 담보로 지원되지 않습니다"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> to </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "{0}에서 코드 가용성을 확인할 수 없습니다. 코드를 생성할 수는 있으나, 해당 네트워크에서 이미 사용 중일 수 있습니다."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "{operationTokenSymbol} 구매"
 msgid "Buy GM: {0}"
 msgstr "GM 구매: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (공급)"
@@ -1478,6 +1498,7 @@ msgstr "개요"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "GMX 계정에 입금"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "입금 오류"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "높은 슬리피지가 설정되었습니다. 현재 스왑 영향: {0}.
 msgid "Instant"
 msgstr "즉시"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "오픈 포지션"
@@ -2943,6 +2972,10 @@ msgstr "단순 래핑입니다"
 msgid "Subscribe"
 msgstr "구독"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "탈중앙화 금융 대시보드"
@@ -3031,6 +3064,10 @@ msgstr "{0} 지출 허용"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "스테이킹이 제출되었습니다"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "가상 마켓 ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "레버리지"
@@ -4367,6 +4407,7 @@ msgstr "청산됨"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "차입 수수료"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "스왑 영향"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "TWAP 생성"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "슬리피지는 가격 변동성으로 인해 예상 체결 가격과 실제 체결 가격의 차이입니다. 슬리피지가 허용 최대값을 초과하면 주문이 체결되지 않습니다. 기본값은 설정에서 조정할 수 있습니다.<0/><1/>낮은 값(예: -{0} 미만)은 변동성이 높을 때 주문 실패를 유발할 수 있습니다.<2/><3/>참고: 슬리피지는 미결제약정 불균형에 기반한 가격 영향과 다릅니다. <4>자세히 보기</4>."
@@ -5136,6 +5186,10 @@ msgstr "체결 시 포지션이 즉시 청산됩니다. 크기를 줄여보십�
 msgid "Create TP/SL"
 msgstr "TP/SL 생성"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "용도: {0} | public: {1}"
@@ -5268,6 +5322,10 @@ msgstr "마켓별 격리 유동성 제공"
 msgid "Use open interest in tokens for balance"
 msgstr "잔액에 토큰 단위 미결제약정 사용"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "원활한 거래"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "지갑에서"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "설정이 업데이트되었습니다"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "출금 수수료"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "추천 할인을 통한 수수료 절감액"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "추천"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "감소"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "사용 자본"
 msgid "AVAILABLE LIQ."
 msgstr "사용 가능 유동성"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "현재 엔드포인트 ({0})"
@@ -6881,6 +6952,7 @@ msgstr "주문 오류. 이 마켓의 가격 변동성이 높습니다. <0>허용
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "자산"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "{0}을(를) {1}(으)로 출금하는 것은 지원되지 않습니다"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "잔고"
 msgid "Force failures"
 msgstr "강제 실패"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "거래 오류"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "GMX Account 입금 및 출금 중..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "스테이킹된 GMX"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "숏 미결제약정 준비금 비율"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "{fromAmount}을 {toAmount}으로 스왑"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "수량"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "입금 실패"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "예상 PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "알림"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "금액 입력"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "SL 가격이 지정가보다 높습니다"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "프로토콜 분석"
 msgid "Show positions on chart"
 msgstr "차트에 포지션 표시"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "포지션 규모가 가용 미결제약정을 초과합니다. 델타: {
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "예"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "GMX에서 알림 및 공지를 받아 거래, 청산 위험 등을 관�
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} 구매에 성공했으나 Base로의 브릿지가 실패했습니다. 자금은 GMX Account에 안전하게 보관되어 있습니다. 브릿지를 재시도하거나 {indexName} 풀로 이동하여 GM 토큰을 출금하십시오."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults)는 GMX V2의 개선된 GLP 버전입니다. 수익률을 최적화하는 암호화폐 인덱스 토큰으로:"
@@ -9959,6 +10076,10 @@ msgstr "베스팅을 위해 예치된 {1} esGMX 중 {0} 토큰이 GMX로 전환�
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "조건가가 청산가보다 높습니다"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "CSV로 다운로드"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "최대 100배 레버리지와 오더북 깊이에 의존하지 않는 온체인 보장 유동성을 활용하십시오"
@@ -10742,6 +10867,15 @@ msgstr "레이지 트레이드"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 3월 20-27일"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "최소 필수 담보"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "{orderText} 업데이트에 실패했습니다"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -6033,6 +6033,10 @@ msgstr ""
 msgid "GMX (Portuguese)"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10091,6 +10095,10 @@ msgstr ""
 
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
 msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -258,6 +258,10 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr ""
@@ -759,6 +763,10 @@ msgstr ""
 msgid "Realized PnL"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr ""
@@ -827,6 +835,10 @@ msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
 msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
@@ -1044,6 +1056,10 @@ msgstr ""
 #: src/components/Referrals/AddAffiliateCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
@@ -1394,6 +1410,10 @@ msgstr ""
 msgid "Buy GM: {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr ""
@@ -1478,6 +1498,7 @@ msgstr ""
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1588,6 +1609,10 @@ msgstr ""
 #: src/domain/synthetics/markets/createDepositTxn.ts
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
 msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr ""
 msgid "Instant"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr ""
@@ -2943,6 +2972,10 @@ msgstr ""
 msgid "Subscribe"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr ""
@@ -3030,6 +3063,10 @@ msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
 msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
@@ -3866,6 +3903,7 @@ msgstr ""
 msgid "Avalanche"
 msgstr ""
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr ""
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr ""
@@ -4367,6 +4407,7 @@ msgstr ""
 msgid "Blueberry Pulse"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr ""
 msgid "Borrow fee"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr ""
@@ -4977,6 +5023,10 @@ msgstr ""
 msgid "Create TWAP"
 msgstr ""
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr ""
@@ -5136,6 +5186,10 @@ msgstr ""
 msgid "Create TP/SL"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr ""
@@ -5268,6 +5322,10 @@ msgstr ""
 msgid "Use open interest in tokens for balance"
 msgstr ""
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr ""
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr ""
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5641,6 +5700,10 @@ msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
 msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
@@ -6090,6 +6153,10 @@ msgstr ""
 #: src/components/TradeInfoIcon/TradeInfoIcon.tsx
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
 msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -6823,6 +6890,10 @@ msgstr ""
 msgid "AVAILABLE LIQ."
 msgstr ""
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr ""
@@ -6881,6 +6952,7 @@ msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr ""
@@ -7194,6 +7266,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
 msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
@@ -7692,6 +7768,10 @@ msgstr ""
 msgid "Force failures"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7762,6 +7842,10 @@ msgstr ""
 
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
 msgstr ""
 
 #: src/config/uiFlagEvents.tsx
@@ -7847,6 +7931,14 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -8019,6 +8111,7 @@ msgstr ""
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr ""
@@ -8073,6 +8166,10 @@ msgstr ""
 msgid "Deposit failed"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr ""
@@ -8101,6 +8198,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
 msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
@@ -8148,6 +8249,11 @@ msgstr ""
 
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
 msgstr ""
 
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr ""
 msgid "Show positions on chart"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8607,6 +8716,10 @@ msgstr ""
 
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
 msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
@@ -9947,6 +10060,10 @@ msgstr ""
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr ""
@@ -9958,6 +10075,10 @@ msgstr ""
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
 msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
@@ -10605,6 +10726,10 @@ msgstr ""
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr ""
@@ -10741,6 +10866,15 @@ msgstr ""
 
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11318,6 +11452,10 @@ msgstr ""
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
 msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -258,6 +258,10 @@ msgstr "Лимит не удался"
 msgid "Performance"
 msgstr "Производительность"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "Всего заработано"
@@ -759,6 +763,10 @@ msgstr "Активировать 1CT"
 msgid "Realized PnL"
 msgstr "Реализованная PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "Высокое влияние внешнего свопа"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {Ордер} other {# Ордеров}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "Некорректный токен обеспечения. {tokenSymbol} не поддерживается в качестве обеспечения"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> до </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "Не удалось проверить доступность кода на {0}. Вы всё равно можете создать код, но он может быть уже занят в этих сетях."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "Купить {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "Купить GM: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (Поставка)"
@@ -1478,6 +1498,7 @@ msgstr "Обзор"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "Внести на счет GMX"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "Ошибка депозита"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "Установлено высокое проскальзывание. Т
 msgid "Instant"
 msgstr "Мгновенно"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "Открытые позиции"
@@ -2943,6 +2972,10 @@ msgstr "Это просто wrap"
 msgid "Subscribe"
 msgstr "Подписаться"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "Панель управления децентрализованными финансами"
@@ -3031,6 +3064,10 @@ msgstr "Разрешить тратить {0}"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "Запрос на стейкинг отправлен"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "Виртуальный ID рынка"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Плечо"
@@ -4367,6 +4407,7 @@ msgstr "Ликвидировано"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "Комиссия за заимствование"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "Влияние свопа на цену"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "Создать TWAP"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "Проскальзывание — это разница между ожидаемой и фактической ценой исполнения из-за волатильности. Ордера не будут исполнены, если проскальзывание превысит максимально допустимое значение. Значение по умолчанию можно изменить в настройках.<0/><1/>Низкое значение (например, менее -{0}) может привести к неисполненным ордерам при волатильности.<2/><3/>Примечание: проскальзывание отличается от влияния на цену, которое основано на дисбалансе открытого интереса. <4>Подробнее</4>."
@@ -5136,6 +5186,10 @@ msgstr "Позиция будет немедленно ликвидирован�
 msgid "Create TP/SL"
 msgstr "Создать TP/SL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "Назначение: {0} | публичный: {1}"
@@ -5268,6 +5322,10 @@ msgstr "Предоставление изолированной ликвидно
 msgid "Use open interest in tokens for balance"
 msgstr "Использовать открытый интерес в токенах для баланса"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "Бесшовная торговля"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "из вашего кошелька"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "Настройки обновлены"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "Комиссия за вывод"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "Ваша экономия на комиссиях от реферальных скидок"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "Рекомендуемые"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "Уменьшить"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "Задействованный капитал"
 msgid "AVAILABLE LIQ."
 msgstr "ДОСТУПНАЯ ЛИКВ."
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "Текущие конечные точки ({0})"
@@ -6881,6 +6952,7 @@ msgstr "Ошибка ордера. Цены на этом рынке неста�
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "Актив"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Вывод {0} на {1} не поддерживается"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "Баланс"
 msgid "Force failures"
 msgstr "Принудительные сбои"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "Ошибки торговли"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "Пополнение и вывод средств из GMX Account..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "GMX в стейкинге"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "Резервный фактор открытого интереса для шортов"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "Обмен {fromAmount} на {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Сумма"
@@ -8073,6 +8166,10 @@ msgstr "{0}мс"
 msgid "Deposit failed"
 msgstr "Внесение не удалось"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "РАСЧ. PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Уведомления"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "Введите сумму"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "Цена SL выше лимитной цены"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "Аналитика протокола"
 msgid "Show positions on chart"
 msgstr "Показать позиции на графике"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "Размер позиции превышает доступный отк
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "Да"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "Получайте оповещения и уведомления от G
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} успешно куплены, но мост на Base не удался. Ваши средства в безопасности в вашем GMX Account. Повторите мост или перейдите в пул {indexName}, чтобы вывести свои GM токены."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) — это улучшенная версия GLP в GMX V2. Это крипто-индексный токен с оптимизацией доходности, который:"
@@ -9959,6 +10076,10 @@ msgstr "{0} токенов конвертировано в GMX из {1} esGMX, �
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Цена активации выше цены ликвидации"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "Скачать как CSV"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "Воспользуйтесь кредитным плечом до 100x и гарантированной ликвидностью на блокчейне, не зависящей от глубины книги ордеров"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 20-27 марта"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "Мин. требуемое обеспечение"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "Не удалось обновить {orderText}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -6033,6 +6033,10 @@ msgstr "Внести {gasPaymentTokensText}"
 msgid "GMX (Portuguese)"
 msgstr "GMX (Португальский)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "Выведено {balanceFormatted} на основной аккаунт
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName} — ошибка расчёта"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -258,6 +258,10 @@ msgstr "限價單失敗"
 msgid "Performance"
 msgstr "績效"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "總收益"
@@ -759,6 +763,10 @@ msgstr "啟用 1CT"
 msgid "Realized PnL"
 msgstr "已實現 PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "外部兌換影響過高"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {訂單} other {# 筆訂單}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "抵押品代幣無效。{tokenSymbol} 不支援作為抵押品"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> 至 </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "無法在 {0} 上驗證代碼是否可用。您仍然可以建立代碼，但該代碼在這些網路上可能已被使用。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "購買 {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "購買 GM：{0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL（供應量）"
@@ -1478,6 +1498,7 @@ msgstr "概覽"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "存入至 GMX Account"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "存入錯誤"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "設定了較高的滑點。目前兌換影響：{0}。"
 msgid "Instant"
 msgstr "即時"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "未平倉位"
@@ -2943,6 +2972,10 @@ msgstr "這只是一個包裝操作"
 msgid "Subscribe"
 msgstr "訂閱"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "去中心化金融儀表板"
@@ -3031,6 +3064,10 @@ msgstr "授權使用 {0}"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "質押已提交"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "虛擬市場 ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "槓桿"
@@ -4367,6 +4407,7 @@ msgstr "已清算"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "借貸費用"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "兌換影響"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "建立 TWAP"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "滑點是由於價格波動導致您的預期成交價格與實際成交價格之間的差異。若滑點超過您設定的最大容許值，訂單將不會執行。預設值可在設定中調整。<0/><1/>過低的值（例如低於 -{0}）可能導致在波動期間訂單失敗。<2/><3/>注意：滑點不同於價格影響，後者是基於未平倉量的不平衡。<4>閱讀更多</4>。"
@@ -5136,6 +5186,10 @@ msgstr "倉位在執行後將立即被清算。請嘗試減少規模。"
 msgid "Create TP/SL"
 msgstr "建立 TP/SL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "用途：{0} | 公開：{1}"
@@ -5268,6 +5322,10 @@ msgstr "為每個市場提供逐倉流動性"
 msgid "Use open interest in tokens for balance"
 msgstr "使用代幣未平倉量計算餘額"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "無縫交易"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "從您的錢包"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "設定已更新"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "提取手續費"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "您透過推薦折扣節省的手續費"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "推薦"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "減倉"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "使用資金"
 msgid "AVAILABLE LIQ."
 msgstr "可用流動性"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "目前端點 ({0})"
@@ -6881,6 +6952,7 @@ msgstr "訂單錯誤。此市場價格波動劇烈，請嘗試<0>提高允許的
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "資產"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "不支援將 {0} 提取至 {1}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "餘額"
 msgid "Force failures"
 msgstr "強制失敗"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "交易錯誤"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "正在存入和提取 GMX Account..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "已質押 GMX"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "做空未平倉量儲備因子"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "將 {fromAmount} 兌換為 {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金額"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "存入失敗"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "預估 PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "通知"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "請輸入數量"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "止損價格高於限價"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "協議分析"
 msgid "Show positions on chart"
 msgstr "在圖表上顯示倉位"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "倉位規模超過可用未平倉量。差額：{usdDeltaText}，最大 
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "是"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "獲取 GMX 的提醒和公告，隨時掌握您的交易、清算風險�
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} 買入成功，但橋接至 Base 失敗。您的資金安全存放在您的 GMX Account 中。請重試橋接，或前往 {indexName} 池提取您的 GM 代幣。"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV（GMX Liquidity Vaults）是 GMX V2 對 GLP 的改良版本。這是一種收益優化的加密指數代幣，能夠："
@@ -9959,6 +10076,10 @@ msgstr "{0} 個代幣已從存入歸屬期的 {1} esGMX 轉換為 GMX。"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "觸發價格高於清算價格"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "下載為 CSV"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "享受最高 100 倍槓桿以及不依賴訂單簿深度的鏈上保證流動性"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 20-27 Mar"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "最低所需抵押品"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "{orderText} 更新失敗"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -6033,6 +6033,10 @@ msgstr "存入 {gasPaymentTokensText}"
 msgid "GMX (Portuguese)"
 msgstr "GMX（葡萄牙語）"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "已提取 {balanceFormatted} 至主帳戶"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName} 結算失敗"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -6033,6 +6033,10 @@ msgstr "存入 {gasPaymentTokensText}"
 msgid "GMX (Portuguese)"
 msgstr "GMX (葡萄牙语)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Oracle Price"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "No eligible trades during the competition window"
@@ -10092,6 +10096,10 @@ msgstr "已提取 {balanceFormatted} 至主账户"
 #: src/components/StatusNotification/FeesSettlementStatusNotification.tsx
 msgid "{positionName} failed to settle"
 msgstr "{positionName} 结算失败"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Fetching price…"
+msgstr ""
 
 #: src/pages/Ecosystem/Ecosystem.tsx
 msgid "Ecosystem projects"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -258,6 +258,10 @@ msgstr "限价失败"
 msgid "Performance"
 msgstr "表现"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot Value"
+msgstr ""
+
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Total earned"
 msgstr "总收益"
@@ -759,6 +763,10 @@ msgstr "激活 1CT"
 msgid "Realized PnL"
 msgstr "已实现盈亏"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Managed Hedge"
+msgstr ""
+
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High external swap impact"
 msgstr "高外部交换影响"
@@ -828,6 +836,10 @@ msgstr "{actionsCount, plural, one {订单} other {# 个订单}}"
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Invalid collateral token. {tokenSymbol} isn't supported as collateral"
 msgstr "抵押品代币无效。{tokenSymbol} 不支持作为抵押品"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "No hedgeable vaults configured. Deploy contracts first."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -1045,6 +1057,10 @@ msgstr "{0} <0/><1> 到 </1>{1} <2/>"
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "Unable to verify code availability on {0}. You can still create the code, but it may already be taken on those networks."
 msgstr "无法在 {0} 上验证代码可用性。您仍可创建该代码，但在这些网络上可能已被占用。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short position requests are executed by Keepers (GMX V1 two-step flow)."
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Deposit completed"
@@ -1394,6 +1410,10 @@ msgstr "购买 {operationTokenSymbol}"
 msgid "Buy GM: {0}"
 msgstr "购买 GM: {0}"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "±20% P&L Simulation"
+msgstr ""
+
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "TVL (Supply)"
 msgstr "TVL (供应)"
@@ -1478,6 +1498,7 @@ msgstr "概述"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Collateral"
@@ -1589,6 +1610,10 @@ msgstr "存入 GMX 账户"
 #: src/domain/synthetics/markets/createGlvDepositTxn.ts
 msgid "Deposit error"
 msgstr "存入错误"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Spot (long)"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -2785,6 +2810,10 @@ msgstr "滑点设置过高。当前兑换影响：{0}。"
 msgid "Instant"
 msgstr "立即"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Deposit {0} to the Vault and open a delta-neutral short in one transaction."
+msgstr ""
+
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Open positions"
 msgstr "未平仓位"
@@ -2943,6 +2972,10 @@ msgstr "这只是一笔包装操作"
 msgid "Subscribe"
 msgstr "订阅"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Asset not found."
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
 msgstr "去中心化金融仪表盘"
@@ -3031,6 +3064,10 @@ msgstr "允许花费 {0}"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake submitted"
 msgstr "质押已提交"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Net"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Insufficient {symbol} balance: {availableFormatted} available, {requiredFormatted} required"
@@ -3866,6 +3903,7 @@ msgstr "V1 Arbitrum"
 msgid "Avalanche"
 msgstr "Avalanche"
 
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
@@ -4099,6 +4137,8 @@ msgstr "虚拟市场 ID"
 #: src/components/TradeBox/TradeBox.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "杠杆"
@@ -4367,6 +4407,7 @@ msgstr "已清算"
 msgid "Blueberry Pulse"
 msgstr "Blueberry Pulse"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
@@ -4752,6 +4793,11 @@ msgstr "LayerZero scan"
 msgid "Borrow fee"
 msgstr "借贷费用"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Size"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
 msgstr "兑换影响"
@@ -4977,6 +5023,10 @@ msgstr "bps"
 msgid "Create TWAP"
 msgstr "创建 TWAP"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Hold RWA in your wallet, open short only"
+msgstr ""
+
 #: src/components/TradeBox/SwapSlippageField.tsx
 msgid "Slippage is the difference between your expected and actual execution price due to price volatility. Orders won't execute if slippage exceeds your allowed maximum. The default can be adjusted in settings.<0/><1/>A low value (e.g. less than -{0}) may cause failed orders during volatility.<2/><3/>Note: slippage is different from price impact, which is based on open interest imbalances. <4>Read more</4>."
 msgstr "滑点是由于价格波动导致的预期执行价格与实际执行价格之间的差异。如果滑点超过您允许的最大值，订单将不会执行。默认值可以在设置中调整。<0/><1/>低值（例如小于 -{0}）可能会在波动期间导致订单失败。<2/><3/>注意：滑点与基于未平仓合约不平衡的价格影响不同。<4>了解更多</4>。"
@@ -5136,6 +5186,10 @@ msgstr "仓位在执行时将被立即清算。请尝试减小规模。"
 msgid "Create TP/SL"
 msgstr "创建 TP/SL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Short Margin"
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
 msgstr "Purpose: {0} | public: {1}"
@@ -5268,6 +5322,10 @@ msgstr "为每个市场提供独立流动性"
 msgid "Use open interest in tokens for balance"
 msgstr "使用代币未平仓量计算余额"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Deposit RWA to Vault + open short in one transaction"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Seamless trading"
 msgstr "无缝交易"
@@ -5277,8 +5335,8 @@ msgid "from your wallet"
 msgstr "从您的钱包"
 
 #: src/pages/Hedge/HedgePage.tsx
-msgid "Delta-neutral strategy — coming soon."
-msgstr ""
+#~ msgid "Delta-neutral strategy — coming soon."
+#~ msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -5311,6 +5369,7 @@ msgstr "设置已更新"
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 #: src/context/SyntheticsStateContext/selectors/chartSelectors/selectChartLines.tsx
 #: src/domain/synthetics/orders/utils.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -5642,6 +5701,10 @@ msgstr "提取费用"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Your fee savings from referral discounts"
 msgstr "您通过推荐折扣节省的费用"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Required"
+msgstr ""
 
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
@@ -6091,6 +6154,10 @@ msgstr "推荐"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Decrease"
 msgstr "减少"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Price change"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6823,6 +6890,10 @@ msgstr "已用资金"
 msgid "AVAILABLE LIQ."
 msgstr "可用流动性"
 
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
+msgstr ""
+
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
 msgstr "当前端点 ({0})"
@@ -6881,6 +6952,7 @@ msgstr "订单错误。该市场价格波动剧烈，请尝试<0>增加允许的
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Asset"
 msgstr "资产"
@@ -7195,6 +7267,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "不支持将 {0} 提取至 {1}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Back to Hedge"
+msgstr ""
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7692,6 +7768,10 @@ msgstr "余额"
 msgid "Force failures"
 msgstr "强制失败"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "1× = delta-neutral. Higher = partial hedge."
+msgstr ""
+
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/pages/UiPage/BannerTest.tsx
@@ -7763,6 +7843,10 @@ msgstr "交易错误"
 #: src/domain/multichain/useMultichainFundingToast.tsx
 msgid "Depositing to and withdrawing from GMX Account..."
 msgstr "正在存入和从 GMX Account 提取..."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Keep {0} in your wallet and open a short position only."
+msgstr ""
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -7848,6 +7932,14 @@ msgstr "已质押 GMX"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Open interest reserve factor shorts"
 msgstr "做空未平仓量储备系数"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Transaction submitted:"
+msgstr ""
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8019,6 +8111,7 @@ msgstr "将 {fromAmount} 交换为 {toAmount}"
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/TradersStats.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金额"
@@ -8073,6 +8166,10 @@ msgstr "{0}ms"
 msgid "Deposit failed"
 msgstr "存入失败"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Enter an amount to see the P&L simulation."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "EST. PNL"
 msgstr "预估 PNL"
@@ -8102,6 +8199,10 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "通知"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed Net APY"
+msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8149,6 +8250,11 @@ msgstr "输入金额"
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "SL price above limit price"
 msgstr "止损价格高于限价"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody"
+msgstr ""
 
 #: src/lib/tenderly.tsx
 #: src/lib/tenderly.tsx
@@ -8324,6 +8430,9 @@ msgstr "协议分析"
 msgid "Show positions on chart"
 msgstr "在图表上显示仓位"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
 msgstr ""
@@ -8608,6 +8717,10 @@ msgstr "仓位规模超过可用未平仓量。Delta：{usdDeltaText}，最大 O
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Yes"
 msgstr "是"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Self-Custody Hedge"
+msgstr ""
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Increase size (TWAP)"
@@ -9947,6 +10060,10 @@ msgstr "获取 GMX 的提醒和公告，随时掌握您的交易、清算风险�
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} 买入成功，但跨链桥至 Base 失败。您的资金安全保存在您的 GMX Account 中。请重试跨链桥或前往 {indexName} 池提取您的 GM 代币。"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat."
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) 是 GMX V2 对 GLP 的改进版本。它是一种收益优化的加密指数代币，具有以下特点："
@@ -9959,6 +10076,10 @@ msgstr "已从存入归属期的 {1} esGMX 中转换 {0} 个代币为 GMX。"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "触发价格高于清算价格"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Self-Custody APY"
+msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10605,6 +10726,10 @@ msgstr "下载为 CSV"
 msgid "Set Short Stop Market @ {0}"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Connect wallet to hedge"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
 msgstr "享受高达 100 倍杠杆以及不依赖订单簿深度的链上保证流动性"
@@ -10742,6 +10867,15 @@ msgstr "Rage Trade"
 #: src/domain/synthetics/common/incentivesAirdropMessages.ts
 msgid "EIP-4844, 20-27 Mar"
 msgstr "EIP-4844, 3 月 20-27 日"
+
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgePage.tsx
+msgid "Managed"
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11319,6 +11453,10 @@ msgstr "最低所需抵押品"
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} update failed"
 msgstr "{orderText} 更新失败"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Success"

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -14,15 +14,19 @@
  */
 
 import { t } from "@lingui/macro";
-import { parseEther, parseUnits } from "ethers";
+import { Contract, formatEther, parseEther, parseUnits } from "ethers";
 import { useEffect, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 
 import { useHedgeActions } from "domain/vantage/hedge/useHedgeActions";
 import type { HedgeMarginToken, HedgeMode } from "domain/vantage/hedge/useHedgeActions";
-import { useHedgeSimulator, buildSvgPath } from "domain/vantage/hedge/useHedgeSimulator";
+import { buildSvgPath, useHedgeSimulator } from "domain/vantage/hedge/useHedgeSimulator";
 import { VAULT_CONFIGS } from "domain/vantage/vaults/vaultConfig";
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
 import useWallet from "lib/wallets/useWallet";
+import MockPriceFeedAbi from "vantage/abis/MockPriceFeed.json";
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
 
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { AppNav } from "components/AppNav/AppNav";
@@ -34,6 +38,46 @@ import NumberInput from "components/NumberInput/NumberInput";
 
 /** Approximate ETH price in USD used to estimate collateral in ETH */
 const ETH_PRICE_USD = 2000;
+
+const MOCK_PRICE_FEED = (localhostDeployment.addresses as { MockPriceFeed?: string }).MockPriceFeed ?? "";
+const POLL_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// useRwaSpotPrice — fetches oracle price for a token from MockPriceFeed
+// ---------------------------------------------------------------------------
+
+function useRwaSpotPrice(tokenAddress: string | undefined): number | null {
+  const { chainId } = useChainId();
+  const [price, setPrice] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!tokenAddress || !MOCK_PRICE_FEED) return;
+
+    const provider = getProvider(undefined, chainId);
+    const feed = new Contract(MOCK_PRICE_FEED, MockPriceFeedAbi, provider);
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const raw: bigint = await feed.prices(tokenAddress);
+        if (!cancelled && raw > 0n) {
+          setPrice(parseFloat(formatEther(raw)));
+        }
+      } catch {
+        // leave null
+      }
+    }
+
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [chainId, tokenAddress]);
+
+  return price;
+}
 
 // ---------------------------------------------------------------------------
 // P&L Simulator Chart
@@ -130,18 +174,27 @@ export default function HedgeDetailPage() {
 
   const { isSubmitting, error: actionError, txHash, validate, execute } = useHedgeActions();
 
-  // Hardcoded spot price for simulation (in production: use oracle price)
-  // For localhost, MockPriceFeed typically sets $1 for RWA tokens
-  const spotPriceUsd = 1.0;
+  // Oracle spot price from MockPriceFeed (WAD → number)
+  const spotPriceUsd = useRwaSpotPrice(cfg?.tokenAddress);
 
   const rwaAmount = parseFloat(rwaAmountStr) || 0;
   const leverage = Math.max(1, parseFloat(leverageStr) || 1);
 
-  // Delta-neutral sizing: sizeDelta = rwaAmount × spotPrice
-  // collateral = sizeDelta / leverage
-  const sizeDeltaUsd = rwaAmount * spotPriceUsd;
-  const requiredCollateralUsd = sizeDeltaUsd / leverage;
-  const requiredCollateralEth = requiredCollateralUsd / ETH_PRICE_USD;
+  // Managed: sizeDelta = rwaAmount × spotPrice (delta-neutral)
+  // Self-Custody: sizeDelta derived from user's collateral input × leverage
+  const price = spotPriceUsd ?? 0;
+  const managedSizeDeltaUsd = rwaAmount * price;
+  const selfCustodyCollateralInput = parseFloat(usdcCollateralStr) || 0;
+  const selfCustodySizeDeltaUsd =
+    marginToken === "usdc"
+      ? selfCustodyCollateralInput * leverage
+      : selfCustodyCollateralInput * ETH_PRICE_USD * leverage;
+
+  const sizeDeltaUsd = mode === "managed" ? managedSizeDeltaUsd : selfCustodySizeDeltaUsd;
+
+  // Required margin = sizeDelta / leverage
+  const requiredCollateralUsd = mode === "managed" ? sizeDeltaUsd / leverage : selfCustodyCollateralInput;
+  const requiredCollateralEth = mode === "managed" ? requiredCollateralUsd / ETH_PRICE_USD : selfCustodyCollateralInput;
 
   // Clear validation error when inputs change
   useEffect(() => {
@@ -253,7 +306,7 @@ export default function HedgeDetailPage() {
               <div>
                 <div className="text-11 text-slate-500">{t`Spot Value`}</div>
                 <div className="mt-4 text-15 font-semibold text-white">
-                  ${(rwaAmount * spotPriceUsd).toLocaleString("en-US", { maximumFractionDigits: 2 })}
+                  ${(rwaAmount * (spotPriceUsd ?? 0)).toLocaleString("en-US", { maximumFractionDigits: 2 })}
                 </div>
               </div>
               <div>
@@ -372,21 +425,29 @@ export default function HedgeDetailPage() {
 
             {/* Calculated amounts */}
             <div className="mb-20 rounded-4 bg-slate-800/40 p-14 text-13">
-              <div className="flex justify-between">
-                <span className="text-slate-400">{t`Short Size`}</span>
-                <span className="text-white">${sizeDeltaUsd.toFixed(2)}</span>
-              </div>
-              {mode === "managed" && (
-                <div className="mt-8 flex justify-between">
-                  <span className="text-slate-400">
-                    {t`Required`} {marginToken === "usdc" ? "USDC" : "ETH"}
-                  </span>
-                  <span className="font-medium text-white">
-                    {marginToken === "usdc"
-                      ? `${requiredCollateralUsd.toFixed(2)} USDC`
-                      : `${requiredCollateralEth.toFixed(6)} ETH`}
-                  </span>
-                </div>
+              {spotPriceUsd === null ? (
+                <div className="text-slate-500">{t`Fetching price…`}</div>
+              ) : (
+                <>
+                  <div className="flex justify-between">
+                    <span className="text-slate-400">{t`Oracle Price`}</span>
+                    <span className="text-white">${spotPriceUsd.toFixed(4)}</span>
+                  </div>
+                  <div className="mt-8 flex justify-between">
+                    <span className="text-slate-400">{t`Short Size`}</span>
+                    <span className="text-white">${sizeDeltaUsd.toFixed(2)}</span>
+                  </div>
+                  <div className="mt-8 flex justify-between border-t border-slate-700/60 pt-8">
+                    <span className="text-slate-400">
+                      {t`Required`} {marginToken === "usdc" ? "USDC" : "ETH"}
+                    </span>
+                    <span className="text-indigo-300 font-semibold">
+                      {marginToken === "usdc"
+                        ? `${requiredCollateralUsd.toFixed(2)} USDC`
+                        : `${requiredCollateralEth.toFixed(6)} ETH`}
+                    </span>
+                  </div>
+                </>
               )}
             </div>
 

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -1,0 +1,435 @@
+/**
+ * HedgeDetailPage.tsx
+ *
+ * Delta-neutral hedge detail & execution page.
+ * Route: /hedge/:key
+ *
+ * Layout:
+ *   Left  — ±20% P&L simulator (SVG chart)
+ *   Right — Mode toggle (Managed / Self-Custody)
+ *           Margin token toggle (USDC / ETH)
+ *           Inputs: RWA amount (managed), leverage
+ *           Calculated: sizeDelta, required collateral
+ *           Execute button
+ */
+
+import { t } from "@lingui/macro";
+import { parseEther, parseUnits } from "ethers";
+import { useEffect, useState } from "react";
+import { useHistory, useParams } from "react-router-dom";
+
+import { useHedgeActions } from "domain/vantage/hedge/useHedgeActions";
+import type { HedgeMarginToken, HedgeMode } from "domain/vantage/hedge/useHedgeActions";
+import { useHedgeSimulator, buildSvgPath } from "domain/vantage/hedge/useHedgeSimulator";
+import { VAULT_CONFIGS } from "domain/vantage/vaults/vaultConfig";
+import useWallet from "lib/wallets/useWallet";
+
+import { AppHeader } from "components/AppHeader/AppHeader";
+import { AppNav } from "components/AppNav/AppNav";
+import NumberInput from "components/NumberInput/NumberInput";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Approximate ETH price in USD used to estimate collateral in ETH */
+const ETH_PRICE_USD = 2000;
+
+// ---------------------------------------------------------------------------
+// P&L Simulator Chart
+// ---------------------------------------------------------------------------
+
+type SimChartProps = {
+  spotPriceUsd: number | null;
+  rwaAmount: number;
+  sizeDelta: number;
+};
+
+function SimChart({ spotPriceUsd, rwaAmount, sizeDelta }: SimChartProps) {
+  const points = useHedgeSimulator(spotPriceUsd, rwaAmount, sizeDelta);
+
+  const W = 400;
+  const H = 160;
+
+  if (points.length < 2) {
+    return (
+      <div className="flex h-[160px] items-center justify-center text-13 text-slate-500">
+        {t`Enter an amount to see the P&L simulation.`}
+      </div>
+    );
+  }
+
+  const spotPath = buildSvgPath(points, "spotPnl", W, H);
+  const shortPath = buildSvgPath(points, "shortPnl", W, H);
+  const netPath = buildSvgPath(points, "netPnl", W, H);
+
+  // Zero line Y position
+  const values = points.flatMap((p) => [p.spotPnl, p.shortPnl, p.netPnl]);
+  const minV = Math.min(...values);
+  const maxV = Math.max(...values);
+  const range = maxV - minV || 1;
+  const zeroY = H - ((0 - minV) / range) * H;
+
+  return (
+    <div>
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" preserveAspectRatio="none">
+        {/* Zero reference line */}
+        <line
+          x1="0"
+          y1={zeroY.toFixed(1)}
+          x2={W}
+          y2={zeroY.toFixed(1)}
+          stroke="#475569"
+          strokeDasharray="4 4"
+          strokeWidth="1"
+        />
+        {/* Spot long */}
+        <path d={spotPath} fill="none" stroke="#60a5fa" strokeWidth="1.5" />
+        {/* Short position */}
+        <path d={shortPath} fill="none" stroke="#f87171" strokeWidth="1.5" />
+        {/* Net (delta-neutral = ~flat) */}
+        <path d={netPath} fill="none" stroke="#34d399" strokeWidth="2" />
+      </svg>
+      <div className="mt-8 flex gap-16 text-11 text-slate-400">
+        <div className="flex items-center gap-4">
+          <div className="rounded h-2 w-12 bg-blue-400" /> {t`Spot (long)`}
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="rounded h-2 w-12 bg-red-400" /> {t`Short`}
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="rounded h-2 w-12 bg-green-400" /> {t`Net`}
+        </div>
+      </div>
+      <div className="mt-4 flex justify-between text-11 text-slate-500">
+        <span>−20%</span>
+        <span>{t`Price change`}</span>
+        <span>+20%</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function HedgeDetailPage() {
+  const { key } = useParams<{ key: string }>();
+  const history = useHistory();
+  const { account } = useWallet();
+
+  const cfg = VAULT_CONFIGS.find((v) => v.key === key);
+
+  const [mode, setMode] = useState<HedgeMode>("managed");
+  const [marginToken, setMarginToken] = useState<HedgeMarginToken>("usdc");
+  const [rwaAmountStr, setRwaAmountStr] = useState("");
+  const [leverageStr, setLeverageStr] = useState("1");
+  const [usdcCollateralStr, setUsdcCollateralStr] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const { isSubmitting, error: actionError, txHash, validate, execute } = useHedgeActions();
+
+  // Hardcoded spot price for simulation (in production: use oracle price)
+  // For localhost, MockPriceFeed typically sets $1 for RWA tokens
+  const spotPriceUsd = 1.0;
+
+  const rwaAmount = parseFloat(rwaAmountStr) || 0;
+  const leverage = Math.max(1, parseFloat(leverageStr) || 1);
+
+  // Delta-neutral sizing: sizeDelta = rwaAmount × spotPrice
+  // collateral = sizeDelta / leverage
+  const sizeDeltaUsd = rwaAmount * spotPriceUsd;
+  const requiredCollateralUsd = sizeDeltaUsd / leverage;
+  const requiredCollateralEth = requiredCollateralUsd / ETH_PRICE_USD;
+
+  // Clear validation error when inputs change
+  useEffect(() => {
+    setValidationError(null);
+  }, [rwaAmountStr, leverageStr, usdcCollateralStr, mode, marginToken]);
+
+  // ── Not found ─────────────────────────────────────────────────────────────
+
+  if (!cfg || !cfg.tokenAddress || !cfg.vaultAddress) {
+    return (
+      <div className="w-full">
+        <div className="border-b border-stroke-primary px-16 py-8">
+          <AppHeader leftContent={<AppNav />} />
+        </div>
+        <div className="mt-48 text-center text-slate-400">
+          <p>{t`Asset not found.`}</p>
+          <button onClick={() => history.push("/hedge")} className="text-indigo-400 mt-8 text-14 underline">
+            {t`Back to Hedge`}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+
+  async function handleExecute() {
+    if (!account || !cfg) return;
+
+    const rwaAmountWad = parseEther(rwaAmountStr || "0");
+    const sizeDeltaWad = parseEther(sizeDeltaUsd.toFixed(18));
+
+    let collateralAmount: bigint;
+    if (marginToken === "usdc") {
+      collateralAmount = parseUnits(requiredCollateralUsd.toFixed(6), 6);
+    } else {
+      // ETH: convert required USD to wei
+      collateralAmount = parseEther(requiredCollateralEth.toFixed(18));
+    }
+
+    const params = {
+      rwaToken: cfg.tokenAddress,
+      rwaAmount: rwaAmountWad,
+      collateralToken: cfg.tokenAddress, // placeholder; USDC addr resolved in hook
+      collateralAmount,
+      indexToken: cfg.tokenAddress,
+      sizeDelta: sizeDeltaWad,
+    };
+
+    // In managed mode we need the actual USDC address from vault config — use lpManagerAddress as proxy
+    // The real USDC address is deployment-dependent; for localhost, tokens.USDC is used.
+    // For now, pass a zero address (test environment resolves via deployment JSON).
+    // TODO: wire up actual USDC address from vaultConfig / deployment
+    const err = await validate(mode, marginToken, params);
+    if (err) {
+      setValidationError(err);
+      return;
+    }
+
+    await execute(mode, marginToken, params);
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const canExecute =
+    account && !isSubmitting && (mode === "managed" ? rwaAmount > 0 : parseFloat(usdcCollateralStr) > 0);
+
+  return (
+    <div className="w-full">
+      {/* Header */}
+      <div className="border-b border-stroke-primary px-16 py-8">
+        <AppHeader leftContent={<AppNav />} />
+      </div>
+
+      <div className="mt-24 px-16">
+        {/* Back link */}
+        <button
+          onClick={() => history.push("/hedge")}
+          className="mb-16 flex items-center gap-6 text-13 text-slate-400 hover:text-white"
+        >
+          ← {t`Hedge`}
+        </button>
+
+        {/* Page title */}
+        <div className="mb-24 flex items-center gap-12">
+          <div className="flex h-40 w-40 items-center justify-center rounded-full bg-slate-700 text-16 font-bold text-white">
+            {cfg.symbol.slice(0, 2)}
+          </div>
+          <div>
+            <h1 className="text-h1">
+              {cfg.symbol} {t`Hedge`}
+            </h1>
+            <p className="text-13 text-slate-400">{cfg.name}</p>
+          </div>
+        </div>
+
+        {/* Main layout */}
+        <div className="grid grid-cols-1 gap-24 lg:grid-cols-[1fr_420px]">
+          {/* ── Left: Simulator ─────────────────────────────────────────────── */}
+          <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-24">
+            <h2 className="mb-4 text-16 font-semibold text-white">{t`±20% P&L Simulation`}</h2>
+            <p className="mb-16 text-12 text-slate-400">
+              {t`Shows spot, short, and net P&L across a ±20% price range. A perfect delta-neutral position (Net) stays flat.`}
+            </p>
+            <SimChart spotPriceUsd={spotPriceUsd} rwaAmount={rwaAmount} sizeDelta={sizeDeltaUsd} />
+
+            {/* Stats row */}
+            <div className="mt-20 grid grid-cols-3 gap-16 border-t border-stroke-primary pt-16">
+              <div>
+                <div className="text-11 text-slate-500">{t`Spot Value`}</div>
+                <div className="mt-4 text-15 font-semibold text-white">
+                  ${(rwaAmount * spotPriceUsd).toLocaleString("en-US", { maximumFractionDigits: 2 })}
+                </div>
+              </div>
+              <div>
+                <div className="text-11 text-slate-500">{t`Short Size`}</div>
+                <div className="mt-4 text-15 font-semibold text-white">
+                  ${sizeDeltaUsd.toLocaleString("en-US", { maximumFractionDigits: 2 })}
+                </div>
+              </div>
+              <div>
+                <div className="text-11 text-slate-500">{t`Leverage`}</div>
+                <div className="mt-4 text-15 font-semibold text-white">{leverage}×</div>
+              </div>
+            </div>
+          </div>
+
+          {/* ── Right: Action panel ──────────────────────────────────────────── */}
+          <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-24">
+            {/* Mode toggle */}
+            <div className="mb-20">
+              <div className="mb-8 text-12 text-slate-400">{t`Mode`}</div>
+              <div className="flex rounded-4 border border-stroke-primary">
+                <button
+                  onClick={() => setMode("managed")}
+                  className={`flex-1 rounded-l-4 py-8 text-13 font-medium transition-colors ${
+                    mode === "managed"
+                      ? "bg-indigo-600 text-white"
+                      : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
+                  }`}
+                >
+                  {t`Managed`}
+                </button>
+                <button
+                  onClick={() => setMode("selfCustody")}
+                  className={`flex-1 rounded-r-4 py-8 text-13 font-medium transition-colors ${
+                    mode === "selfCustody"
+                      ? "bg-indigo-600 text-white"
+                      : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
+                  }`}
+                >
+                  {t`Self-Custody`}
+                </button>
+              </div>
+              <p className="mt-8 text-12 text-slate-500">
+                {mode === "managed"
+                  ? t`Deposit ${cfg.symbol} to the Vault and open a delta-neutral short in one transaction.`
+                  : t`Keep ${cfg.symbol} in your wallet and open a short position only.`}
+              </p>
+            </div>
+
+            {/* Margin token toggle */}
+            <div className="mb-20">
+              <div className="mb-8 text-12 text-slate-400">{t`Short Margin`}</div>
+              <div className="flex rounded-4 border border-stroke-primary">
+                <button
+                  onClick={() => setMarginToken("usdc")}
+                  className={`flex-1 rounded-l-4 py-8 text-13 font-medium transition-colors ${
+                    marginToken === "usdc"
+                      ? "bg-slate-600 text-white"
+                      : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
+                  }`}
+                >
+                  USDC
+                </button>
+                <button
+                  onClick={() => setMarginToken("eth")}
+                  className={`flex-1 rounded-r-4 py-8 text-13 font-medium transition-colors ${
+                    marginToken === "eth"
+                      ? "bg-slate-600 text-white"
+                      : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
+                  }`}
+                >
+                  ETH
+                </button>
+              </div>
+            </div>
+
+            {/* Inputs */}
+            {mode === "managed" && (
+              <div className="mb-16">
+                <label className="mb-6 block text-12 text-slate-400">
+                  {cfg.symbol} {t`Amount`}
+                </label>
+                <NumberInput
+                  value={rwaAmountStr}
+                  onValueChange={(e) => setRwaAmountStr(e.target.value)}
+                  className="focus:border-indigo-500 w-full rounded-4 border border-stroke-primary bg-slate-800/60 px-12 py-10 text-14 text-white focus:outline-none"
+                  placeholder="0.00"
+                />
+              </div>
+            )}
+
+            {mode === "selfCustody" && (
+              <div className="mb-16">
+                <label className="mb-6 block text-12 text-slate-400">
+                  {marginToken === "usdc" ? "USDC" : "ETH"} {t`Collateral`}
+                </label>
+                <NumberInput
+                  value={usdcCollateralStr}
+                  onValueChange={(e) => setUsdcCollateralStr(e.target.value)}
+                  className="focus:border-indigo-500 w-full rounded-4 border border-stroke-primary bg-slate-800/60 px-12 py-10 text-14 text-white focus:outline-none"
+                  placeholder="0.00"
+                />
+              </div>
+            )}
+
+            <div className="mb-20">
+              <label className="mb-6 block text-12 text-slate-400">{t`Leverage`}</label>
+              <NumberInput
+                value={leverageStr}
+                onValueChange={(e) => setLeverageStr(e.target.value)}
+                className="focus:border-indigo-500 w-full rounded-4 border border-stroke-primary bg-slate-800/60 px-12 py-10 text-14 text-white focus:outline-none"
+                placeholder="1"
+              />
+              <p className="mt-4 text-11 text-slate-500">{t`1× = delta-neutral. Higher = partial hedge.`}</p>
+            </div>
+
+            {/* Calculated amounts */}
+            <div className="mb-20 rounded-4 bg-slate-800/40 p-14 text-13">
+              <div className="flex justify-between">
+                <span className="text-slate-400">{t`Short Size`}</span>
+                <span className="text-white">${sizeDeltaUsd.toFixed(2)}</span>
+              </div>
+              {mode === "managed" && (
+                <div className="mt-8 flex justify-between">
+                  <span className="text-slate-400">
+                    {t`Required`} {marginToken === "usdc" ? "USDC" : "ETH"}
+                  </span>
+                  <span className="font-medium text-white">
+                    {marginToken === "usdc"
+                      ? `${requiredCollateralUsd.toFixed(2)} USDC`
+                      : `${requiredCollateralEth.toFixed(6)} ETH`}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Errors */}
+            {(validationError || actionError) && (
+              <div className="mb-16 rounded-4 bg-red-900/30 px-12 py-8 text-12 text-red-400">
+                {validationError ?? actionError}
+              </div>
+            )}
+
+            {/* Success */}
+            {txHash && (
+              <div className="mb-16 rounded-4 bg-green-900/30 px-12 py-8 text-12 text-green-400">
+                {t`Transaction submitted:`} {txHash.slice(0, 20)}…
+              </div>
+            )}
+
+            {/* Execute button */}
+            {!account ? (
+              <div className="rounded-4 bg-slate-700/50 py-14 text-center text-14 text-slate-400">
+                {t`Connect wallet to hedge`}
+              </div>
+            ) : (
+              <button
+                onClick={handleExecute}
+                disabled={!canExecute}
+                className={`w-full rounded-4 py-14 text-15 font-semibold transition-colors ${
+                  canExecute
+                    ? "bg-indigo-600 hover:bg-indigo-500 text-white"
+                    : "cursor-not-allowed bg-slate-700 text-slate-500"
+                }`}
+              >
+                {isSubmitting ? t`Submitting…` : mode === "managed" ? t`Managed Hedge` : t`Self-Custody Hedge`}
+              </button>
+            )}
+
+            {/* Keeper note */}
+            <p className="mt-12 text-center text-11 text-slate-600">
+              {t`Short position requests are executed by Keepers (GMX V1 two-step flow).`}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Hedge/HedgePage.tsx
+++ b/src/pages/Hedge/HedgePage.tsx
@@ -1,27 +1,165 @@
 /**
  * HedgePage.tsx
  *
- * Delta-Neutral Strategy interface.
+ * Delta-Neutral Strategy list view.
  * Route: /hedge
+ *
+ * Columns: Asset | Vault APY | Managed Net APY | Self-Custody APY | AUM | Action
+ * Interaction: "Hedge" button → /hedge/:key
  */
 
 import { t } from "@lingui/macro";
+import { formatEther } from "ethers";
+import { useHistory } from "react-router-dom";
+
+import { useHedgeList } from "domain/vantage/hedge/useHedgeList";
+import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL } from "domain/vantage/vaults/vaultConfig";
 
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { AppNav } from "components/AppNav/AppNav";
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatUsd(wad: bigint): string {
+  const n = parseFloat(formatEther(wad));
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatApy(apy: number | null): string {
+  if (apy === null) return "—";
+  const sign = apy >= 0 ? "+" : "";
+  return `${sign}${(apy * 100).toFixed(2)}%`;
+}
+
+function apyColor(apy: number | null): string {
+  if (apy === null) return "text-slate-500";
+  return apy >= 0 ? "text-green-400" : "text-red-400";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function HedgePage() {
+  const history = useHistory();
+  const items = useHedgeList();
+
   return (
     <div className="w-full">
+      {/* Header */}
       <div className="border-b border-stroke-primary px-16 py-8">
         <AppHeader leftContent={<AppNav />} />
       </div>
 
       <div className="mt-24 px-16">
+        {/* Page title */}
         <div className="mb-24">
           <h1 className="text-h1">{t`Hedge`}</h1>
-          <p className="text-body-medium mt-4 text-slate-400">{t`Delta-neutral strategy — coming soon.`}</p>
+          <p className="text-body-medium mt-4 text-slate-400">
+            {t`Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure.`}
+          </p>
         </div>
+
+        {/* Mode legend */}
+        <div className="mb-16 flex gap-24 text-13 text-slate-400">
+          <div>
+            <span className="font-semibold text-white">{t`Managed`}</span>
+            {" — "}
+            {t`Deposit RWA to Vault + open short in one transaction`}
+          </div>
+          <div>
+            <span className="font-semibold text-white">{t`Self-Custody`}</span>
+            {" — "}
+            {t`Hold RWA in your wallet, open short only`}
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary">
+          {/* Table header */}
+          <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_auto] items-center gap-0 border-b border-stroke-primary px-20 py-12 text-12 text-slate-400">
+            <div>{t`Asset`}</div>
+            <div className="text-right">{t`Vault APY`}</div>
+            <div className="text-right">{t`Managed Net APY`}</div>
+            <div className="text-right">{t`Self-Custody APY`}</div>
+            <div className="text-right">{t`AUM`}</div>
+            <div className="w-80" />
+          </div>
+
+          {/* Rows */}
+          {items.map((item) => (
+            <div
+              key={item.key}
+              className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_auto] items-center gap-0 border-b border-stroke-primary px-20 py-16 last:border-0 hover:bg-slate-800/40"
+            >
+              {/* Asset */}
+              <div className="flex items-center gap-12">
+                <div className="flex h-36 w-36 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
+                  {item.symbol.slice(0, 2)}
+                </div>
+                <div>
+                  <div className="text-15 font-semibold text-white">{item.symbol}</div>
+                  <div className="mt-2 flex items-center gap-6">
+                    <span className="text-12 text-slate-400">{item.name}</span>
+                    <span className={`text-10 rounded-full px-6 py-1 font-medium ${ASSET_TYPE_COLOR[item.assetType]}`}>
+                      {ASSET_TYPE_LABEL[item.assetType]}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Vault APY */}
+              <div className={`text-right text-15 font-medium ${apyColor(item.vaultApy)}`}>
+                {formatApy(item.vaultApy)}
+              </div>
+
+              {/* Managed Net APY */}
+              <div className={`text-right text-15 font-medium ${apyColor(item.managedNetApy)}`}>
+                {formatApy(item.managedNetApy)}
+              </div>
+
+              {/* Self-Custody APY */}
+              <div className={`text-right text-15 font-medium ${apyColor(item.selfCustodyApy)}`}>
+                {formatApy(item.selfCustodyApy)}
+              </div>
+
+              {/* AUM */}
+              <div className="text-right">
+                {item.isLoading ? (
+                  <span className="text-slate-500">—</span>
+                ) : (
+                  <span className="text-15 font-medium text-white">{formatUsd(item.aum)}</span>
+                )}
+              </div>
+
+              {/* Action */}
+              <div className="flex w-80 justify-end">
+                <button
+                  onClick={() => history.push(`/hedge/${item.key}`)}
+                  className="bg-indigo-600 hover:bg-indigo-500 rounded-4 px-14 py-6 text-13 font-medium text-white transition-colors"
+                >
+                  {t`Hedge`}
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {/* Empty state */}
+          {items.length === 0 && (
+            <div className="py-40 text-center text-14 text-slate-400">
+              {t`No hedgeable vaults configured. Deploy contracts first.`}
+            </div>
+          )}
+        </div>
+
+        {/* Disclaimer */}
+        <p className="mt-16 text-center text-12 text-slate-500">
+          {t`Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns.`}
+        </p>
       </div>
     </div>
   );

--- a/src/vantage/abis/HedgeController.json
+++ b/src/vantage/abis/HedgeController.json
@@ -1,0 +1,102 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_lpManager",      "type": "address" },
+      { "internalType": "address", "name": "_positionRouter", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "user",            "type": "address" },
+      { "indexed": true,  "internalType": "address", "name": "rwaToken",        "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "rwaAmount",       "type": "uint256" },
+      { "indexed": false, "internalType": "bytes32", "name": "shortRequestKey", "type": "bytes32" }
+    ],
+    "name": "ManagedHedgeCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "user",            "type": "address" },
+      { "indexed": true,  "internalType": "address", "name": "indexToken",      "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "sizeDelta",       "type": "uint256" },
+      { "indexed": false, "internalType": "bytes32", "name": "shortRequestKey", "type": "bytes32" }
+    ],
+    "name": "SelfCustodyHedgeCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "rwaToken",         "type": "address" },
+      { "internalType": "uint256", "name": "rwaAmount",        "type": "uint256" },
+      { "internalType": "address", "name": "collateralToken",  "type": "address" },
+      { "internalType": "uint256", "name": "collateralAmount", "type": "uint256" },
+      { "internalType": "address", "name": "indexToken",       "type": "address" },
+      { "internalType": "uint256", "name": "sizeDelta",        "type": "uint256" },
+      { "internalType": "uint256", "name": "acceptablePrice",  "type": "uint256" },
+      { "internalType": "uint256", "name": "executionFee",     "type": "uint256" }
+    ],
+    "name": "createManagedHedge",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "rwaToken",        "type": "address" },
+      { "internalType": "uint256", "name": "rwaAmount",       "type": "uint256" },
+      { "internalType": "address", "name": "indexToken",      "type": "address" },
+      { "internalType": "uint256", "name": "sizeDelta",       "type": "uint256" },
+      { "internalType": "uint256", "name": "acceptablePrice", "type": "uint256" },
+      { "internalType": "uint256", "name": "executionFee",    "type": "uint256" }
+    ],
+    "name": "createManagedHedgeETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "collateralToken",  "type": "address" },
+      { "internalType": "uint256", "name": "collateralAmount", "type": "uint256" },
+      { "internalType": "address", "name": "indexToken",       "type": "address" },
+      { "internalType": "uint256", "name": "sizeDelta",        "type": "uint256" },
+      { "internalType": "uint256", "name": "acceptablePrice",  "type": "uint256" },
+      { "internalType": "uint256", "name": "executionFee",     "type": "uint256" }
+    ],
+    "name": "createSelfCustodyHedge",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "indexToken",      "type": "address" },
+      { "internalType": "uint256", "name": "sizeDelta",       "type": "uint256" },
+      { "internalType": "uint256", "name": "acceptablePrice", "type": "uint256" },
+      { "internalType": "uint256", "name": "executionFee",    "type": "uint256" }
+    ],
+    "name": "createSelfCustodyHedgeETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lpManager",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "positionRouter",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/vantage/contracts.ts
+++ b/src/vantage/contracts.ts
@@ -57,6 +57,7 @@ export type VantageContractName =
   | "AssetRegistry"
   | "ChainlinkAdapter"
   | "ComplianceRegistry"
+  | "HedgeController"
   | "LPManager"
   | "LPToken"
   | "ManualAdapter"
@@ -84,6 +85,7 @@ const VANTAGE_CONTRACTS: Record<number, VantageAddressMap> = {
     AssetRegistry: ARBITRUM_ASSET_REGISTRY,
     ChainlinkAdapter: ARBITRUM_CHAINLINK_ADAPTER,
     ComplianceRegistry: ARBITRUM_COMPLIANCE_REGISTRY,
+    HedgeController: ZERO,
     LPManager: ARBITRUM_LP_MANAGER,
     LPToken: ARBITRUM_LP_TOKEN,
     ManualAdapter: ARBITRUM_MANUAL_ADAPTER,
@@ -103,6 +105,7 @@ const VANTAGE_CONTRACTS: Record<number, VantageAddressMap> = {
     AssetRegistry: localhostDeployment.addresses.AssetRegistry ?? ZERO,
     ChainlinkAdapter: ZERO,
     ComplianceRegistry: ZERO,
+    HedgeController: (localhostDeployment.addresses as { HedgeController?: string }).HedgeController ?? ZERO,
     LPManager: localhostDeployment.addresses.LPManager ?? ZERO,
     LPToken: localhostDeployment.addresses.LPToken ?? ZERO,
     ManualAdapter: ZERO,
@@ -122,6 +125,7 @@ const VANTAGE_CONTRACTS: Record<number, VantageAddressMap> = {
     AssetRegistry: ARBITRUM_SEPOLIA_ASSET_REGISTRY,
     ChainlinkAdapter: ARBITRUM_SEPOLIA_CHAINLINK_ADAPTER,
     ComplianceRegistry: ARBITRUM_SEPOLIA_COMPLIANCE_REGISTRY,
+    HedgeController: ZERO,
     LPManager: ARBITRUM_SEPOLIA_LP_MANAGER,
     LPToken: ARBITRUM_SEPOLIA_LP_TOKEN,
     ManualAdapter: ARBITRUM_SEPOLIA_MANUAL_ADAPTER,


### PR DESCRIPTION
## 概要

Issue #170 のフロントエンド実装。`/hedge` と `/hedge/:key` ページを追加し、デルタニュートラルヘッジ戦略の一覧表示・実行を可能にする。

## 変更内容

### 新規ファイル

- **`src/vantage/abis/HedgeController.json`**
  - `createManagedHedge` / `createManagedHedgeETH` / `createSelfCustodyHedge` / `createSelfCustodyHedgeETH` ABI

- **`src/domain/vantage/hedge/useHedgeList.ts`**
  - Vault APY + Short Funding Rate + AUM を Vault ごとに取得
  - `managedNetApy = vaultApy + fundingApy`、`selfCustodyApy = fundingApy`
  - `cumulativeFundingRate(indexToken, false)` を 30s ポーリング

- **`src/domain/vantage/hedge/useHedgeSimulator.ts`**
  - ±20% 価格変動に対する Spot / Short / Net P&L を計算
  - SVG パス生成ユーティリティ `buildSvgPath`

- **`src/domain/vantage/hedge/useHedgeActions.ts`**
  - 残高バリデーション（RWA / USDC / ETH）
  - approve → コントラクト呼び出し（Managed/Self-Custody × USDC/ETH マージン）
  - エラーメッセージの revert reason 抽出

- **`src/pages/Hedge/HedgeDetailPage.tsx`** (`/hedge/:key`)
  - Managed / Self-Custody モードトグル
  - USDC / ETH 証拠金トグル
  - RWA 量入力 → `sizeDelta = rwaAmount × spotPrice` 自動計算
  - レバレッジ入力 → `collateral = sizeDelta / leverage` 自動計算
  - ±20% P&L シミュレーションチャート（Spot / Short / Net 3線 SVG）
  - 残高不足エラー表示、ウォレット未接続ガード

### 変更ファイル

- **`src/pages/Hedge/HedgePage.tsx`** (`/hedge`)
  - 一覧テーブル: Asset / Vault APY / Managed Net APY / Self-Custody APY / AUM / Hedge ボタン

- **`src/vantage/contracts.ts`**
  - `HedgeController` を `VantageContractName` 型に追加（全チェーン対応）

- **`src/App/MainRoutes.tsx`**
  - `/hedge/:key` ルート追加

## スクリーンショット

| `/hedge` 一覧 | `/hedge/:key` 詳細 |
|---|---|
| Asset / APY / AUM テーブル | P&L チャート + 実行フォーム |

🤖 Generated with [Claude Code](https://claude.com/claude-code)