### PR TITLE
feat: LPZapper フロントエンド統合 — Zap In タブ追加 (Issue #172)

### DIFF
--- a/src/domain/vantage/vaults/useZapInActions.ts
+++ b/src/domain/vantage/vaults/useZapInActions.ts
@@ -1,0 +1,129 @@
+/**
+ * useZapInActions.ts
+ *
+ * Transaction hook for LPZapper (Route 2 deposit):
+ *   - zapIn    : USDC → Uniswap V3 swap → RWA token → LP shares
+ *   - zapInETH : native ETH → WETH → Uniswap V3 swap → RWA token → LP shares
+ *
+ * Flow:
+ *   1. Validate: check sender balance for input token
+ *   2. zapIn only: approve USDC to LPZapper if allowance insufficient
+ *   3. Call LPZapper.zapIn or LPZapper.zapInETH
+ *   4. Return tx hash
+ */
+
+import { Contract } from "ethers";
+import { parseEther, parseUnits } from "ethers";
+import { useCallback, useState } from "react";
+
+import { useChainId } from "lib/chains";
+import { useEthersSigner } from "lib/wallets/useEthersSigner";
+import useWallet from "lib/wallets/useWallet";
+import LPZapperAbi from "vantage/abis/LPZapper.json";
+import ERC20Abi from "vantage/abis/MockERC20.json";
+import type { ZapTokenConfig } from "vantage/config/zapTokens";
+import { getVantageContractAddress } from "vantage/contracts";
+
+import type { VaultConfig } from "./vaultConfig";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ZapInParams {
+  /** Amount string entered by user (in input token units, e.g. "100" USDC) */
+  amountIn: string;
+  /** Minimum RWA token out (0n = accept any; set based on quoted output) */
+  minTokenOut: bigint;
+  /** USDC token address (needed for approval on USDC route) */
+  usdcAddress: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useZapInActions(cfg: VaultConfig, zapToken: ZapTokenConfig, chainId?: number) {
+  const { chainId: walletChainId } = useChainId();
+  const resolvedChainId = chainId ?? walletChainId;
+  const { account } = useWallet();
+  const signer = useEthersSigner();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Validate
+  // ---------------------------------------------------------------------------
+
+  const validate = useCallback(
+    async (params: ZapInParams): Promise<string | null> => {
+      if (!account || !signer) return "Wallet not connected";
+      if (!params.amountIn || Number(params.amountIn) <= 0) return "Enter an amount";
+
+      try {
+        if (zapToken.isNative) {
+          const ethBal = await signer.provider!.getBalance(account);
+          const needed = parseEther(params.amountIn);
+          if (ethBal < needed) return "Insufficient ETH balance";
+        } else {
+          const token = new Contract(params.usdcAddress, ERC20Abi, signer.provider!);
+          const bal: bigint = await token.balanceOf(account);
+          const needed = parseUnits(params.amountIn, zapToken.decimals);
+          if (bal < needed) return `Insufficient ${zapToken.symbol} balance`;
+        }
+      } catch {
+        return "Balance check failed";
+      }
+
+      return null;
+    },
+    [account, signer, zapToken]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Execute
+  // ---------------------------------------------------------------------------
+
+  const execute = useCallback(
+    async (params: ZapInParams): Promise<string | null> => {
+      if (!account || !signer) return null;
+
+      const zapperAddress = getVantageContractAddress(resolvedChainId, "LPZapper");
+      if (!zapperAddress || zapperAddress === "0x0000000000000000000000000000000000000000") {
+        throw new Error("LPZapper not deployed on this network");
+      }
+
+      const zapper = new Contract(zapperAddress, LPZapperAbi, signer);
+
+      setIsSubmitting(true);
+      try {
+        let tx;
+
+        if (zapToken.isNative) {
+          // ETH route: no approve needed
+          const ethAmount = parseEther(params.amountIn);
+          tx = await zapper.zapInETH(cfg.tokenAddress, params.minTokenOut, zapToken.poolFee, account, {
+            value: ethAmount,
+          });
+        } else {
+          // USDC route: approve if needed
+          const usdcAmount = parseUnits(params.amountIn, zapToken.decimals);
+          const usdc = new Contract(params.usdcAddress, ERC20Abi, signer);
+          const allowance: bigint = await usdc.allowance(account, zapperAddress);
+          if (allowance < usdcAmount) {
+            const approveTx = await usdc.approve(zapperAddress, usdcAmount);
+            await approveTx.wait();
+          }
+          tx = await zapper.zapIn(cfg.tokenAddress, usdcAmount, params.minTokenOut, zapToken.poolFee, account);
+        }
+
+        return tx.hash as string;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [account, signer, resolvedChainId, cfg.tokenAddress, zapToken]
+  );
+
+  return { validate, execute, isSubmitting };
+}

--- a/src/domain/vantage/vaults/useZapInActions.ts
+++ b/src/domain/vantage/vaults/useZapInActions.ts
@@ -21,6 +21,7 @@ import { useEthersSigner } from "lib/wallets/useEthersSigner";
 import useWallet from "lib/wallets/useWallet";
 import LPZapperAbi from "vantage/abis/LPZapper.json";
 import ERC20Abi from "vantage/abis/MockERC20.json";
+import { resolvePoolFee } from "vantage/config/zapTokens";
 import type { ZapTokenConfig } from "vantage/config/zapTokens";
 import { getVantageContractAddress } from "vantage/contracts";
 
@@ -95,6 +96,9 @@ export function useZapInActions(cfg: VaultConfig, zapToken: ZapTokenConfig, chai
 
       const zapper = new Contract(zapperAddress, LPZapperAbi, signer);
 
+      // Resolve the optimal pool fee for this (inputToken, targetToken) pair.
+      const poolFee = resolvePoolFee(zapToken.isNative ? "eth" : "usdc", cfg.symbol);
+
       setIsSubmitting(true);
       try {
         let tx;
@@ -102,7 +106,7 @@ export function useZapInActions(cfg: VaultConfig, zapToken: ZapTokenConfig, chai
         if (zapToken.isNative) {
           // ETH route: no approve needed
           const ethAmount = parseEther(params.amountIn);
-          tx = await zapper.zapInETH(cfg.tokenAddress, params.minTokenOut, zapToken.poolFee, account, {
+          tx = await zapper.zapInETH(cfg.tokenAddress, params.minTokenOut, poolFee, account, {
             value: ethAmount,
           });
         } else {
@@ -114,7 +118,7 @@ export function useZapInActions(cfg: VaultConfig, zapToken: ZapTokenConfig, chai
             const approveTx = await usdc.approve(zapperAddress, usdcAmount);
             await approveTx.wait();
           }
-          tx = await zapper.zapIn(cfg.tokenAddress, usdcAmount, params.minTokenOut, zapToken.poolFee, account);
+          tx = await zapper.zapIn(cfg.tokenAddress, usdcAmount, params.minTokenOut, poolFee, account);
         }
 
         return tx.hash as string;
@@ -122,7 +126,7 @@ export function useZapInActions(cfg: VaultConfig, zapToken: ZapTokenConfig, chai
         setIsSubmitting(false);
       }
     },
-    [account, signer, resolvedChainId, cfg.tokenAddress, zapToken]
+    [account, signer, resolvedChainId, cfg.tokenAddress, cfg.symbol, zapToken]
   );
 
   return { validate, execute, isSubmitting };

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "Aktion suchen"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "Unzureichende Liquidität. Verfügbar: {availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "Entstaken übermittelt"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "Unzureichende Liquidität für den Tausch von Zahlungstoken zu Sicherhei
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "Weniger Details"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "Verschiebe von <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> zu <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "Swap {fromAmount} für {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Betrag"
 
@@ -8616,6 +8634,10 @@ msgstr "Kein Preiseinfluss. Einzelner Ausführungspreis für das<0/>Erhöhen von
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "Geworbene Trader auf Arbitrum"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "Was ist GM?"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "Search action"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr "Connect wallet to zap in"
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
@@ -5959,6 +5963,10 @@ msgstr "Insufficient liquidity. Available: {availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "Unstake submitted"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr "Zapping…"
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "Insufficient liquidity for pay-to-collateral swap at trigger price"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "Fewer details"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr "DEX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr "Shortfall Debt"
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr "Zap In"
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "Swap {fromAmount} for {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Amount"
 
@@ -8617,6 +8635,10 @@ msgstr "No price impact. Single execution price for<0/>increasing longs or decre
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
 msgstr "Confirming…"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
+msgstr "Slippage guard"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -10033,6 +10055,10 @@ msgstr "Traders referred on Arbitrum"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "What is GM?"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr "Route"
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "Buscar acción"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "Liquidez insuficiente. Disponible: {availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "Unstakear enviado"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "Liquidez insuficiente para el intercambio de pago a garantía al precio 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "Menos detalles"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "Cambiando de <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> a <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "Intercambiar {fromAmount} por {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Importe"
 
@@ -8616,6 +8634,10 @@ msgstr "Sin impacto en el precio. Precio de ejecución único para<0/>aumentar l
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "Traders referidos en Arbitrum"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "¿Qué es GM?"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "Rechercher une action"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "Liquidité insuffisante. Disponible : {availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "Unstake soumis"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "Liquidité insuffisante pour l'échange paiement-garantie au prix de dé
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "Moins de détails"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "Déplacement de <0><1>GM : {fromIndexName}</1><2>{fromPoolName}</2></0> vers <3><4>GM : {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "Échanger {fromAmount} pour {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Montant"
 
@@ -8616,6 +8634,10 @@ msgstr "Aucun impact sur le prix. Prix d'exécution unique pour<0/>l'augmentatio
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "Traders référés sur Arbitrum"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "Qu’est-ce que GM ?"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "アクションを検索"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "流動性不足。利用可能: {availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "アンステーク送信済み"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "トリガー価格での支払トークンから担保へのスワップ
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "詳細を折りたたむ"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "<0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> から <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3> へシフト中"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "{fromAmount} を {toAmount} にスワップ"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金額"
 
@@ -8616,6 +8634,10 @@ msgstr "価格への影響はありません。このサイズでの<0/>ロン�
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "Arbitrumで紹介されたトレーダー"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "GMとは？"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "액션 검색"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "유동성 부족. 가용: {availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "언스테이킹 제출됨"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "조건가에서 지불-담보 스왑을 위한 유동성 부족"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "간략히 보기"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "<0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0>에서 <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>으로 이전 중"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "{fromAmount}을 {toAmount}으로 스왑"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "수량"
 
@@ -8616,6 +8634,10 @@ msgstr "가격 영향 없음. 이 규모에서 롱 증가 또는<0/>숏 감소 �
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "Arbitrum에서 추천된 트레이더"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "GM이란 무엇인가요?"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -2520,6 +2520,10 @@ msgstr ""
 msgid "Search action"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr ""
 msgid "Unstake submitted"
 msgstr ""
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6084,6 +6092,10 @@ msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -6240,6 +6252,11 @@ msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
 msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr ""
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr ""
 
@@ -8616,6 +8634,10 @@ msgstr ""
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10032,6 +10054,10 @@ msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
 msgstr ""
 
 #: src/components/OrderList/OrderList.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "Поиск действия"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "Недостаточная ликвидность. Доступно: {av
 msgid "Unstake submitted"
 msgstr "Вывод из стейкинга отправлен"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "Недостаточная ликвидность для обмена п
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "Меньше деталей"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "Переход от <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> к <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "Обмен {fromAmount} на {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "Сумма"
 
@@ -8616,6 +8634,10 @@ msgstr "Нет влияния на цену. Единая цена исполн�
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "Привлечённые трейдеры на Arbitrum"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "Что такое GM?"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "搜尋操作"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "流動性不足。可用：{availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "解除質押已提交"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "在觸發價格下，支付代幣至抵押品兌換的流動性不足"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "收起詳情"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "從 <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> 轉移至 <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "將 {fromAmount} 兌換為 {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金額"
 
@@ -8616,6 +8634,10 @@ msgstr "無價格影響。在此規模下加倉做多<0/>或減倉做空為<1/>�
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "在 Arbitrum 上推薦的交易者"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "什麼是 GM？"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2520,6 +2520,10 @@ msgstr "FUNDING APR"
 msgid "Search action"
 msgstr "搜索操作"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Connect wallet to zap in"
+msgstr ""
+
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
 msgstr ""
@@ -5959,6 +5963,10 @@ msgstr "流动性不足。可用：{availableLiquidityText}"
 msgid "Unstake submitted"
 msgstr "解除质押已提交"
 
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zapping…"
+msgstr ""
+
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6085,6 +6093,10 @@ msgstr "在触发价格下，支付代币转换为抵押品的流动性不足"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Fewer details"
 msgstr "收起详情"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "DEX"
+msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6241,6 +6253,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
 msgstr "从 <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> 转移到 <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Zap In"
+msgstr ""
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -8117,6 +8134,7 @@ msgstr "将 {fromAmount} 交换为 {toAmount}"
 #: src/components/Referrals/TradersStats.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
+#: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount"
 msgstr "金额"
 
@@ -8616,6 +8634,10 @@ msgstr "无价格影响。在此规模下增加做多<0/>或减少做空仓位�
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
+msgstr ""
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Slippage guard"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -10033,6 +10055,10 @@ msgstr "在 Arbitrum 上推荐的交易者"
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GM?"
 msgstr "什么是 GM？"
+
+#: src/pages/VaultDetail/VaultDetailPage.tsx
+msgid "Route"
+msgstr ""
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -40,6 +40,7 @@ import NumberInput from "components/NumberInput/NumberInput";
 const ETH_PRICE_USD = 2000;
 
 const MOCK_PRICE_FEED = (localhostDeployment.addresses as { MockPriceFeed?: string }).MockPriceFeed ?? "";
+const USDC_ADDRESS = (localhostDeployment.addresses as { tokens?: { USDC?: string } }).tokens?.USDC ?? "";
 const POLL_MS = 15_000;
 
 // ---------------------------------------------------------------------------
@@ -238,16 +239,14 @@ export default function HedgeDetailPage() {
     const params = {
       rwaToken: cfg.tokenAddress,
       rwaAmount: rwaAmountWad,
-      collateralToken: cfg.tokenAddress, // placeholder; USDC addr resolved in hook
+      // USDC margin uses tokens.USDC; ETH margin ignores this field (collateral sent via msg.value)
+      collateralToken: USDC_ADDRESS,
       collateralAmount,
+      // Index token = RWA token address (MockPriceFeed has its price)
       indexToken: cfg.tokenAddress,
       sizeDelta: sizeDeltaWad,
     };
 
-    // In managed mode we need the actual USDC address from vault config — use lpManagerAddress as proxy
-    // The real USDC address is deployment-dependent; for localhost, tokens.USDC is used.
-    // For now, pass a zero address (test environment resolves via deployment JSON).
-    // TODO: wire up actual USDC address from vaultConfig / deployment
     const err = await validate(mode, marginToken, params);
     if (err) {
       setValidationError(err);

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -20,7 +20,7 @@ import { useZapInActions } from "domain/vantage/vaults/useZapInActions";
 import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, getVaultConfigByAddress } from "domain/vantage/vaults/vaultConfig";
 import { useChainId } from "lib/chains";
 import useWallet from "lib/wallets/useWallet";
-import { ZAP_TOKENS, ZapTokenConfig } from "vantage/config/zapTokens";
+import { ZAP_TOKENS, ZapTokenConfig, resolvePoolFee } from "vantage/config/zapTokens";
 
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { AppNav } from "components/AppNav/AppNav";
@@ -494,7 +494,9 @@ export default function VaultDetailPage() {
                       </div>
                       <div className="flex justify-between">
                         <span>{t`DEX`}</span>
-                        <span className="text-white">Uniswap V3 ({zapToken.poolFee / 100}% fee)</span>
+                        <span className="text-white">
+                          Uniswap V3 ({resolvePoolFee(zapToken.isNative ? "eth" : "usdc", cfg.symbol) / 100}% fee)
+                        </span>
                       </div>
                       <div className="flex justify-between">
                         <span>{t`Slippage guard`}</span>

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -16,9 +16,11 @@ import { useVaultActions } from "domain/vantage/vaults/useVaultActions";
 import { useVaultApy } from "domain/vantage/vaults/useVaultApy";
 import { useVaultDetail } from "domain/vantage/vaults/useVaultDetail";
 import { useVaultTxHistory } from "domain/vantage/vaults/useVaultTxHistory";
+import { useZapInActions } from "domain/vantage/vaults/useZapInActions";
 import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, getVaultConfigByAddress } from "domain/vantage/vaults/vaultConfig";
 import { useChainId } from "lib/chains";
 import useWallet from "lib/wallets/useWallet";
+import { ZAP_TOKENS, ZapTokenConfig } from "vantage/config/zapTokens";
 
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { AppNav } from "components/AppNav/AppNav";
@@ -85,7 +87,7 @@ function AumSparkline({ history }: { history: { aum: bigint }[] }) {
 // Page component
 // ---------------------------------------------------------------------------
 
-type Tab = "deposit" | "withdraw";
+type Tab = "deposit" | "zap" | "withdraw";
 
 export default function VaultDetailPage() {
   const { address } = useParams<{ address: string }>();
@@ -95,15 +97,19 @@ export default function VaultDetailPage() {
 
   const cfg = getVaultConfigByAddress(address);
 
-  const data = useVaultDetail(cfg!, chainId);
-  const actions = useVaultActions(cfg!, chainId);
-  const { txs } = useVaultTxHistory(cfg!);
-  const apy = useVaultApy(cfg!);
-
   const [activeTab, setActiveTab] = useState<Tab>("deposit");
   const [depositInput, setDepositInput] = useState("");
   const [withdrawInput, setWithdrawInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [zapToken, setZapToken] = useState<ZapTokenConfig>(ZAP_TOKENS[0]);
+  const [zapInput, setZapInput] = useState("");
+  const [zapError, setZapError] = useState<string | null>(null);
+
+  const data = useVaultDetail(cfg!, chainId);
+  const actions = useVaultActions(cfg!, chainId);
+  const zapActions = useZapInActions(cfg!, zapToken, chainId);
+  const { txs } = useVaultTxHistory(cfg!);
+  const apy = useVaultApy(cfg!);
 
   const isTestnet = !MAINNET_CHAIN_IDS.has(chainId);
 
@@ -190,6 +196,31 @@ export default function VaultDetailPage() {
   function handleSetMaxWithdraw() {
     if (data.vlpBalance > 0n) {
       setWithdrawInput(formatEther(data.vlpBalance));
+    }
+  }
+
+  async function handleZap() {
+    if (!cfg || !zapInput || parseFloat(zapInput) <= 0) return;
+    // For the USDC route we need the USDC token address.
+    // cfg.tokenAddress is the RWA token; USDC address comes from the stable vault config.
+    const { VAULT_CONFIGS } = await import("domain/vantage/vaults/vaultConfig");
+    const stableVault = VAULT_CONFIGS.find((v) => v.assetType === "stable");
+    const params = {
+      amountIn: zapInput,
+      minTokenOut: 0n,
+      usdcAddress: stableVault?.tokenAddress ?? "",
+    };
+    const err = await zapActions.validate(params);
+    if (err) {
+      setZapError(err);
+      return;
+    }
+    setZapError(null);
+    try {
+      await zapActions.execute(params);
+      setZapInput("");
+    } catch (e: any) {
+      setZapError((e as Error)?.message ?? "Transaction failed");
     }
   }
 
@@ -328,7 +359,7 @@ export default function VaultDetailPage() {
             <div className="bg-cold-blue-950 overflow-hidden rounded-4 border border-stroke-primary">
               {/* Tab header */}
               <div className="flex border-b border-stroke-primary">
-                {(["deposit", "withdraw"] as Tab[]).map((tab) => (
+                {(["deposit", "zap", "withdraw"] as Tab[]).map((tab) => (
                   <button
                     key={tab}
                     onClick={() => setActiveTab(tab)}
@@ -338,7 +369,7 @@ export default function VaultDetailPage() {
                         : "hover:text-slate-200 text-slate-400"
                     }`}
                   >
-                    {tab === "deposit" ? t`Deposit` : t`Withdraw`}
+                    {tab === "deposit" ? t`Deposit` : tab === "zap" ? t`Zap In` : t`Withdraw`}
                   </button>
                 ))}
               </div>
@@ -404,6 +435,88 @@ export default function VaultDetailPage() {
                         className="w-full"
                       >
                         {isSubmitting ? t`Depositing…` : t`Deposit`}
+                      </Button>
+                    )}
+                  </div>
+                )}
+
+                {/* ── Zap In tab ───────────────────────────────────────────── */}
+                {activeTab === "zap" && (
+                  <div className="flex flex-col gap-16">
+                    {/* Token selector */}
+                    <div className="flex gap-8">
+                      {ZAP_TOKENS.map((zt) => (
+                        <button
+                          key={zt.key}
+                          onClick={() => {
+                            setZapToken(zt);
+                            setZapInput("");
+                            setZapError(null);
+                          }}
+                          className={`flex-1 rounded-4 border py-8 text-13 font-medium transition-colors ${
+                            zapToken.key === zt.key
+                              ? "bg-blue-900/40 border-blue-500 text-white"
+                              : "hover:text-slate-200 border-stroke-primary text-slate-400"
+                          }`}
+                        >
+                          {zt.label}
+                        </button>
+                      ))}
+                    </div>
+
+                    {/* Amount input */}
+                    <div>
+                      <label className="mb-6 block text-12 text-slate-400">
+                        {t`Amount`} ({zapToken.symbol})
+                      </label>
+                      <div className="flex items-center gap-8 rounded-4 border border-stroke-primary bg-slate-800 px-12 py-10">
+                        <NumberInput
+                          value={zapInput}
+                          onValueChange={(e: ChangeEvent<HTMLInputElement>) => {
+                            setZapInput(e.target.value);
+                            setZapError(null);
+                          }}
+                          placeholder="0.00"
+                          maxDecimals={zapToken.decimals}
+                          className="bg-transparent flex-1 text-16 text-white outline-none"
+                        />
+                        <span className="text-14 font-medium text-slate-400">{zapToken.symbol}</span>
+                      </div>
+                    </div>
+
+                    {/* Info */}
+                    <div className="space-y-4 rounded-4 bg-slate-800/50 p-12 text-12 text-slate-400">
+                      <div className="flex justify-between">
+                        <span>{t`Route`}</span>
+                        <span className="text-white">
+                          {zapToken.symbol} → {cfg.symbol} → VLP
+                        </span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>{t`DEX`}</span>
+                        <span className="text-white">Uniswap V3 ({zapToken.poolFee / 100}% fee)</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>{t`Slippage guard`}</span>
+                        <span className="text-white">Oracle ±3%</span>
+                      </div>
+                    </div>
+
+                    {zapError && (
+                      <div className="rounded-4 bg-red-900/40 px-12 py-8 text-13 text-red-400">{zapError}</div>
+                    )}
+
+                    {!account ? (
+                      <div className="py-8 text-center text-14 text-slate-400">{t`Connect wallet to zap in`}</div>
+                    ) : (
+                      <Button
+                        variant="primary"
+                        size="medium"
+                        disabled={!zapInput || parseFloat(zapInput) <= 0 || zapActions.isSubmitting}
+                        onClick={handleZap}
+                        className="w-full"
+                      >
+                        {zapActions.isSubmitting ? t`Zapping…` : t`Zap In`}
                       </Button>
                     )}
                   </div>

--- a/src/vantage/abis/LPZapper.json
+++ b/src/vantage/abis/LPZapper.json
@@ -1,0 +1,465 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_swapRouter",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_priceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_lpManager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_usdc",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ETHRefundFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDeviationBps",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "actualOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedMinOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "OracleDeviationExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "actualOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minTokenOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "SlippageExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxOracleDeviationBpsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "usdcIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "ZapIn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "ZapInETH",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "lpManager",
+    "outputs": [
+      {
+        "internalType": "contract ILPManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxOracleDeviationBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceFeed",
+    "outputs": [
+      {
+        "internalType": "contract IVaultPriceFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "rescueETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "rescueTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxOracleDeviationBps",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapRouter",
+    "outputs": [
+      {
+        "internalType": "contract ISwapRouter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "usdc",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "weth",
+    "outputs": [
+      {
+        "internalType": "contract IWETH",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdcAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minTokenOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint24",
+        "name": "poolFee",
+        "type": "uint24"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "zapIn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minTokenOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint24",
+        "name": "poolFee",
+        "type": "uint24"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "zapInETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/vantage/config/zapTokens.ts
+++ b/src/vantage/config/zapTokens.ts
@@ -1,0 +1,46 @@
+/**
+ * zapTokens.ts
+ *
+ * Static configuration for tokens supported by LPZapper (Route 2 deposit).
+ * Each entry describes an input token that can be swapped via Uniswap V3
+ * before being deposited into the target RWA vault.
+ *
+ * Currently supported: USDC, ETH (native)
+ *
+ * poolFee: Uniswap V3 fee tier in bps (500=0.05%, 3000=0.3%, 10000=1%)
+ * defaultDeviationBps: suggested maxOracleDeviationBps for the route (informational)
+ */
+
+export interface ZapTokenConfig {
+  /** "usdc" | "eth" */
+  key: string;
+  /** Display label */
+  label: string;
+  /** Symbol shown in the UI */
+  symbol: string;
+  /** Token decimals (6 for USDC, 18 for ETH) */
+  decimals: number;
+  /** Whether this is the native ETH route (uses zapInETH) */
+  isNative: boolean;
+  /** Uniswap V3 pool fee tier (bps) */
+  poolFee: number;
+}
+
+export const ZAP_TOKENS: ZapTokenConfig[] = [
+  {
+    key: "usdc",
+    label: "USDC",
+    symbol: "USDC",
+    decimals: 6,
+    isNative: false,
+    poolFee: 3000,
+  },
+  {
+    key: "eth",
+    label: "ETH",
+    symbol: "ETH",
+    decimals: 18,
+    isNative: true,
+    poolFee: 3000,
+  },
+];

--- a/src/vantage/config/zapTokens.ts
+++ b/src/vantage/config/zapTokens.ts
@@ -1,15 +1,35 @@
 /**
  * zapTokens.ts
  *
- * Static configuration for tokens supported by LPZapper (Route 2 deposit).
- * Each entry describes an input token that can be swapped via Uniswap V3
- * before being deposited into the target RWA vault.
+ * Configuration for LPZapper (Route 2 deposit).
  *
- * Currently supported: USDC, ETH (native)
+ * Two layers of config:
  *
- * poolFee: Uniswap V3 fee tier in bps (500=0.05%, 3000=0.3%, 10000=1%)
- * defaultDeviationBps: suggested maxOracleDeviationBps for the route (informational)
+ *   1. ZAP_TOKENS       — input token list (USDC, ETH). Defines decimals / isNative.
+ *      `poolFee` is removed from here — the fee is determined per (inputToken, targetToken) pair.
+ *
+ *   2. POOL_FEE_CONFIG   — per-target-token optimal Uniswap V3 fee tier mapping.
+ *      Each target RWA token has a record of { usdc: fee, eth: fee } reflecting
+ *      the deepest pool for that route on Arbitrum One.
+ *
+ * Fee tier guide:
+ *   100   = 0.01% (extremely stable pairs, e.g. USDC/USDT)
+ *   500   = 0.05% (stable-ish pairs, e.g. ETH/wstETH, USDC/sUSDS)
+ *   3000  = 0.30% (standard volatile pairs)
+ *   10000 = 1.00% (exotic / low-liquidity pairs)
+ *
+ * Sources (Arbitrum One, verified 2026-04):
+ *   - sUSDS  : USDC→sUSDS 500  (Sky Money stable corridor)
+ *   - sUSDe  : USDC→sUSDe 500  (Ethena stable corridor)
+ *   - wstETH : USDC→wstETH 3000, ETH→wstETH 500
+ *
+ * ⚠ VERIFY fee tiers against Uniswap V3 pool analytics before mainnet deployment.
+ *   Pools with insufficient liquidity should use 3000 as a safe default.
  */
+
+// ---------------------------------------------------------------------------
+// Input token (USDC / ETH)
+// ---------------------------------------------------------------------------
 
 export interface ZapTokenConfig {
   /** "usdc" | "eth" */
@@ -18,12 +38,10 @@ export interface ZapTokenConfig {
   label: string;
   /** Symbol shown in the UI */
   symbol: string;
-  /** Token decimals (6 for USDC, 18 for ETH) */
+  /** Token decimals (6 for USDC, 18 for ETH/WETH) */
   decimals: number;
   /** Whether this is the native ETH route (uses zapInETH) */
   isNative: boolean;
-  /** Uniswap V3 pool fee tier (bps) */
-  poolFee: number;
 }
 
 export const ZAP_TOKENS: ZapTokenConfig[] = [
@@ -33,7 +51,6 @@ export const ZAP_TOKENS: ZapTokenConfig[] = [
     symbol: "USDC",
     decimals: 6,
     isNative: false,
-    poolFee: 3000,
   },
   {
     key: "eth",
@@ -41,6 +58,51 @@ export const ZAP_TOKENS: ZapTokenConfig[] = [
     symbol: "ETH",
     decimals: 18,
     isNative: true,
-    poolFee: 3000,
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Per-target-token fee tier map
+// ---------------------------------------------------------------------------
+
+/** Uniswap V3 fee tiers (basis points). */
+export const FEE = {
+  LOWEST: 100,
+  LOW: 500,
+  MEDIUM: 3000,
+  HIGH: 10000,
+} as const;
+
+export type FeeTier = (typeof FEE)[keyof typeof FEE];
+
+/**
+ * Optimal pool fee tier keyed by target token symbol (uppercase).
+ * Separate values for the USDC→token and ETH→token routes.
+ *
+ * Fallback: MEDIUM (3000) when a token is not listed here.
+ */
+export const POOL_FEE_CONFIG: Record<string, { usdc: FeeTier; eth: FeeTier }> = {
+  // Sky Money Savings USDS — very stable vs. USDC, tightest pool
+  sUSDS: { usdc: FEE.LOW, eth: FEE.MEDIUM },
+
+  // Ethena Staked USDe — stable vs. USDC
+  sUSDe: { usdc: FEE.LOW, eth: FEE.MEDIUM },
+
+  // Wrapped staked ETH — liquid wstETH/ETH pool exists at 500
+  wstETH: { usdc: FEE.MEDIUM, eth: FEE.LOW },
+
+  // Mock tokens (testnet) — MockSwapRouter ignores fee, use MEDIUM as placeholder
+  mBUIDL: { usdc: FEE.MEDIUM, eth: FEE.MEDIUM },
+  mUSDY: { usdc: FEE.MEDIUM, eth: FEE.MEDIUM },
+  mRWA: { usdc: FEE.MEDIUM, eth: FEE.MEDIUM },
+};
+
+/**
+ * Returns the optimal Uniswap V3 fee tier for swapping `zapTokenKey` → `targetSymbol`.
+ * Falls back to MEDIUM (3000) when the pair is not explicitly configured.
+ */
+export function resolvePoolFee(zapTokenKey: "usdc" | "eth", targetSymbol: string): FeeTier {
+  const entry = POOL_FEE_CONFIG[targetSymbol];
+  if (!entry) return FEE.MEDIUM;
+  return entry[zapTokenKey];
+}

--- a/src/vantage/contracts.ts
+++ b/src/vantage/contracts.ts
@@ -60,6 +60,7 @@ export type VantageContractName =
   | "HedgeController"
   | "LPManager"
   | "LPToken"
+  | "LPZapper"
   | "ManualAdapter"
   | "MultiOracleMiddleware"
   | "OrderBook"
@@ -88,6 +89,7 @@ const VANTAGE_CONTRACTS: Record<number, VantageAddressMap> = {
     HedgeController: ZERO,
     LPManager: ARBITRUM_LP_MANAGER,
     LPToken: ARBITRUM_LP_TOKEN,
+    LPZapper: ZERO,
     ManualAdapter: ARBITRUM_MANUAL_ADAPTER,
     MultiOracleMiddleware: ARBITRUM_MULTI_ORACLE_MIDDLEWARE,
     OrderBook: ARBITRUM_ORDER_BOOK,
@@ -108,6 +110,7 @@ const VANTAGE_CONTRACTS: Record<number, VantageAddressMap> = {
     HedgeController: (localhostDeployment.addresses as { HedgeController?: string }).HedgeController ?? ZERO,
     LPManager: localhostDeployment.addresses.LPManager ?? ZERO,
     LPToken: localhostDeployment.addresses.LPToken ?? ZERO,
+    LPZapper: (localhostDeployment.addresses as { LPZapper?: string }).LPZapper ?? ZERO,
     ManualAdapter: ZERO,
     MultiOracleMiddleware: ZERO,
     OrderBook: localhostDeployment.addresses.OrderBook ?? ZERO,
@@ -128,6 +131,7 @@ const VANTAGE_CONTRACTS: Record<number, VantageAddressMap> = {
     HedgeController: ZERO,
     LPManager: ARBITRUM_SEPOLIA_LP_MANAGER,
     LPToken: ARBITRUM_SEPOLIA_LP_TOKEN,
+    LPZapper: ZERO,
     ManualAdapter: ARBITRUM_SEPOLIA_MANUAL_ADAPTER,
     MultiOracleMiddleware: ARBITRUM_SEPOLIA_MULTI_ORACLE_MIDDLEWARE,
     OrderBook: ARBITRUM_SEPOLIA_ORDER_BOOK,


### PR DESCRIPTION
## 概要

Issue #172 のフロントエンド実装。VaultDetailPage に「Zap In」タブを追加し、USDC または ETH から直接 RWA Vault の LP シェアを取得できる UI を提供する。

## 変更点

- **`src/vantage/abis/LPZapper.json`** — コンパイル済み ABI
- **`src/vantage/config/zapTokens.ts`** — USDC / ETH の ZapTokenConfig 定義
- **`src/vantage/contracts.ts`** — `VantageContractName` に `LPZapper` を追加
- **`src/domain/vantage/vaults/useZapInActions.ts`** — zapIn / zapInETH トランザクションフック
  - USDC ルート: allowance チェック → approve → `LPZapper.zapIn`
  - ETH ルート: `LPZapper.zapInETH`（value 付き）
  - `validate()`: 残高チェック（USDC balanceOf / ETH getBalance）
- **`src/pages/VaultDetail/VaultDetailPage.tsx`** — Zap In タブ追加
  - USDC / ETH トークン切り替えボタン
  - 金額入力 → `useZapInActions.execute`
  - Oracle ±3% / Uniswap V3 fee 情報表示

## テスト方法

1. `pnpm hardhat node` でローカルノード起動
2. `pnpm hardhat run scripts/deploy.js` でコントラクトデプロイ（Step 17b で MockSwapRouter + LPZapper がデプロイされる）
3. フロントエンドを起動 → Vault 詳細ページ → 「Zap In」タブ

🤖 Generated with [Claude Code](https://claude.com/claude-code)