### PR TITLE
feat(issue-179): Dynamic Safety Buffer indicator on Hedge page

### DIFF
--- a/src/domain/vantage/hedge/useHedgePageData.ts
+++ b/src/domain/vantage/hedge/useHedgePageData.ts
@@ -83,6 +83,12 @@ export interface HedgePageData {
   hedgeCapacityPct: number | null;
   /** Safety buffer configured on the Vault (basis points, e.g. 2000 = 20%) */
   safetyBufferBps: number | null;
+  /**
+   * Dynamic buffer currently in effect (Issue #179).
+   * Equals safetyBufferBps during stable markets; rises above it during FR spikes.
+   * null when data is unavailable.
+   */
+  requiredBufferBps: number | null;
 }
 
 const EMPTY: HedgePageData = {
@@ -97,6 +103,7 @@ const EMPTY: HedgePageData = {
   isHedgeDisabled: false,
   hedgeCapacityPct: null,
   safetyBufferBps: null,
+  requiredBufferBps: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -198,11 +205,16 @@ export function useHedgePageData(
         // Simplified per-unit estimate: |shortFRBps| / (yieldAprBps × (1-buffer)) × 100.
         let isHedgeDisabled = false;
         let safetyBufferBps: number | null = null;
+        let requiredBufferBps: number | null = null;
         let hedgeCapacityPct: number | null = null;
         try {
-          [isHedgeDisabled, safetyBufferBps] = await Promise.all([
+          [isHedgeDisabled, safetyBufferBps, requiredBufferBps] = await Promise.all([
             vault.isHedgeDisabled() as Promise<boolean>,
             vault.safetyBufferBps().then(Number) as Promise<number>,
+            vault
+              .getRequiredBuffer()
+              .then(Number)
+              .catch(() => null) as Promise<number | null>,
           ]);
 
           if (fundingRateBps !== null && yieldAprBps !== null && safetyBufferBps !== null) {
@@ -248,6 +260,7 @@ export function useHedgePageData(
             isHedgeDisabled,
             hedgeCapacityPct,
             safetyBufferBps,
+            requiredBufferBps,
           });
         }
       } catch {

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3821,6 +3821,10 @@ msgstr "Dezentralisiertes Optionsprotokoll"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "Handeln Sie in großem Umfang, ohne sich über dünne Orderbücher oder Slippage Sorgen machen zu müssen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "GLV kaufen"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "Kauf von {gmOrGlvLabel} fehlgeschlagen."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "Genießen Sie ein reibungsloses Handelserlebnis und umgehen Sie Blockcha
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "Top-Positionen"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3821,6 +3821,10 @@ msgstr "Decentralized options protocol"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "Trade at scale without worrying about thin order books or slippage"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "Buy GLV"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "Buy {gmOrGlvLabel} failed."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "Enjoy a frictionless trading experience and sidestep blockchain congesti
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "Top positions"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr "Buffer"
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3821,6 +3821,10 @@ msgstr "Protocolo descentralizado de opciones"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "Opere a gran escala sin preocuparse por libros de órdenes con poca profundidad o deslizamiento"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "Comprar GLV"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "Error al comprar {gmOrGlvLabel}."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "Disfrute de una experiencia de trading sin fricciones y evite la congest
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "Principales posiciones"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3821,6 +3821,10 @@ msgstr "Protocole d'options décentralisé"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "Tradez à grande échelle sans vous soucier de carnets d'ordres peu profonds ou du glissement"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "Acheter GLV"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "L'achat de {gmOrGlvLabel} a échoué."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "Profitez d'une expérience de trading fluide et évitez la congestion de
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "Meilleures positions"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3821,6 +3821,10 @@ msgstr "分散型オプションプロトコル"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "薄い板やスリッページを気にせず、大規模な取引を行えます"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "GLVを購入"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "{gmOrGlvLabel}の購入に失敗しました。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "One-Click TradingとExpress Tradingで、ブロックチェーンの混�
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "トップポジション"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3821,6 +3821,10 @@ msgstr "탈중앙화 옵션 프로토콜"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "얇은 호가창이나 슬리피지 걱정 없이 대규모로 거래하십시오"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "GLV 구매"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "{gmOrGlvLabel} 구매에 실패했습니다."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "One-Click Trading 및 Express Trading으로 원활한 거래 경험을 �
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "상위 포지션"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -3821,6 +3821,10 @@ msgstr ""
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5217,6 +5221,10 @@ msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
 msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
@@ -8558,6 +8566,11 @@ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
 msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -3821,6 +3821,10 @@ msgstr "Децентрализованный протокол опционов"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "Торгуйте крупными объёмами, не беспокоясь о тонких книгах ордеров или проскальзывании"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "Купить GLV"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "Покупка {gmOrGlvLabel} не удалась."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "Наслаждайтесь бесперебойной торговлей
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "Лучшие позиции"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -3821,6 +3821,10 @@ msgstr "去中心化選擇權協議"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "大規模交易，無需擔憂薄弱的訂單簿或滑點"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "買入 GLV"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "買入 {gmOrGlvLabel} 失敗。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "透過 One-Click Trading 和 Express Trading，享受無摩擦的交易�
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "熱門倉位"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3821,6 +3821,10 @@ msgstr "去中心化期权协议"
 msgid "Trade at scale without worrying about thin order books or slippage"
 msgstr "大规模交易无需担忧订单簿深度不足或滑点问题"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle"
@@ -5218,6 +5222,10 @@ msgstr "购买 GLV"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Buy {gmOrGlvLabel} failed."
 msgstr "买入 {gmOrGlvLabel} 失败。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -8559,6 +8567,11 @@ msgstr "通过 One-Click Trading 和 Express Trading 享受顺畅的交易体验
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Top positions"
 msgstr "排名仓位"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Buffer"
+msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -32,6 +32,7 @@ import localhostDeployment from "vantage/deployments/frontend-localhost.json";
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { AppNav } from "components/AppNav/AppNav";
 import NumberInput from "components/NumberInput/NumberInput";
+import Tooltip from "components/Tooltip/Tooltip";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -106,6 +107,10 @@ type StatusBarProps = {
   netApyBps: number | null;
   isHedgeDisabled: boolean;
   hedgeCapacityPct: number | null;
+  /** Base safety buffer (safetyBufferBps). Equals requiredBufferBps during stable markets. */
+  safetyBufferBps: number | null;
+  /** Current dynamic buffer in effect (Issue #179). Rises above safetyBufferBps during FR spikes. */
+  requiredBufferBps: number | null;
 };
 
 function HedgeStatusBar({
@@ -117,6 +122,8 @@ function HedgeStatusBar({
   netApyBps,
   isHedgeDisabled,
   hedgeCapacityPct,
+  safetyBufferBps,
+  requiredBufferBps,
 }: StatusBarProps) {
   const usedPct =
     maxShortCapacityUsd && remainingCapacityUsd !== null
@@ -215,6 +222,47 @@ function HedgeStatusBar({
           {systemStatus === "healthy" && netApyBps !== null && netApyBps > 0 && (
             <div className="mt-4 text-11 text-green-500">{t`You are being paid to hedge`}</div>
           )}
+
+          {/* Dynamic Buffer indicator (Issue #179) */}
+          {safetyBufferBps !== null &&
+            requiredBufferBps !== null &&
+            (() => {
+              const basePct = (safetyBufferBps / 100).toFixed(1);
+              const curPct = (requiredBufferBps / 100).toFixed(1);
+              const isSpiked = requiredBufferBps > safetyBufferBps;
+
+              return (
+                <div className="mt-8">
+                  <Tooltip
+                    position="bottom-end"
+                    content={
+                      isSpiked
+                        ? t`FR spike detected. Safety buffer has been automatically raised from ${basePct}% to ${curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises.`
+                        : t`Safety buffer is at its base level (${basePct}%). Market conditions are stable — no FR spike adjustment active.`
+                    }
+                    handle={
+                      <div
+                        className={`inline-flex cursor-help items-center gap-5 rounded-full px-8 py-3 text-11 font-medium ${
+                          isSpiked ? "bg-orange-900/30 text-orange-300" : "bg-slate-800 text-slate-400"
+                        }`}
+                      >
+                        {isSpiked ? (
+                          <>
+                            <span className="bg-orange-400 h-5 w-5 rounded-full" />
+                            {t`Buffer`}: {basePct}% → {curPct}% ↑
+                          </>
+                        ) : (
+                          <>
+                            <span className="h-5 w-5 rounded-full bg-slate-500" />
+                            {t`Buffer`}: {curPct}%
+                          </>
+                        )}
+                      </div>
+                    }
+                  />
+                </div>
+              );
+            })()}
         </div>
       </div>
     </div>
@@ -556,6 +604,8 @@ export default function HedgeDetailPage() {
           netApyBps={pageData.netApyBps}
           isHedgeDisabled={pageData.isHedgeDisabled}
           hedgeCapacityPct={pageData.hedgeCapacityPct}
+          safetyBufferBps={pageData.safetyBufferBps}
+          requiredBufferBps={pageData.requiredBufferBps}
         />
 
         {/* ── Section 2 + 3: Chart (left) + Action panel (right) ───────────── */}


### PR DESCRIPTION
## 概要

Issue #179（Dynamic Safety Buffer with Slippage Guard）のコントラクト実装に対応したフロントエンド。HedgeDetailPage の System Status セルに動的バッファーのリアルタイム表示を追加。

## 変更ファイル

### `src/domain/vantage/hedge/useHedgePageData.ts`
- `HedgePageData` に `requiredBufferBps: number | null` を追加
- ポーリング Step 7 で `vault.getRequiredBuffer()` を取得
  - `.catch(() => null)` で古いデプロイメントへの後方互換を保持

### `src/pages/Hedge/HedgeDetailPage.tsx`
- `Tooltip` コンポーネントを import
- `StatusBarProps` に `safetyBufferBps` / `requiredBufferBps` を追加
- HedgeStatusBar の System Status セル下部に **Dynamic Buffer バッジ** を追加

## UI 挙動

| 状態 | 表示 |
|---|---|
| FR 安定時（`requiredBuffer == safetyBuffer`） | グレーのピル `Buffer: 20.0%` |
| FR スパイク時（`requiredBuffer > safetyBuffer`） | オレンジのピル `Buffer: 20.0% → 28.5% ↑` |

スパイク時のツールチップ:
> *"FR spike detected. Safety buffer has been automatically raised from 20.0% to 28.5% to protect LP assets. New hedge capacity is tighter until the market stabilises."*

安定時のツールチップ:
> *"Safety buffer is at its base level (20.0%). Market conditions are stable — no FR spike adjustment active."*

## 対応コントラクト PR

itchii-06/bcellar-monorepo#186