### PR TITLE
feat(issue-180): Soft Deleveraging — FR停止警告 + ソルベンシー比率UI

### DIFF
--- a/src/domain/vantage/hedge/useHedgePageData.ts
+++ b/src/domain/vantage/hedge/useHedgePageData.ts
@@ -89,6 +89,17 @@ export interface HedgePageData {
    * null when data is unavailable.
    */
   requiredBufferBps: number | null;
+  /**
+   * Unix timestamp when the raw SolvencyRatio first dropped below 1.0 (Issue #180).
+   * 0 = currently healthy. Non-zero = deficit has been ongoing since this time.
+   * null when data is unavailable.
+   */
+  solvencyDropAt: number | null;
+  /**
+   * True when the user's own short position in this vault has been soft-locked
+   * by the Keeper (FR offset temporarily suspended, Issue #180).
+   */
+  isSoftLockedPosition: boolean;
 }
 
 const EMPTY: HedgePageData = {
@@ -104,6 +115,8 @@ const EMPTY: HedgePageData = {
   hedgeCapacityPct: null,
   safetyBufferBps: null,
   requiredBufferBps: null,
+  solvencyDropAt: null,
+  isSoftLockedPosition: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -207,14 +220,19 @@ export function useHedgePageData(
         let safetyBufferBps: number | null = null;
         let requiredBufferBps: number | null = null;
         let hedgeCapacityPct: number | null = null;
+        let solvencyDropAt: number | null = null;
         try {
-          [isHedgeDisabled, safetyBufferBps, requiredBufferBps] = await Promise.all([
+          [isHedgeDisabled, safetyBufferBps, requiredBufferBps, solvencyDropAt] = await Promise.all([
             vault.isHedgeDisabled() as Promise<boolean>,
             vault.safetyBufferBps().then(Number) as Promise<number>,
             vault
               .getRequiredBuffer()
               .then(Number)
               .catch(() => null) as Promise<number | null>,
+            vault
+              .solvencyDropAt()
+              .then(Number)
+              .catch(() => 0) as Promise<number>,
           ]);
 
           if (fundingRateBps !== null && yieldAprBps !== null && safetyBufferBps !== null) {
@@ -227,8 +245,9 @@ export function useHedgePageData(
           // Vault may not have these methods in older deployments — fail silently
         }
 
-        // ── 8. User position (short, USDC collateral) ───────────────────────
+        // ── 8. User position (short, USDC collateral) + soft-lock status ───────
         let userPosition: UserPosition | null = null;
+        let isSoftLockedPosition = false;
         if (account && USDC_ADDRESS) {
           const key: string = await vault.getPositionKey(
             account,
@@ -236,7 +255,10 @@ export function useHedgePageData(
             tokenAddr,
             false // isLong = false (short)
           );
-          const pos = await vault.positions(key);
+          const [pos, softLocked] = await Promise.all([
+            vault.positions(key),
+            vault.isSoftLockedPosition(key).catch(() => false) as Promise<boolean>,
+          ]);
           if (BigInt(pos.size) > 0n) {
             userPosition = {
               sizeUsd: parseFloat(formatEther(pos.size)),
@@ -244,6 +266,7 @@ export function useHedgePageData(
               averagePrice: parseFloat(formatEther(pos.averagePrice)),
               collateralToken: "USDC",
             };
+            isSoftLockedPosition = softLocked;
           }
         }
 
@@ -261,6 +284,8 @@ export function useHedgePageData(
             hedgeCapacityPct,
             safetyBufferBps,
             requiredBufferBps,
+            solvencyDropAt,
+            isSoftLockedPosition,
           });
         }
       } catch {

--- a/src/domain/vantage/portfolio/usePortfolioData.ts
+++ b/src/domain/vantage/portfolio/usePortfolioData.ts
@@ -67,6 +67,17 @@ export type HedgePortfolioItem = {
   /** User's short collateral in USD (float) — null if no position */
   shortCollateralUsd: number | null;
   isLoading: boolean;
+  /**
+   * Unix timestamp when the vault's raw SolvencyRatio first dropped below 1.0 (Issue #180).
+   * 0 or null = currently healthy.
+   */
+  solvencyDropAt: number | null;
+  /** True if the user's own short position is currently soft-locked (FR offset suspended). */
+  isSoftLocked: boolean;
+  /** Yield APR in bps — used for solvency ratio display */
+  yieldAprBps: number | null;
+  /** Funding rate in bps from short's perspective (negative = shorts pay) */
+  fundingRateBps: number | null;
 };
 
 export type PortfolioGlobalStats = {
@@ -167,6 +178,10 @@ export function usePortfolioData(chainId: number, account: string | undefined): 
           shortSizeUsd: hd?.userPosition?.sizeUsd ?? null,
           shortCollateralUsd: hd?.userPosition?.collateralUsd ?? null,
           isLoading: hd ? false : true,
+          solvencyDropAt: hd?.solvencyDropAt ?? null,
+          isSoftLocked: hd?.isSoftLockedPosition ?? false,
+          yieldAprBps: hd?.yieldAprBps ?? null,
+          fundingRateBps: hd?.fundingRateBps ?? null,
         };
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -876,6 +876,11 @@ msgstr "STIP.b retroaktiver Bonus"
 msgid "in liquidity"
 msgstr "In Liquidität"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "Nahtloser Handel mit Express-Zuverlässigkeit"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> zu </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "Fehlgeschlagene Abhebung"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "Marktverringerung fehlgeschlagen"
@@ -2664,6 +2677,10 @@ msgstr "Abwicklung bestätigen"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "Protokoll-Risiko-Explorer und Statistiken"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "Maximaler Finanzierungsfaktor"
 msgid "High price impact"
 msgstr "Hoher Preis-Impact"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "Abhebung vom GMX-Konto"
 msgid "Purpose"
 msgstr "Zweck"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "Für mich"
@@ -7791,6 +7816,10 @@ msgstr "Funding-Gebühr / Tag"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "GLP-Erstattung (Test)"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "GM mit {0} kaufen bis zu den unten angegebenen Limits"
 msgid "V2 trading"
 msgstr "V2-Trading"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "Protokoll-Analytik"
@@ -9277,6 +9310,10 @@ msgstr "Staken Sie GMX und kaufen Sie GLV oder GM, um Belohnungen zu erhalten"
 msgid "Sellable"
 msgstr "Verkäuflich"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "Wählen Sie Positionen aus, bei denen die aufgelaufene Finanzierungsgebühr die {0} Gas-Kosten für die Abwicklung übersteigt"
@@ -9574,6 +9611,10 @@ msgstr "Einzahlungen werden auf Avalanche nicht unterstützt."
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "Verschieben"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "Empfehlungscodes"
 msgid "Performance vs benchmark over selected period"
 msgstr "Performance im Vergleich zum Benchmark über den ausgewählten Zeitraum"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "Empfehlungscode aktualisiert"
@@ -10690,6 +10735,10 @@ msgstr "Etwas unwichtiger Text, aber dennoch lesbar"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "Geringe Sicherheit nach Gebühren. Zahlen Sie mehr ein, um das Liquidati
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "Keine Märkte gefunden"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -876,6 +876,11 @@ msgstr "STIP.b retroactive bonus"
 msgid "in liquidity"
 msgstr "in liquidity"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr "システム収益保護のため、現在一時的にFR相殺が停止されています"
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
@@ -1055,6 +1060,10 @@ msgstr "Seamless trading with Express reliability"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> to </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr "前より赤字検知"
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "Failed withdraw"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr "プロトコル・ソルベンシー"
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "Failed Market Decrease"
@@ -2664,6 +2677,10 @@ msgstr "Confirm settle"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "Protocol risk explorer and stats"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr "FRコスト"
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "Max funding factor"
 msgid "High price impact"
 msgstr "High price impact"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr "FR停止中"
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "Withdrawal from GMX Account"
 msgid "Purpose"
 msgstr "Purpose"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "For me"
@@ -7791,6 +7816,10 @@ msgstr "Funding fee / day"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "GLP reimbursement (test)"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr "（赤字）"
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "Buy GM with {0} up to the caps below"
 msgid "V2 trading"
 msgstr "V2 trading"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr "（健全）"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "Protocol analytics"
@@ -9277,6 +9310,10 @@ msgstr "Stake GMX and buy GLV or GM to earn rewards"
 msgid "Sellable"
 msgstr "Sellable"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr "FR相殺停止中"
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
@@ -9574,6 +9611,10 @@ msgstr "Deposits are not supported on Avalanche."
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "shift"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "Referral codes"
 msgid "Performance vs benchmark over selected period"
 msgstr "Performance vs benchmark over selected period"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr "ソルベンシーは回復しています。ポジションの復元を待っています。"
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "Referral code updated"
@@ -10690,6 +10735,10 @@ msgstr "Somewhat unimportant text, but still readable"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr "ソルベンシー比率"
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "Low collateral after fees. Deposit more to reduce liquidation risk."
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "No markets found"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr "利回り"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -876,6 +876,11 @@ msgstr "Bonificación retroactiva STIP.b"
 msgid "in liquidity"
 msgstr "en liquidez"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "Operativa fluida con la fiabilidad de Express"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> a </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "Retirada fallida"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "Reducción de Mercado Fallida"
@@ -2664,6 +2677,10 @@ msgstr "Confirmar compensación"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "Explorador de riesgos de protocolo y estadísticas"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "Factor máximo de financiación"
 msgid "High price impact"
 msgstr "Alto impacto en el precio"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "Retiro de Cuenta GMX"
 msgid "Purpose"
 msgstr "Propósito"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "Para mí"
@@ -7791,6 +7816,10 @@ msgstr "Comisión de financiación / día"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "Reembolso de GLP (prueba)"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "Comprar GM con {0} hasta los límites indicados a continuación"
 msgid "V2 trading"
 msgstr "Trading V2"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "Análisis de datos del protocolo"
@@ -9277,6 +9310,10 @@ msgstr "Stakear GMX y comprar GLV o GM para obtener recompensas"
 msgid "Sellable"
 msgstr "Vendible"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "Seleccione las posiciones en las que la comisión de financiación acumulada supere el coste de gas de {0} para compensar"
@@ -9574,6 +9611,10 @@ msgstr "Los depósitos no son compatibles en Avalanche."
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "cambio"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "Códigos de referido"
 msgid "Performance vs benchmark over selected period"
 msgstr "Rendimiento frente al índice de referencia en el período seleccionado"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "Código de referido actualizado"
@@ -10690,6 +10735,10 @@ msgstr "Texto algo secundario, pero aún legible"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "Garantía baja tras comisiones. Deposite más para reducir el riesgo de 
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "No se encontraron mercados"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -876,6 +876,11 @@ msgstr "Bonus rétroactif STIP.b"
 msgid "in liquidity"
 msgstr "en liquidité"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "Trading fluide avec la fiabilité Express"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> à </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "Retrait échoué"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "Diminution de marché échouée"
@@ -2664,6 +2677,10 @@ msgstr "Confirmer le règlement"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "Explorateur de risques de protocole et stats"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "Facteur de financement maximum"
 msgid "High price impact"
 msgstr "Impact élevé sur le prix"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "Retrait du Compte GMX"
 msgid "Purpose"
 msgstr "Objectif"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "Pour moi"
@@ -7791,6 +7816,10 @@ msgstr "Frais de funding / jour"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "Remboursement GLP (test)"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "Acheter des GM avec {0} jusqu'aux plafonds ci-dessous"
 msgid "V2 trading"
 msgstr "Trading V2"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "Analyses du protocole"
@@ -9277,6 +9310,10 @@ msgstr "Staker GMX et acheter GLV ou GM pour gagner des récompenses"
 msgid "Sellable"
 msgstr "Vendable"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "Sélectionnez les positions dont les frais de financement accumulés dépassent le coût en gas de {0} pour le règlement"
@@ -9574,6 +9611,10 @@ msgstr "Les dépôts ne sont pas pris en charge sur Avalanche."
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "décalage"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "Codes de parrainage"
 msgid "Performance vs benchmark over selected period"
 msgstr "Performance par rapport au benchmark sur la période sélectionnée"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "Code de parrainage mis à jour"
@@ -10690,6 +10735,10 @@ msgstr "Texte relativement peu important, mais toujours lisible"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "Garantie insuffisante après les frais. Déposez davantage pour réduire
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "Aucun marché trouvé"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -876,6 +876,11 @@ msgstr "STIP.b遡及ボーナス"
 msgid "in liquidity"
 msgstr "流動性で"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "Express の信頼性によるシームレスな取引"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> から </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "出金失敗"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "マーケット減少失敗"
@@ -2664,6 +2677,10 @@ msgstr "決済を確認"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "プロトコルリスクエクスプローラーと統計"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "最大ファンディングファクター"
 msgid "High price impact"
 msgstr "高い価格影響"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "GMXアカウントからの引き出し"
 msgid "Purpose"
 msgstr "目的"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "自分用"
@@ -7791,6 +7816,10 @@ msgstr "ファンディング手数料 / 日"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "GLP払い戻し（テスト）"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "以下の上限まで{0}でGMを購入できます"
 msgid "V2 trading"
 msgstr "V2取引"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "プロトコルの分析"
@@ -9277,6 +9310,10 @@ msgstr "GMXをステークし、GLVまたはGMを購入して報酬を獲得"
 msgid "Sellable"
 msgstr "売却可能"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "発生したファンディング手数料が決済のGasコスト{0}を超えるポジションを選択してください"
@@ -9574,6 +9611,10 @@ msgstr "Avalancheでは入金はサポートされていません。"
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "シフト"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "リファラルコード"
 msgid "Performance vs benchmark over selected period"
 msgstr "選択期間におけるベンチマークとの比較パフォーマンス"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "リファラルコードが更新されました"
@@ -10690,6 +10735,10 @@ msgstr "やや重要度の低いテキストですが、読み取り可能です
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30秒"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "手数料控除後の担保が低くなっています。清算リスク
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "マーケットが見つかりません"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -876,6 +876,11 @@ msgstr "STIP.b 소급 보너스"
 msgid "in liquidity"
 msgstr "유동성 내"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "Express의 안정성을 갖춘 매끄러운 트레이딩"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> to </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "출금 실패"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "마켓 감소 실패"
@@ -2664,6 +2677,10 @@ msgstr "정산 확인"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "프로토콜 위험 탐색기 및 통계"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "최대 펀딩 계수"
 msgid "High price impact"
 msgstr "높은 가격 영향"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "GMX 계정에서 출금"
 msgid "Purpose"
 msgstr "목적"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "나에게"
@@ -7791,6 +7816,10 @@ msgstr "일일 펀딩 수수료"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "GLP 보상금 (테스트)"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "아래 한도까지 {0}(으)로 GM을 구매할 수 있습니다"
 msgid "V2 trading"
 msgstr "V2 거래"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "프로토콜 분석"
@@ -9277,6 +9310,10 @@ msgstr "GMX를 스테이킹하고 GLV 또는 GM을 구매하여 보상을 받으
 msgid "Sellable"
 msgstr "판매 가능"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "발생 펀딩 수수료가 정산 Gas 비용 {0}을 초과하는 포지션을 선택하십시오"
@@ -9574,6 +9611,10 @@ msgstr "Avalanche에서는 입금이 지원되지 않습니다."
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "시프트"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "추천 코드"
 msgid "Performance vs benchmark over selected period"
 msgstr "선택한 기간의 벤치마크 대비 성과"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "추천 코드가 업데이트되었습니다"
@@ -10690,6 +10735,10 @@ msgstr "다소 중요하지 않은 텍스트이지만 읽을 수 있습니다"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30초"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "수수료 차감 후 담보가 부족합니다. 청산 위험을 줄이�
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "마켓을 찾을 수 없습니다"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -876,6 +876,11 @@ msgstr ""
 msgid "in liquidity"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1054,6 +1059,10 @@ msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
+msgstr ""
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
 msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
@@ -2236,6 +2245,10 @@ msgstr ""
 msgid "V2 Avalanche"
 msgstr ""
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr ""
@@ -2663,6 +2676,10 @@ msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
+msgstr ""
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
 msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
@@ -6227,6 +6244,10 @@ msgstr ""
 msgid "High price impact"
 msgstr ""
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr ""
 msgid "Purpose"
 msgstr ""
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr ""
@@ -7790,6 +7815,10 @@ msgstr ""
 
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
+msgstr ""
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
 msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
@@ -8585,6 +8614,10 @@ msgstr ""
 msgid "V2 trading"
 msgstr ""
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr ""
@@ -9277,6 +9310,10 @@ msgstr ""
 msgid "Sellable"
 msgstr ""
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr ""
@@ -9573,6 +9610,10 @@ msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
 msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
@@ -10635,6 +10676,10 @@ msgstr ""
 msgid "Performance vs benchmark over selected period"
 msgstr ""
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr ""
@@ -10689,6 +10734,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
+msgstr ""
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
 msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
@@ -11093,6 +11142,10 @@ msgstr ""
 #: src/components/MarketSelector/MarketSelector.tsx
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
+msgstr ""
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -876,6 +876,11 @@ msgstr "Ретроактивный бонус STIP.b"
 msgid "in liquidity"
 msgstr "используется для обеспечения ликвидности"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "Удобная торговля с надёжностью Express"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> до </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "Вывод не выполнен"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "Рыночное уменьшение не удалось"
@@ -2664,6 +2677,10 @@ msgstr "Подтвердить расчёт"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "Исследователь рисков протокола и статистика"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "Макс. фактор финансирования"
 msgid "High price impact"
 msgstr "Высокое влияние на цену"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "Вывод со счета GMX"
 msgid "Purpose"
 msgstr "Назначение"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "Для меня"
@@ -7791,6 +7816,10 @@ msgstr "Комиссия за финансирование / день"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "Возмещение GLP (тест)"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "Купить GM за {0} в пределах лимитов ниже"
 msgid "V2 trading"
 msgstr "Торговля V2"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "Аналитика протокола"
@@ -9277,6 +9310,10 @@ msgstr "Стейкайте GMX и покупайте GLV или GM для пол
 msgid "Sellable"
 msgstr "Продаваемый"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "Выберите позиции, в которых накопленная комиссия за финансирование превышает стоимость Gas для расчёта в {0}"
@@ -9574,6 +9611,10 @@ msgstr "Депозиты не поддерживаются на Avalanche."
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "сдвиг"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "Реферальные коды"
 msgid "Performance vs benchmark over selected period"
 msgstr "Эффективность по сравнению с бенчмарком за выбранный период"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "Реферальный код обновлён"
@@ -10690,6 +10735,10 @@ msgstr "Относительно второстепенный текст, но �
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30с"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "Низкое обеспечение после комиссий. Вне�
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "Рынки не найдены"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -876,6 +876,11 @@ msgstr "STIP.b 追溯獎勵"
 msgid "in liquidity"
 msgstr "流動性"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "順暢交易，Express 可靠保障"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> 至 </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "提取失敗"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "Market Decrease 失敗"
@@ -2664,6 +2677,10 @@ msgstr "確認結算"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "協議風險瀏覽器與統計數據"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "最大資金費率因子"
 msgid "High price impact"
 msgstr "價格影響過高"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "從 GMX Account 提取"
 msgid "Purpose"
 msgstr "用途"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "為我推薦"
@@ -7791,6 +7816,10 @@ msgstr "每日資金費用"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "GLP 補償（測試）"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "使用 {0} 購買 GM，上限如下"
 msgid "V2 trading"
 msgstr "V2 交易"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "協議分析"
@@ -9277,6 +9310,10 @@ msgstr "質押 GMX 並買入 GLV 或 GM 以賺取獎勵"
 msgid "Sellable"
 msgstr "可賣出"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "選擇累計資金費用超過 {0} Gas 費用的倉位進行結算"
@@ -9574,6 +9611,10 @@ msgstr "Avalanche 不支援存入。"
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "轉換"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "推薦碼"
 msgid "Performance vs benchmark over selected period"
 msgstr "所選期間內與基準的績效比較"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "推薦碼已更新"
@@ -10690,6 +10735,10 @@ msgstr "不太重要的文字，但仍可閱讀"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30 秒"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "扣除費用後抵押品過低。存入更多資金以降低清算風險
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "未找到市場"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -876,6 +876,11 @@ msgstr "STIP.b 追溯奖励"
 msgid "in liquidity"
 msgstr "流动性中"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr ""
@@ -1055,6 +1060,10 @@ msgstr "流畅交易，Express 级可靠性"
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "{0} <0/><1> to </1>{1} <2/>"
 msgstr "{0} <0/><1> 到 </1>{1} <2/>"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "前より赤字検知"
+msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -2236,6 +2245,10 @@ msgstr "提取失败"
 msgid "V2 Avalanche"
 msgstr "V2 Avalanche"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "プロトコル・ソルベンシー"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
 msgstr "市场减少失败"
@@ -2664,6 +2677,10 @@ msgstr "确认结算"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol risk explorer and stats"
 msgstr "协议风险浏览器和统计"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FRコスト"
+msgstr ""
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -6227,6 +6244,10 @@ msgstr "最大资金费率因子"
 msgid "High price impact"
 msgstr "高价格影响"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR停止中"
+msgstr ""
+
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
 #: src/components/PoolSelector2/PoolSelector2.tsx
@@ -7397,6 +7418,10 @@ msgstr "从 GMX 账户提取"
 msgid "Purpose"
 msgstr "用途"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
+msgstr ""
+
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
 msgstr "给我自己"
@@ -7791,6 +7816,10 @@ msgstr "资金费率 / 天"
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLP reimbursement (test)"
 msgstr "GLP 补偿（测试）"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（赤字）"
+msgstr ""
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8585,6 +8614,10 @@ msgstr "使用 {0} 买入 GM，上限如下"
 msgid "V2 trading"
 msgstr "V2 交易"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "（健全）"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
 msgstr "协议分析"
@@ -9277,6 +9310,10 @@ msgstr "质押 GMX 并购买 GLV 或 GM 以赚取奖励"
 msgid "Sellable"
 msgstr "可出售"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "FR相殺停止中"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
 msgstr "选择累计资金费用超过 {0} Gas 结算成本的仓位"
@@ -9574,6 +9611,10 @@ msgstr "Avalanche 上不支持存入。"
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "shift"
 msgstr "转移"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
+msgstr ""
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10635,6 +10676,10 @@ msgstr "推荐码"
 msgid "Performance vs benchmark over selected period"
 msgstr "选定时间段内相对于基准的表现"
 
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
+msgstr ""
+
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
 msgstr "推荐码已更新"
@@ -10690,6 +10735,10 @@ msgstr "相对次要的文本，但仍可阅读"
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30 秒"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "ソルベンシー比率"
+msgstr ""
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11094,6 +11143,10 @@ msgstr "扣除费用后抵押品不足。请存入更多以降低清算风险。
 #: src/components/MarketsList/MarketsList.tsx
 msgid "No markets found"
 msgstr "未找到市场"
+
+#: src/pages/Portfolio/PortfolioPage.tsx
+msgid "利回り"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -645,6 +645,18 @@ export default function HedgeDetailPage() {
                 />
               </div>
 
+              {/* Soft-lock warning (Issue #180) */}
+              {pageData.isSoftLockedPosition && (
+                <div className="border-amber-800/50 bg-amber-900/20 text-amber-300 mb-16 rounded-4 border px-12 py-10 text-12">
+                  <div className="mb-4 font-semibold">
+                    ⚠️ {t`システム収益保護のため、現在一時的にFR相殺が停止されています`}
+                  </div>
+                  <div className="leading-relaxed text-amber-400/80">
+                    {t`プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。`}
+                  </div>
+                </div>
+              )}
+
               {/* Position details */}
               {pageData.userPosition ? (
                 <CurrentPositionPanel

--- a/src/pages/Portfolio/PortfolioPage.tsx
+++ b/src/pages/Portfolio/PortfolioPage.tsx
@@ -125,6 +125,153 @@ function HeroSection({ totalNetWorthUsd, totalProtectionUsd, avgHedgeRatio, netY
 }
 
 // ---------------------------------------------------------------------------
+// Protocol Solvency section (Issue #180 — Soft Deleveraging)
+// ---------------------------------------------------------------------------
+
+type SolvencyItemProps = {
+  symbol: string;
+  solvencyDropAt: number | null;
+  isSoftLocked: boolean;
+  yieldAprBps: number | null;
+  fundingRateBps: number | null;
+};
+
+function SolvencyItem({ symbol, solvencyDropAt, isSoftLocked, yieldAprBps, fundingRateBps }: SolvencyItemProps) {
+  // Solvency ratio: yield / |cost|  (< 1 = insolvent)
+  const costBps = fundingRateBps !== null ? Math.max(0, -fundingRateBps) : null;
+  const yieldBps = yieldAprBps ?? 0;
+  const solvencyRatio = costBps !== null && costBps > 0 ? yieldBps / costBps : null;
+
+  const maxScale = Math.max(yieldBps, costBps ?? 0, 100);
+  const yieldPct = Math.min(100, (yieldBps / maxScale) * 100);
+  const costPct = costBps !== null ? Math.min(100, (costBps / maxScale) * 100) : 0;
+
+  // useMemo called before any conditional return (Rules of Hooks)
+  const yieldBarStyle = useMemo(() => ({ width: `${yieldPct}%` }), [yieldPct]);
+  const costBarStyle = useMemo(() => ({ width: `${costPct}%` }), [costPct]);
+
+  // Deficit duration
+  let deficitDuration: string | null = null;
+  if (solvencyDropAt && solvencyDropAt > 0) {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const elapsedSec = Math.max(0, nowSec - solvencyDropAt);
+    const hours = Math.floor(elapsedSec / 3600);
+    const minutes = Math.floor((elapsedSec % 3600) / 60);
+    deficitDuration = hours > 0 ? `${hours}時間${minutes}分` : `${minutes}分`;
+  }
+
+  // Only show when in deficit or user is soft-locked (after all hooks)
+  const isInDeficit = (solvencyDropAt !== null && solvencyDropAt > 0) || isSoftLocked;
+  if (!isInDeficit) return null;
+
+  return (
+    <div className="border-amber-800/40 bg-amber-900/10 rounded-4 border p-16">
+      {/* Header */}
+      <div className="mb-12 flex items-center justify-between">
+        <div className="flex items-center gap-8">
+          <div className="flex h-28 w-28 items-center justify-center rounded-full bg-slate-700 text-11 font-bold text-white">
+            {symbol.slice(0, 2)}
+          </div>
+          <span className="text-13 font-semibold text-white">{symbol}</span>
+        </div>
+        <div className="flex items-center gap-8">
+          {isSoftLocked && (
+            <span className="bg-amber-900/50 text-amber-300 rounded-full px-8 py-2 text-11 font-semibold">
+              {t`FR相殺停止中`}
+            </span>
+          )}
+          {deficitDuration && (
+            <span className="text-11 text-slate-500">
+              {deficitDuration}
+              {t`前より赤字検知`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Warning */}
+      {isSoftLocked && (
+        <div className="text-amber-400/90 mb-12 text-12">
+          ⚠️ {t`システム収益保護のため、現在一時的にFR相殺が停止されています`}
+        </div>
+      )}
+
+      {/* Solvency ratio bar */}
+      {yieldAprBps !== null && fundingRateBps !== null && (
+        <div className="space-y-8">
+          {/* Yield */}
+          <div className="flex items-center gap-10">
+            <div className="w-[60px] text-right text-11 text-slate-400">{t`利回り`}</div>
+            <div className="relative h-12 flex-1 overflow-hidden rounded-full bg-slate-700/50">
+              <div className="h-full rounded-full bg-green-500 transition-all" style={yieldBarStyle} />
+            </div>
+            <div className="w-[48px] text-right text-11 font-semibold text-green-400">
+              {(yieldBps / 100).toFixed(2)}%
+            </div>
+          </div>
+          {/* FR cost */}
+          <div className="flex items-center gap-10">
+            <div className="w-[60px] text-right text-11 text-slate-400">{t`FRコスト`}</div>
+            <div className="relative h-12 flex-1 overflow-hidden rounded-full bg-slate-700/50">
+              <div className="h-full rounded-full bg-red-500 transition-all" style={costBarStyle} />
+            </div>
+            <div className="w-[48px] text-right text-11 font-semibold text-red-400">
+              {costBps !== null ? (costBps / 100).toFixed(2) : "—"}%
+            </div>
+          </div>
+          {/* Ratio */}
+          {solvencyRatio !== null && (
+            <div className="border-t border-slate-700/60 pt-8">
+              <div className="flex items-center justify-between text-12">
+                <span className="text-slate-400">{t`ソルベンシー比率`}</span>
+                <div className="flex items-center gap-8">
+                  <span className={`font-semibold ${solvencyRatio >= 1 ? "text-green-400" : "text-red-400"}`}>
+                    {solvencyRatio.toFixed(2)}×
+                  </span>
+                  <span className={`text-11 ${solvencyRatio >= 1 ? "text-green-500/70" : "text-red-500/70"}`}>
+                    {solvencyRatio >= 1 ? t`（健全）` : t`（赤字）`}
+                  </span>
+                </div>
+              </div>
+              <div className="mt-6 text-11 text-slate-500">
+                {solvencyRatio < 1
+                  ? t`RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。`
+                  : t`ソルベンシーは回復しています。ポジションの復元を待っています。`}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SolvencySectionProps = { items: HedgePortfolioItem[] };
+
+function SolvencySection({ items }: SolvencySectionProps) {
+  const activeItems = items.filter((h) => (h.solvencyDropAt !== null && h.solvencyDropAt > 0) || h.isSoftLocked);
+  if (activeItems.length === 0) return null;
+
+  return (
+    <div className="mb-24">
+      <h2 className="mb-12 text-14 font-semibold text-white">{t`プロトコル・ソルベンシー`}</h2>
+      <div className="space-y-12">
+        {activeItems.map((h) => (
+          <SolvencyItem
+            key={h.key}
+            symbol={h.symbol}
+            solvencyDropAt={h.solvencyDropAt}
+            isSoftLocked={h.isSoftLocked}
+            yieldAprBps={h.yieldAprBps}
+            fundingRateBps={h.fundingRateBps}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Hedge Positions section — Balancer bar
 // ---------------------------------------------------------------------------
 
@@ -228,7 +375,9 @@ function HedgeSection({ items, hasAccount }: HedgeSectionProps) {
 
                 {/* Status */}
                 <div className="text-right">
-                  {hasPosition ? (
+                  {h.isSoftLocked ? (
+                    <span className="bg-amber-900/40 text-amber-300 rounded-full px-8 py-2 text-11">{t`FR停止中`}</span>
+                  ) : hasPosition ? (
                     <span className="rounded-full bg-green-900/40 px-8 py-2 text-11 text-green-400">{t`Active`}</span>
                   ) : (
                     <span className="text-11 text-slate-500">—</span>
@@ -409,13 +558,16 @@ export default function PortfolioPage() {
           netYieldApy={globalStats.netYieldApy}
         />
 
-        {/* ② Hedge Positions */}
+        {/* ② Solvency Alerts (Issue #180 — shown only when deficit is active) */}
+        <SolvencySection items={hedgeItems} />
+
+        {/* ③ Hedge Positions */}
         <HedgeSection items={hedgeItems} hasAccount={!!account} />
 
-        {/* ③ Trading Terminal */}
+        {/* ④ Trading Terminal */}
         <TradingSection positions={allPositions} hasAccount={!!account} />
 
-        {/* ④ Vault LP Status */}
+        {/* ⑤ Vault LP Status */}
         <VaultLpSection items={vaultLpItems} hasAccount={!!account} />
 
         {/* Disclaimer */}


### PR DESCRIPTION
## 概要

Issue #180 (Soft Deleveraging) のフロントエンド実装。ソフトロックされたユーザーへの警告と、プロトコル全体のソルベンシー状態を可視化します。

## 変更点

### 1. `useHedgePageData.ts` — データ取得追加
- `vault.solvencyDropAt()` → 赤字検知タイムスタンプ（0=健全）
- `vault.isSoftLockedPosition(key)` → ユーザーの short ポジションがソフトロックされているか

### 2. `HedgeDetailPage.tsx` — ソフトロック警告バナー
- ユーザーのポジションがソフトロック中（`isSoftLockedPosition=true`）の場合、「Current Position」欄に警告を表示:
  > ⚠️ システム収益保護のため、現在一時的にFR相殺が停止されています

### 3. `usePortfolioData.ts` / `HedgePortfolioItem` — solvency フィールド追加
- `solvencyDropAt`, `isSoftLocked`, `yieldAprBps`, `fundingRateBps`

### 4. `PortfolioPage.tsx` — ソルベンシーセクション追加

**SolvencySection** (赤字またはソフトロック中のVaultのみ表示):
- ⚠️ FR停止中の警告テキスト
- 利回り（緑）vs FRコスト（赤）のビジュアルゲージ
- ソルベンシー比率（×）＋「なぜロックがかかったか」の説明文
- 赤字継続時間（例: 「2時間15分前より赤字検知」）

**HedgeSection Status列**:
- ソフトロック中: 「FR停止中」（アンバーバッジ）
- 通常: 「Active」（グリーンバッジ）

## スクリーンキャプチャイメージ

```
Portfolio > プロトコル・ソルベンシー
┌──────────────────────────────────────────────┐
│ mBUIDL          [FR相殺停止中] 2時間15分前より赤字検知  │
│                                              │
│ ⚠️ システム収益保護のため、現在一時的にFR相殺が停止されています  │
│                                              │
│ 利回り  [████████░░░░░░░░]  5.20%           │
│ FRコスト [████████████████]  7.80%           │
│                                              │
│ ソルベンシー比率: 0.67× （赤字）               │
│ RWA利回りがFRコストを下回っているため...        │
└──────────────────────────────────────────────┘
```

## テスト

- TypeScript: エラーなし
- ESLint: 警告ゼロ（`react-perf/jsx-no-new-object-as-prop` → `useMemo` で対応）
- Vitest: 52 test files / 517 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)