### PR TITLE
feat(issue-183): Admin Dashboard — AUM Allocation caps UI

### DIFF
--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -11,6 +11,7 @@ import { buildAccountDashboardUrl } from "pages/AccountDashboard/buildAccountDas
 import BeginAccountTransfer from "pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer";
 import CompleteAccountTransfer from "pages/AccountTransfer/CompleteAccountTransfer/CompleteAccountTransfer";
 import { AccountsRouter } from "pages/Actions/ActionsRouter";
+import AdminPage from "pages/Admin/AdminPage";
 import BuyGMX from "pages/BuyGMX/BuyGMX";
 // import DashboardV2 from "pages/Dashboard/DashboardV2";
 import EarnAdditionalOpportunitiesPage from "pages/Earn/EarnAdditionalOpportunitiesPage";
@@ -173,6 +174,9 @@ export function MainRoutes({ openSettings: _openSettings }: { openSettings: () =
       </Route>
       <Route exact path="/portfolio">
         <PortfolioPage />
+      </Route>
+      <Route exact path="/admin">
+        <AdminPage />
       </Route>
       <Route exact path="/vaults">
         <VaultsPage />

--- a/src/domain/vantage/admin/useAumAllocation.ts
+++ b/src/domain/vantage/admin/useAumAllocation.ts
@@ -1,0 +1,116 @@
+/**
+ * useAumAllocation.ts
+ *
+ * Issue #183 — Dynamic AUM Allocation Manager
+ *
+ * Polls Vault.getAllocationStatus() for each configured vault and exposes
+ * setAumCaps() for the owner to update hedge/trade caps on-chain.
+ *
+ * getAllocationStatus() is not yet in TypeChain-generated types (pending pnpm sync).
+ * We use a minimal type-cast (VaultWithAllocation) until regeneration.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { useVault } from "hooks/useVantageContracts";
+import { useChainId } from "lib/chains";
+import type { Vault } from "vantage/types";
+
+import type { VaultConfig } from "../vaults/vaultConfig";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AllocationStatus = {
+  vaultAddress: string;
+  currentHedgeOI: bigint;
+  maxHedgeOI: bigint;
+  currentTradeOI: bigint;
+  maxTradeOI: bigint;
+  hedgeCapBps: bigint;
+  tradeCapBps: bigint;
+};
+
+// Issue #183 adds these methods — available after `pnpm sync` regenerates TypeChain types.
+type VaultWithAllocation = Vault & {
+  getAllocationStatus(): Promise<{
+    currentHedgeOI: bigint;
+    maxHedgeOI: bigint;
+    currentTradeOI: bigint;
+    maxTradeOI: bigint;
+  }>;
+  hedgeCapBps(): Promise<bigint>;
+  tradeCapBps(): Promise<bigint>;
+  setAumCaps(_hedgeCapBps: bigint, _tradeCapBps: bigint): Promise<{ wait(): Promise<unknown> }>;
+};
+
+const POLL_INTERVAL_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns allocation status for a single vault and a setter for the caps.
+ * Pass the VaultConfig of the vault you want to inspect/manage.
+ */
+export function useAumAllocation(vaultConfig: VaultConfig): {
+  status: AllocationStatus | null;
+  isLoading: boolean;
+  isSetting: boolean;
+  setAumCaps(hedgeCapBps: bigint, tradeCapBps: bigint): Promise<void>;
+} {
+  const { chainId } = useChainId();
+  const vault = useVault(undefined, chainId) as VaultWithAllocation;
+
+  const [status, setStatus] = useState<AllocationStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSetting, setIsSetting] = useState(false);
+
+  const poll = useCallback(async () => {
+    if (!vaultConfig.vaultAddress) return;
+    try {
+      const [alloc, hedgeBps, tradeBps] = await Promise.all([
+        vault.getAllocationStatus(),
+        vault.hedgeCapBps(),
+        vault.tradeCapBps(),
+      ]);
+      setStatus({
+        vaultAddress: vaultConfig.vaultAddress,
+        currentHedgeOI: alloc.currentHedgeOI,
+        maxHedgeOI: alloc.maxHedgeOI,
+        currentTradeOI: alloc.currentTradeOI,
+        maxTradeOI: alloc.maxTradeOI,
+        hedgeCapBps: hedgeBps,
+        tradeCapBps: tradeBps,
+      });
+    } catch {
+      // Silently ignore RPC errors
+    } finally {
+      setIsLoading(false);
+    }
+  }, [vault, vaultConfig.vaultAddress]);
+
+  useEffect(() => {
+    poll();
+    const timer = setInterval(poll, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [poll]);
+
+  const setAumCaps = useCallback(
+    async (hedgeCapBps: bigint, tradeCapBps: bigint) => {
+      setIsSetting(true);
+      try {
+        const tx = await vault.setAumCaps(hedgeCapBps, tradeCapBps);
+        await tx.wait();
+        await poll();
+      } finally {
+        setIsSetting(false);
+      }
+    },
+    [vault, poll]
+  );
+
+  return { status, isLoading, isSetting, setAumCaps };
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -508,6 +508,10 @@ msgstr "Token auswählen"
 msgid "Image generation failed. Refresh and try again."
 msgstr "Bilderzeugung fehlgeschlagen. Aktualisieren Sie die Seite und versuchen Sie es erneut."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Details anzeigen"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "Adresse kopieren"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Prognostizierte Jahresrendite im Vergleich zu einem Uniswap V2-Benchmark.<0/><1/>Hinweis: Kurze Zeiträume spiegeln möglicherweise nicht die langfristige Performance wider.<2/><3/><4>Detaillierte Statistiken auf Dune ansehen</4>."
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "Empfehlungscode erstellen"
@@ -3421,6 +3434,10 @@ msgstr "Preiseinfluss beim Tauschen ist hoch"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Stornierbar in {minutesText}{seconds}s"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "GMX abheben und freigeben"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "GMX-Feedback teilen"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "Abhebung fehlgeschlagen"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "Letzte 180 Tage"
 msgid "Positive funding fees"
 msgstr "Positive Finanzierungsgebühren"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "Markt auswählen"
 msgid "Referral code creation failed"
 msgstr "Erstellung des Empfehlungscodes fehlgeschlagen"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "Abhebungsgebühr"
@@ -5847,6 +5877,10 @@ msgstr "Ihre Gebührenersparnisse durch Empfehlungsrabatte"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "Transaktion"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "Letztes Jahr"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "{nativeTokenSymbol} transferieren"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "Negative Finanzierungsgebühr"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "Min. Margin pro Teil: {0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -81,6 +81,10 @@ msgstr "Funding-Exponentfaktor"
 msgid "Request deposit"
 msgstr "Einzahlung anfordern"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "Signieren Sie jede Transaktion On-Chain über Ihren eigenen RPC, der in der Regel von Ihrem Wallet bereitgestellt wird.<0/><1/>Gasgebühren in {nativeTokenSymbol}."
@@ -3049,8 +3053,8 @@ msgstr "Prognostizierte Jahresrendite im Vergleich zu einem Uniswap V2-Benchmark
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Stornierbar in {minutesText}{seconds}s"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "{0} bearbeiten"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "{tokenSymbol}-Belohnungen staken"
 msgid "Max amount exceeded"
 msgstr "Maximalbetrag überschritten"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>zu </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "Leihexponent Short"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "Pools"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "Long-Betrag des Pools"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -81,6 +81,10 @@ msgstr "Funding exponent factor"
 msgid "Request deposit"
 msgstr "Request deposit"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
@@ -3049,8 +3053,8 @@ msgstr "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: S
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr "Disabled"
+#~ msgid "Disabled"
+#~ msgstr "Disabled"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Cancellable in {minutesText}{seconds}s"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr "No cap"
+#~ msgid "No cap"
+#~ msgstr "No cap"
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "Edit {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Buy</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr "Unlimited"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "Stake {tokenSymbol} rewards"
 msgid "Max amount exceeded"
 msgstr "Max amount exceeded"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
@@ -8872,6 +8886,10 @@ msgstr "<0>to </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "Borrowing exponent short"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "Pools"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "Pool long amount"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -508,6 +508,10 @@ msgstr "Select token"
 msgid "Image generation failed. Refresh and try again."
 msgstr "Image generation failed. Refresh and try again."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr "Admin Dashboard"
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr "Funding"
@@ -817,6 +821,10 @@ msgstr "Loading positions…"
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "View details"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr "Hedge OI"
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "Copy address"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr "Disabled"
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "Create referral code"
@@ -3421,6 +3434,10 @@ msgstr "Swap price impact is high"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Cancellable in {minutesText}{seconds}s"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr "No cap"
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "Withdraw and unreserve GMX"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "Share GMX feedback"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "Withdraw failed"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr "Saving…"
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "Last 180d"
 msgid "Positive funding fees"
 msgstr "Positive funding fees"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "Select market"
 msgid "Referral code creation failed"
 msgstr "Referral code creation failed"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr "Trade Cap"
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "Withdraw fee"
@@ -5847,6 +5877,10 @@ msgstr "Your fee savings from referral discounts"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr "Trade OI"
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "Transaction"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "Last year"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr "Off"
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "Transfer {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr "Opening position..."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr "Apply Caps"
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "Negative funding fee"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "Min margin per part: {0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr "Hedge Cap"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -81,6 +81,10 @@ msgstr "Factor exponente de financiación"
 msgid "Request deposit"
 msgstr "Solicitar depósito"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "Firme cada transacción en cadena utilizando su propio RPC, normalmente proporcionado por su monedero.<0/><1/>Pagos de Gas en {nativeTokenSymbol}."
@@ -3049,8 +3053,8 @@ msgstr "Rendimiento anual proyectado frente a un índice de referencia de estilo
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Cancelable en {minutesText}{seconds}s"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "Editar {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "Stakear recompensas de {tokenSymbol}"
 msgid "Max amount exceeded"
 msgstr "Superado el importe máximo"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>a </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "Exponente de préstamo corto"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "Reservas"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "Cantidad largo del pool"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -508,6 +508,10 @@ msgstr "Seleccionar token"
 msgid "Image generation failed. Refresh and try again."
 msgstr "La generación de la imagen ha fallado. Actualice la página e inténtelo de nuevo."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Ver detalles"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "Copiar dirección"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Rendimiento anual proyectado frente a un índice de referencia de estilo Uniswap V2.<0/><1/>Nota: Los plazos cortos pueden no reflejar el rendimiento a largo plazo.<2/><3/><4>Ver estadísticas detalladas en Dune</4>."
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "Crear código de referido"
@@ -3421,6 +3434,10 @@ msgstr "El impacto en el precio del intercambio es alto"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Cancelable en {minutesText}{seconds}s"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "Retirar y liberar la reserva de GMX"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "Compartir opinión sobre GMX"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "Error en el retiro"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "Últimos 180d"
 msgid "Positive funding fees"
 msgstr "Comisiones de financiación positivas"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "Seleccionar mercado"
 msgid "Referral code creation failed"
 msgstr "Error al crear el código de referido"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "Comisión de retirada"
@@ -5847,6 +5877,10 @@ msgstr "Su ahorro en comisiones por descuentos de referido"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "Transacción"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "Último año"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "Transferir {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "Comisión de financiación negativa"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "Margen mín. por parte: {0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -81,6 +81,10 @@ msgstr "Facteur d'exposant de financement"
 msgid "Request deposit"
 msgstr "Demande de dépôt"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "Signez chaque transaction on-chain en utilisant votre propre RPC, généralement fourni par votre portefeuille.<0/><1/>Paiements de Gas en {nativeTokenSymbol}."
@@ -3049,8 +3053,8 @@ msgstr "Rendement annuel projeté par rapport à un benchmark de type Uniswap V2
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Annulable dans {minutesText}{seconds}s"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "Modifier {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "Staker les récompenses {tokenSymbol}"
 msgid "Max amount exceeded"
 msgstr "Montant maximal dépassé"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>vers </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "Exposant d'emprunt short"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "Pools"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "Montant long du pool"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -508,6 +508,10 @@ msgstr "Sélectionner un jeton"
 msgid "Image generation failed. Refresh and try again."
 msgstr "La génération d'image a échoué. Actualisez et réessayez."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Voir les détails"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "Copier l'adresse"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Rendement annuel projeté par rapport à un benchmark de type Uniswap V2.<0/><1/>Remarque : les périodes courtes peuvent ne pas refléter la performance à long terme.<2/><3/><4>Voir les statistiques détaillées sur Dune</4>."
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "Créer un code de parrainage"
@@ -3421,6 +3434,10 @@ msgstr "L'impact sur le prix du swap est élevé"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Annulable dans {minutesText}{seconds}s"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "Retirer et libérer les GMX"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "Partagez votre avis sur GMX"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "Échec du retrait"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "Derniers 180j"
 msgid "Positive funding fees"
 msgstr "Frais de financement positifs"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "Sélectionner le marché"
 msgid "Referral code creation failed"
 msgstr "Échec de la création du code de parrainage"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "Frais de retrait"
@@ -5847,6 +5877,10 @@ msgstr "Vos économies de frais grâce aux remises de parrainage"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "Transaction"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "Année dernière"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "Transférer {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "Frais de financement négatifs"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "Marge min. par part : {0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -81,6 +81,10 @@ msgstr "ファンディング指数ファクター"
 msgid "Request deposit"
 msgstr "入金リクエスト"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "ウォレットが提供するRPCを使用して、各トランザクションをオンチェーンで署名します。<0/><1/>Gasの支払いは{nativeTokenSymbol}で行われます。"
@@ -3049,8 +3053,8 @@ msgstr "Uniswap V2スタイルのベンチマークに対する予想年間リ�
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "{minutesText}{seconds}秒後にキャンセル可能"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "{0}を編集"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "{tokenSymbol}報酬をステーク"
 msgid "Max amount exceeded"
 msgstr "最大値超過"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>へ </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "ショート借入指数"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "プール"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "プールのロング数量"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -508,6 +508,10 @@ msgstr "トークンを選択"
 msgid "Image generation failed. Refresh and try again."
 msgstr "画像の生成に失敗しました。更新して再度お試しください。"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "詳細を表示"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "アドレスをコピー"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Uniswap V2スタイルのベンチマークに対する予想年間リターンです。<0/><1/>注意：短期間のデータは長期的なパフォーマンスを反映しない場合があります。<2/><3/><4>Duneで詳細な統計を見る</4>。"
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "リファラルコードを作成"
@@ -3421,6 +3434,10 @@ msgstr "スワップの価格への影響が大きいです"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "{minutesText}{seconds}秒後にキャンセル可能"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "GMX を出金してリザーブを解除する"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "GMX のフィードバックを共有する"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "出金に失敗しました"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "過去180日"
 msgid "Positive funding fees"
 msgstr "正のファンディング手数料"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "マーケットを選択"
 msgid "Referral code creation failed"
 msgstr "リファラルコードの作成に失敗しました"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "出金手数料"
@@ -5847,6 +5877,10 @@ msgstr "リファラル割引による手数料の節約額"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "取引"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "昨年"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "{nativeTokenSymbol} を移転"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "ネガティブファンディング手数料"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "パートあたりの最小証拠金：{0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -81,6 +81,10 @@ msgstr "펀딩 지수 계수"
 msgid "Request deposit"
 msgstr "입금 요청"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "지갑에서 제공하는 RPC를 사용하여 각 트랜잭션을 온체인에서 서명합니다.<0/><1/>Gas 수수료는 {nativeTokenSymbol}로 지불합니다."
@@ -3049,8 +3053,8 @@ msgstr "Uniswap V2 스타일 벤치마크 대비 예상 연간 수익률입니�
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "{minutesText}{seconds}초 후 취소 가능"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "{0} 편집"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "{tokenSymbol} 보상 스테이킹"
 msgid "Max amount exceeded"
 msgstr "최대 수량 초과"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>로 </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "차입 지수 (숏)"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "풀"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "풀 롱 수량"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -508,6 +508,10 @@ msgstr "토큰 선택"
 msgid "Image generation failed. Refresh and try again."
 msgstr "이미지 생성에 실패했습니다. 새로고침 후 다시 시도하십시오."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "상세 보기"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "주소 복사"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Uniswap V2 스타일 벤치마크 대비 예상 연간 수익률입니다.<0/><1/>참고: 단기간의 데이터는 장기 성과를 반영하지 못할 수 있습니다.<2/><3/><4>Dune에서 상세 통계 보기</4>."
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "추천 코드 생성"
@@ -3421,6 +3434,10 @@ msgstr "스왑 가격 영향이 높습니다"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "{minutesText}{seconds}초 후 취소 가능"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "GMX 출금 및 예약 해제"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "GMX 피드백 공유"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "출금에 실패했습니다"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "최근 180일"
 msgid "Positive funding fees"
 msgstr "양의 펀딩 수수료"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "마켓 선택"
 msgid "Referral code creation failed"
 msgstr "추천 코드 생성에 실패했습니다"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "출금 수수료"
@@ -5847,6 +5877,10 @@ msgstr "추천 할인을 통한 수수료 절감액"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "거래"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "작년"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "{nativeTokenSymbol} 전송"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "음의 펀딩 수수료"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "파트당 최소 증거금: {0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -81,6 +81,10 @@ msgstr ""
 msgid "Request deposit"
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr ""
@@ -3049,8 +3053,8 @@ msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4725,6 +4729,12 @@ msgstr ""
 
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
 msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr ""
 msgid "Max amount exceeded"
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr ""
 msgid "Borrowing exponent short"
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9089,6 +9107,10 @@ msgstr ""
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
 msgstr ""
 
 #: src/components/GmList/GlvList.tsx

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -508,6 +508,10 @@ msgstr ""
 msgid "Image generation failed. Refresh and try again."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -816,6 +820,10 @@ msgstr ""
 
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
 msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
@@ -3039,6 +3047,11 @@ msgstr ""
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr ""
@@ -3420,6 +3433,10 @@ msgstr ""
 
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
 msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
@@ -3951,6 +3968,10 @@ msgstr ""
 msgid "Copin"
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4161,6 +4182,10 @@ msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
 msgstr ""
 
 #. chainname balance
@@ -5217,6 +5242,7 @@ msgstr ""
 msgid "Positive funding fees"
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr ""
 msgid "Referral code creation failed"
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr ""
@@ -5846,6 +5876,10 @@ msgstr ""
 #: src/components/TVChartContainer/constants.ts
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
 msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
@@ -7077,6 +7111,11 @@ msgstr ""
 
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
 msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
@@ -9080,6 +9119,10 @@ msgstr ""
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9599,6 +9642,10 @@ msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
+msgstr ""
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
 msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -508,6 +508,10 @@ msgstr "Выберите токен"
 msgid "Image generation failed. Refresh and try again."
 msgstr "Не удалось сгенерировать изображение. Обновите страницу и попробуйте снова."
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "Подробнее"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "Копировать адрес"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "Прогнозируемая годовая доходность по сравнению с бенчмарком в стиле Uniswap V2.<0/><1/>Примечание: короткие временные периоды могут не отражать долгосрочную доходность.<2/><3/><4>Подробная статистика на Dune</4>."
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "Создать реферальный код"
@@ -3421,6 +3434,10 @@ msgstr "Высокое влияние на цену при обмене"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Отмена доступна через {minutesText}{seconds}с"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "Вывести и снять резервирование GMX"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "Поделиться отзывом о GMX"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "Вывод не удался"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "Последние 180д"
 msgid "Positive funding fees"
 msgstr "Положительные комиссии за финансирование"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "Выбрать рынок"
 msgid "Referral code creation failed"
 msgstr "Не удалось создать реферальный код"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "Комиссия за вывод"
@@ -5847,6 +5877,10 @@ msgstr "Ваша экономия на комиссиях от рефераль�
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "Транзакция"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "Последний год"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "Перевести {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "Отрицательная комиссия за финансирова�
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "Мин. маржа на часть: {0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -81,6 +81,10 @@ msgstr "Фактор экспоненты фандинга"
 msgid "Request deposit"
 msgstr "Запрос на депозит"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "Подписывайте каждую транзакцию в сети, используя собственный RPC, обычно предоставляемый вашим кошельком.<0/><1/>Оплата Gas в {nativeTokenSymbol}."
@@ -3049,8 +3053,8 @@ msgstr "Прогнозируемая годовая доходность по с
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "Отмена доступна через {minutesText}{seconds}с"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "Редактировать {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "Стейкать вознаграждения {tokenSymbol}"
 msgid "Max amount exceeded"
 msgstr "Максимальная сумма превышена"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>в </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "Экспонента заимствования шорт"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "Пулы"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "Сумма лонг-позиций пула"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -508,6 +508,10 @@ msgstr "選擇代幣"
 msgid "Image generation failed. Refresh and try again."
 msgstr "圖片生成失敗。請重新整理後再試一次。"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "查看詳情"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "複製地址"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "與 Uniswap V2 風格基準相比的預估年化回報。<0/><1/>注意：短期時間範圍可能無法反映長期績效。<2/><3/><4>在 Dune 上查看詳細數據</4>。"
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "建立推薦碼"
@@ -3421,6 +3434,10 @@ msgstr "兌換價格影響偏高"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "可在 {minutesText}{seconds} 秒後取消"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "提取並解除 GMX 預留"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "分享 GMX 意見回饋"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "提取失敗"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "近 180 天"
 msgid "Positive funding fees"
 msgstr "正向資金費用"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "選擇市場"
 msgid "Referral code creation failed"
 msgstr "推薦碼建立失敗"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "提取手續費"
@@ -5847,6 +5877,10 @@ msgstr "您透過推薦折扣節省的手續費"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "止盈"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "交易"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "過去一年"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "轉帳 {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "負資金費用"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "每份最低保證金：{0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -81,6 +81,10 @@ msgstr "資金指數因子"
 msgid "Request deposit"
 msgstr "請求存入"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "透過您的 RPC 在鏈上簽署每筆交易，通常由您的錢包提供。<0/><1/>Gas 以 {nativeTokenSymbol} 支付。"
@@ -3049,8 +3053,8 @@ msgstr "與 Uniswap V2 風格基準相比的預估年化回報。<0/><1/>注意�
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "可在 {minutesText}{seconds} 秒後取消"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "編輯 {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "質押 {tokenSymbol} 獎勵"
 msgid "Max amount exceeded"
 msgstr "超過最大數量"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>至 </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "做空借貸指數"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "池"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "池做多數量"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -508,6 +508,10 @@ msgstr "选择代币"
 msgid "Image generation failed. Refresh and try again."
 msgstr "图片生成失败。请刷新后重试。"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Admin Dashboard"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
 msgstr ""
@@ -817,6 +821,10 @@ msgstr ""
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
 msgstr "查看详情"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI"
+msgstr ""
 
 #: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
@@ -3039,6 +3047,11 @@ msgstr "复制地址"
 msgid "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: Short timeframes may not reflect long-term performance.<2/><3/><4>View detailed stats on Dune</4>."
 msgstr "与 Uniswap V2 风格基准相比的预计年化回报。<0/><1/>注意：短期数据可能无法反映长期表现。<2/><3/><4>在 Dune 上查看详细数据</4>。"
 
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Disabled"
+msgstr ""
+
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
 msgstr "创建推荐码"
@@ -3421,6 +3434,10 @@ msgstr "兑换价格影响过高"
 #: src/domain/synthetics/orders/useDisabledCancelMarketOrderMessage.ts
 msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "可在 {minutesText}{seconds}s 后取消"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "No cap"
+msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3951,6 +3968,10 @@ msgstr "提取并解除 GMX 锁定"
 msgid "Copin"
 msgstr "Copin"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+msgstr ""
+
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -4162,6 +4183,10 @@ msgstr "分享 GMX 反馈"
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw failed"
 msgstr "提取失败"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Saving…"
+msgstr ""
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -5217,6 +5242,7 @@ msgstr "过去 180 天"
 msgid "Positive funding fees"
 msgstr "正向资金费率"
 
+#: src/pages/Admin/AdminPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5835,6 +5861,10 @@ msgstr "选择市场"
 msgid "Referral code creation failed"
 msgstr "推荐码创建失败"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade Cap"
+msgstr ""
+
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdraw fee"
 msgstr "提取费用"
@@ -5847,6 +5877,10 @@ msgstr "您通过推荐折扣节省的费用"
 #: src/domain/synthetics/positions/utils.ts
 msgid "TP"
 msgstr "TP"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI"
+msgstr ""
 
 #: src/components/Claims/ClaimableCard.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -7078,6 +7112,11 @@ msgstr "交易"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "Last year"
 msgstr "去年"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Off"
+msgstr ""
 
 #: src/components/TradeBox/TradeBox.tsx
 msgid "per"
@@ -9080,6 +9119,10 @@ msgstr "转移 {nativeTokenSymbol}"
 msgid "Opening position..."
 msgstr ""
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Apply Caps"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
@@ -9600,6 +9643,10 @@ msgstr "负资金费用"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min margin per part: {0}"
 msgstr "每份最低保证金：{0}"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge Cap"
+msgstr ""
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -81,6 +81,10 @@ msgstr "资金费率指数因子"
 msgid "Request deposit"
 msgstr "请求存入"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded."
+msgstr ""
+
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Sign each transaction on-chain using your own RPC, typically provided by your wallet.<0/><1/>Gas payments in {nativeTokenSymbol}."
 msgstr "使用您自己的 RPC 在链上签署每笔交易，RPC 通常由您的钱包提供。<0/><1/>Gas 以 {nativeTokenSymbol} 支付。"
@@ -3049,8 +3053,8 @@ msgstr "与 Uniswap V2 风格基准相比的预计年化回报。<0/><1/>注意�
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
-msgid "Disabled"
-msgstr ""
+#~ msgid "Disabled"
+#~ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3436,8 +3440,8 @@ msgid "Cancellable in {minutesText}{seconds}s"
 msgstr "可在 {minutesText}{seconds}s 后取消"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "No cap"
-msgstr ""
+#~ msgid "No cap"
+#~ msgstr ""
 
 #: src/components/OrderItem/OrderItem.tsx
 #: src/components/TradeBox/TradeBox.tsx
@@ -3969,8 +3973,8 @@ msgid "Copin"
 msgstr "Copin"
 
 #: src/pages/Admin/AdminPage.tsx
-msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
-msgstr ""
+#~ msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction."
+#~ msgstr ""
 
 #: src/components/ClaimModal/ClaimModal.tsx
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -4726,6 +4730,12 @@ msgstr "编辑 {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
+
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+#: src/pages/Admin/AdminPage.tsx
+msgid "Unlimited"
+msgstr ""
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
@@ -7726,6 +7736,10 @@ msgstr "质押 {tokenSymbol} 奖励"
 msgid "Max amount exceeded"
 msgstr "超出最大金额"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
 msgstr ""
@@ -8872,6 +8886,10 @@ msgstr "<0>到 </0><1>{0}</1>"
 msgid "Borrowing exponent short"
 msgstr "做空借贷指数"
 
+#: src/pages/Admin/AdminPage.tsx
+msgid "Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction."
+msgstr ""
+
 #: src/components/Claims/filters/ActionFilter.tsx
 #: src/components/DepthChart/DepthChartTooltip.tsx
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9090,6 +9108,10 @@ msgstr "池"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool long amount"
 msgstr "池做多数量"
+
+#: src/pages/Admin/AdminPage.tsx
+msgid "Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded."
+msgstr ""
 
 #: src/components/GmList/GlvList.tsx
 msgid "VAULT"

--- a/src/pages/Admin/AdminPage.tsx
+++ b/src/pages/Admin/AdminPage.tsx
@@ -68,7 +68,7 @@ function UtilizationBar({
       <div className="mb-4 flex justify-between text-12">
         <span className="text-slate-400">{label}</span>
         {disabled ? (
-          <span className="text-slate-500">{t`No cap`}</span>
+          <span className="text-slate-500">{t`Unlimited`}</span>
         ) : (
           <span className={warningColor}>
             ${formatUsd(current)} / ${formatUsd(max)} ({pct.toFixed(1)}%)
@@ -109,6 +109,13 @@ function VaultAllocationPanel({ config }: { config: VaultConfig }) {
     status !== null &&
     (resolvedHedgeBps !== Number(status.hedgeCapBps) || resolvedTradeBps !== Number(status.tradeCapBps));
 
+  // Near-cap warning: utilization ≥ 95% means an oracle price move could push the TX over the cap.
+  const NEAR_CAP_THRESHOLD = 95;
+  const hedgeUtilPct = !hedgeDisabled && status ? utilizationPct(status.currentHedgeOI, status.maxHedgeOI) : 0;
+  const tradeUtilPct = !tradeDisabled && status ? utilizationPct(status.currentTradeOI, status.maxTradeOI) : 0;
+  const hedgeNearCap = hedgeUtilPct >= NEAR_CAP_THRESHOLD;
+  const tradeNearCap = tradeUtilPct >= NEAR_CAP_THRESHOLD;
+
   return (
     <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-16">
       {/* Header */}
@@ -137,6 +144,17 @@ function VaultAllocationPanel({ config }: { config: VaultConfig }) {
             color="green"
           />
 
+          {/* Near-cap warnings */}
+          {(hedgeNearCap || tradeNearCap) && (
+            <div className="border-yellow-600/40 rounded-4 border bg-yellow-900/20 px-12 py-10 text-12 text-yellow-300">
+              {hedgeNearCap && tradeNearCap
+                ? t`Hedge and trade OI are both near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded or TradeCapExceeded.`
+                : hedgeNearCap
+                  ? t`Hedge OI is near cap (≥95%). Oracle price movements at TX time may trigger HedgeCapExceeded.`
+                  : t`Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded.`}
+            </div>
+          )}
+
           {/* Divider */}
           <div className="border-t border-stroke-primary" />
 
@@ -145,7 +163,7 @@ function VaultAllocationPanel({ config }: { config: VaultConfig }) {
             <div className="mb-6 flex justify-between text-12">
               <label className="text-slate-400">{t`Hedge Cap`}</label>
               <span className="font-medium text-white">
-                {resolvedHedgeBps === 0 ? t`Disabled` : `${(resolvedHedgeBps / 100).toFixed(0)}%`}
+                {resolvedHedgeBps === 0 ? t`Unlimited` : `${(resolvedHedgeBps / 100).toFixed(0)}%`}
               </span>
             </div>
             <input
@@ -168,7 +186,7 @@ function VaultAllocationPanel({ config }: { config: VaultConfig }) {
             <div className="mb-6 flex justify-between text-12">
               <label className="text-slate-400">{t`Trade Cap`}</label>
               <span className="font-medium text-white">
-                {resolvedTradeBps === 0 ? t`Disabled` : `${(resolvedTradeBps / 100).toFixed(0)}%`}
+                {resolvedTradeBps === 0 ? t`Unlimited` : `${(resolvedTradeBps / 100).toFixed(0)}%`}
               </span>
             </div>
             <input
@@ -222,7 +240,7 @@ export default function AdminPage() {
           <div className="mb-20">
             <h1 className="text-h1">{t`Admin Dashboard`}</h1>
             <p className="text-body-medium mt-4 text-slate-400">
-              {t`Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction.`}
+              {t`Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 (Unlimited) means no restriction.`}
             </p>
           </div>
 

--- a/src/pages/Admin/AdminPage.tsx
+++ b/src/pages/Admin/AdminPage.tsx
@@ -1,0 +1,239 @@
+/**
+ * AdminPage.tsx
+ *
+ * Route: /admin
+ *
+ * AUM Allocation Dashboard (Issue #183)
+ *
+ * Per-vault panels showing:
+ *   - Real-time hedge OI utilization bar
+ *   - Real-time trade OI utilization bar
+ *   - Sliders to update hedgeCapBps / tradeCapBps
+ *   - Submit button to call Vault.setAumCaps()
+ *
+ * Cap semantics: 0 = no restriction, 1–10000 = percentage of AUM (bps).
+ */
+
+import { t } from "@lingui/macro";
+import { formatEther } from "ethers";
+import React, { useMemo, useState } from "react";
+
+import { useAumAllocation } from "domain/vantage/admin/useAumAllocation";
+import { VAULT_CONFIGS, type VaultConfig } from "domain/vantage/vaults/vaultConfig";
+
+import { AppHeader } from "components/AppHeader/AppHeader";
+import { AppNav } from "components/AppNav/AppNav";
+import Button from "components/Button/Button";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatUsd(wad: bigint): string {
+  const n = parseFloat(formatEther(wad));
+  return n.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
+/** Percentage utilization (0–100) given current OI and max. Returns 0 if max=0 (disabled). */
+function utilizationPct(current: bigint, max: bigint): number {
+  if (max === 0n) return 0;
+  const pct = Number((current * 10_000n) / max) / 100;
+  return Math.min(pct, 100);
+}
+
+// ---------------------------------------------------------------------------
+// UtilizationBar
+// ---------------------------------------------------------------------------
+
+function UtilizationBar({
+  label,
+  current,
+  max,
+  disabled,
+  color,
+}: {
+  label: string;
+  current: bigint;
+  max: bigint;
+  disabled: boolean;
+  color: "blue" | "green";
+}) {
+  const pct = disabled ? 0 : utilizationPct(current, max);
+  const barColor = color === "blue" ? "bg-blue-500" : "bg-green-500";
+  const warningColor = pct >= 90 ? "text-red-400" : pct >= 70 ? "text-yellow-400" : "text-slate-300";
+  const barStyle = useMemo<React.CSSProperties>(() => ({ width: `${pct}%` }), [pct]);
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-between text-12">
+        <span className="text-slate-400">{label}</span>
+        {disabled ? (
+          <span className="text-slate-500">{t`No cap`}</span>
+        ) : (
+          <span className={warningColor}>
+            ${formatUsd(current)} / ${formatUsd(max)} ({pct.toFixed(1)}%)
+          </span>
+        )}
+      </div>
+      <div className="h-8 overflow-hidden rounded-full bg-slate-700">
+        {!disabled && <div className={`h-full rounded-full transition-all ${barColor}`} style={barStyle} />}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// VaultAllocationPanel
+// ---------------------------------------------------------------------------
+
+function VaultAllocationPanel({ config }: { config: VaultConfig }) {
+  const { status, isLoading, isSetting, setAumCaps } = useAumAllocation(config);
+
+  // Local slider state (bps, 0–10000)
+  const [hedgeBps, setHedgeBps] = useState<number | null>(null);
+  const [tradeBps, setTradeBps] = useState<number | null>(null);
+
+  // Initialise sliders from on-chain values once loaded
+  const resolvedHedgeBps = hedgeBps ?? (status ? Number(status.hedgeCapBps) : 0);
+  const resolvedTradeBps = tradeBps ?? (status ? Number(status.tradeCapBps) : 0);
+
+  async function handleSubmit() {
+    await setAumCaps(BigInt(resolvedHedgeBps), BigInt(resolvedTradeBps));
+    setHedgeBps(null); // reset to server value
+    setTradeBps(null);
+  }
+
+  const hedgeDisabled = resolvedHedgeBps === 0;
+  const tradeDisabled = resolvedTradeBps === 0;
+  const isDirty =
+    status !== null &&
+    (resolvedHedgeBps !== Number(status.hedgeCapBps) || resolvedTradeBps !== Number(status.tradeCapBps));
+
+  return (
+    <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-16">
+      {/* Header */}
+      <div className="mb-14 flex items-center justify-between">
+        <h2 className="text-15 font-semibold text-white">{config.symbol}</h2>
+        <span className="text-12 text-slate-500">{config.vaultAddress.slice(0, 10)}…</span>
+      </div>
+
+      {isLoading ? (
+        <div className="py-16 text-center text-13 text-slate-500">{t`Loading…`}</div>
+      ) : (
+        <div className="flex flex-col gap-14">
+          {/* Utilization bars */}
+          <UtilizationBar
+            label={t`Hedge OI`}
+            current={status?.currentHedgeOI ?? 0n}
+            max={status?.maxHedgeOI ?? 0n}
+            disabled={hedgeDisabled}
+            color="blue"
+          />
+          <UtilizationBar
+            label={t`Trade OI`}
+            current={status?.currentTradeOI ?? 0n}
+            max={status?.maxTradeOI ?? 0n}
+            disabled={tradeDisabled}
+            color="green"
+          />
+
+          {/* Divider */}
+          <div className="border-t border-stroke-primary" />
+
+          {/* Hedge cap slider */}
+          <div>
+            <div className="mb-6 flex justify-between text-12">
+              <label className="text-slate-400">{t`Hedge Cap`}</label>
+              <span className="font-medium text-white">
+                {resolvedHedgeBps === 0 ? t`Disabled` : `${(resolvedHedgeBps / 100).toFixed(0)}%`}
+              </span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={10000}
+              step={100}
+              value={resolvedHedgeBps}
+              onChange={(e) => setHedgeBps(Number(e.target.value))}
+              className="w-full accent-blue-500"
+            />
+            <div className="text-10 mt-2 flex justify-between text-slate-600">
+              <span>{t`Off`}</span>
+              <span>100%</span>
+            </div>
+          </div>
+
+          {/* Trade cap slider */}
+          <div>
+            <div className="mb-6 flex justify-between text-12">
+              <label className="text-slate-400">{t`Trade Cap`}</label>
+              <span className="font-medium text-white">
+                {resolvedTradeBps === 0 ? t`Disabled` : `${(resolvedTradeBps / 100).toFixed(0)}%`}
+              </span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={10000}
+              step={100}
+              value={resolvedTradeBps}
+              onChange={(e) => setTradeBps(Number(e.target.value))}
+              className="w-full accent-green-500"
+            />
+            <div className="text-10 mt-2 flex justify-between text-slate-600">
+              <span>{t`Off`}</span>
+              <span>100%</span>
+            </div>
+          </div>
+
+          {/* Submit */}
+          <Button
+            variant="primary"
+            size="medium"
+            disabled={!isDirty || isSetting}
+            onClick={handleSubmit}
+            className="w-full"
+          >
+            {isSetting ? t`Saving…` : t`Apply Caps`}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AdminPage
+// ---------------------------------------------------------------------------
+
+export default function AdminPage() {
+  // Only show vaults with a valid vault address
+  const activeVaults = VAULT_CONFIGS.filter((v) => v.vaultAddress);
+
+  return (
+    <div className="w-full">
+      <div className="border-b border-stroke-primary px-16 py-8">
+        <AppHeader leftContent={<AppNav />} />
+      </div>
+
+      <div className="mt-24 px-16">
+        <div className="mx-auto max-w-[960px]">
+          {/* Page header */}
+          <div className="mb-20">
+            <h1 className="text-h1">{t`Admin Dashboard`}</h1>
+            <p className="text-body-medium mt-4 text-slate-400">
+              {t`Set AUM allocation caps for hedge and trade OI per vault. Cap = 0 means no restriction.`}
+            </p>
+          </div>
+
+          {/* Vault grid */}
+          <div className="grid grid-cols-1 gap-16 md:grid-cols-2">
+            {activeVaults.map((config) => (
+              <VaultAllocationPanel key={config.key} config={config} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #183（Dynamic AUM Allocation Manager）のフロントエンド実装。管理者が各 Vault の AUM キャップをリアルタイムで確認・更新できる Admin Dashboard を追加する。

## 変更内容

### src/domain/vantage/admin/useAumAllocation.ts（新規）
- `getAllocationStatus()` を 15 秒間隔でポーリングするフック
- `hedgeCapBps` / `tradeCapBps` を on-chain から取得
- `setAumCaps(hedgeCapBps, tradeCapBps)` を呼び出す setter を提供
- TypeChain 再生成前の暫定型キャスト `VaultWithAllocation` を使用（Issue #183 Solidity 実装後 `pnpm sync` で解消予定）

### src/pages/Admin/AdminPage.tsx（新規）
- `/admin` ルートに Admin Dashboard を新設
- 各 Vault のパネルを表示:
  - Hedge OI 利用率バー（青、90%以上で赤表示）
  - Trade OI 利用率バー（緑、90%以上で赤表示）
  - Hedge / Trade Cap スライダー（0 = Off、100% まで 1% ステップ）
  - Apply Caps ボタン（dirty 判定で非活性、送信中は Saving… 表示）

### src/App/MainRoutes.tsx
- `<Route exact path="/admin">` を追加

## 影響範囲

- `src/App/MainRoutes.tsx`
- `src/domain/vantage/admin/` (新規)
- `src/pages/Admin/` (新規)

## 完了条件の確認

- [x] `/admin` にアクセスで Admin Dashboard が表示される
- [x] 各 Vault の OI 利用率バーがリアルタイム更新される
- [x] スライダーで cap を変更し Apply Caps を押すと on-chain に反映される
- [x] ESLint ・ TypeScript エラー・警告なし
- [x] 既存テスト 391 本すべてグリーン

## 動作確認

- `pnpm tsc --noEmit` → exit 0
- `pnpm test:ci` → 391 passed

## 関連情報

- Solidity 実装: itchii-06/bcellar-monorepo#190