### PR TITLE
feat(issue-191): ADL Mode Toggle in Hedge Terminal

### DIFF
--- a/src/domain/vantage/hedge/useHedgeActions.ts
+++ b/src/domain/vantage/hedge/useHedgeActions.ts
@@ -70,7 +70,8 @@ export type HedgeActionResult = {
   execute: (
     mode: HedgeMode,
     marginToken: HedgeMarginToken,
-    params: Omit<HedgeParams, "acceptablePrice">
+    params: Omit<HedgeParams, "acceptablePrice">,
+    convertOnADL: boolean
   ) => Promise<void>;
 };
 
@@ -140,7 +141,8 @@ export function useHedgeActions(): HedgeActionResult {
     async (
       mode: HedgeMode,
       marginToken: HedgeMarginToken,
-      params: Omit<HedgeParams, "acceptablePrice">
+      params: Omit<HedgeParams, "acceptablePrice">,
+      convertOnADL: boolean
     ): Promise<void> => {
       if (!signer) {
         setError("Wallet not connected");
@@ -184,6 +186,7 @@ export function useHedgeActions(): HedgeActionResult {
               params.indexToken,
               params.sizeDelta,
               acceptablePrice,
+              convertOnADL,
               executionFee,
               { value: executionFee }
             );
@@ -198,6 +201,7 @@ export function useHedgeActions(): HedgeActionResult {
               params.indexToken,
               params.sizeDelta,
               acceptablePrice,
+              convertOnADL,
               executionFee,
               { value: msgValue }
             );
@@ -221,6 +225,7 @@ export function useHedgeActions(): HedgeActionResult {
               params.indexToken,
               params.sizeDelta,
               acceptablePrice,
+              convertOnADL,
               executionFee,
               { value: executionFee }
             );
@@ -232,6 +237,7 @@ export function useHedgeActions(): HedgeActionResult {
               params.indexToken,
               params.sizeDelta,
               acceptablePrice,
+              convertOnADL,
               executionFee,
               { value: msgValue }
             );

--- a/src/domain/vantage/hedge/useHedgePageData.ts
+++ b/src/domain/vantage/hedge/useHedgePageData.ts
@@ -48,6 +48,8 @@ export interface UserPosition {
   averagePrice: number;
   /** Which token was used as collateral */
   collateralToken: "USDC" | "ETH";
+  /** ADL handling mode: true = convert to paid-short (Mode B), false = auto-terminate (Mode A) */
+  shouldConvertOnADL: boolean;
 }
 
 export interface HedgePageData {
@@ -255,9 +257,10 @@ export function useHedgePageData(
             tokenAddr,
             false // isLong = false (short)
           );
-          const [pos, softLocked] = await Promise.all([
+          const [pos, softLocked, convertOnADL] = await Promise.all([
             vault.positions(key),
             vault.isSoftLockedPosition(key).catch(() => false) as Promise<boolean>,
+            vault.shouldConvertOnADL(key).catch(() => false) as Promise<boolean>,
           ]);
           if (BigInt(pos.size) > 0n) {
             userPosition = {
@@ -265,6 +268,7 @@ export function useHedgePageData(
               collateralUsd: parseFloat(formatEther(pos.collateral)),
               averagePrice: parseFloat(formatEther(pos.averagePrice)),
               collateralToken: "USDC",
+              shouldConvertOnADL: convertOnADL,
             };
             isSoftLockedPosition = softLocked;
           }

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -760,6 +760,10 @@ msgstr "Hell"
 msgid "Use manual path"
 msgstr "Manuellen Pfad verwenden"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "Longs / Shorts"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Sicherheits-Spread"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "TP/SL setzen"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Maximal {MAX_REFERRAL_CODE_LENGTH} Zeichen"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "Nicht gestakt"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "Express + One-Click"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "Textfarben"
 msgid "7d"
 msgstr "7T"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "Token-Genehmigung"
@@ -11744,6 +11772,10 @@ msgstr "Zum Einzahlen verfügbar"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "Geben Sie einen Empfehlungscode ein, um Gebührenrabatte zu erhalten"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -760,6 +760,10 @@ msgstr "Light"
 msgid "Use manual path"
 msgstr "Use manual path"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr "Mode B — Convert to Paid-Short"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "Longs / shorts"
@@ -3265,6 +3269,10 @@ msgstr "Transaction submitted"
 msgid "Ask"
 msgstr "Ask"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Collateral spread"
@@ -5398,6 +5406,10 @@ msgstr "Warning: Your position value exceeds current vault AUM. Withdrawal may b
 msgid "Vault LP"
 msgstr "Vault LP"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr "Mode A — Auto-Terminate"
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "Set TP/SL"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Max {MAX_REFERRAL_CODE_LENGTH} characters"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr "Convert to Paid-Short"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "Not staked"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr "Position is closed and margin is returned when ADL is triggered."
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "Express + One-Click"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr "ADL Mode:"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "Text colors"
 msgid "7d"
 msgstr "7d"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr "Close (Recommended)"
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "Token permit"
@@ -11744,6 +11772,10 @@ msgstr "Available to deposit"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "Enter a referral code to get fee discounts"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr "Emergency Behavior (ADL)"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -760,6 +760,10 @@ msgstr "Claro"
 msgid "Use manual path"
 msgstr "Usar ruta manual"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "Largos / cortos"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Diferencial de garantía"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "Establecer TP/SL"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Máximo {MAX_REFERRAL_CODE_LENGTH} caracteres"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "Sin staking"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "Express + Un Clic"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "Colores de texto"
 msgid "7d"
 msgstr "7d"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "Permiso de token"
@@ -11744,6 +11772,10 @@ msgstr "Disponible para depositar"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "Introduzca un código de referido para obtener descuentos en las comisiones"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -760,6 +760,10 @@ msgstr "Clair"
 msgid "Use manual path"
 msgstr "Utiliser le chemin manuel"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "Longs / shorts"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Écart de garantie"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "Définir TP/SL"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Max {MAX_REFERRAL_CODE_LENGTH} caractères"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "Non staké"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "Express + One-Click"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "Couleurs de texte"
 msgid "7d"
 msgstr "7j"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "Permis de jeton"
@@ -11744,6 +11772,10 @@ msgstr "Disponible pour déposer"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "Entrez un code de parrainage pour obtenir des réductions sur les frais"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -760,6 +760,10 @@ msgstr "ライト"
 msgid "Use manual path"
 msgstr "手動パスを使用"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "ロング / ショート"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "担保スプレッド"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "TP/SLを設定"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "最大 {MAX_REFERRAL_CODE_LENGTH} 文字"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "未ステーキング"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "エクスプレス + ワンクリック"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "テキストカラー"
 msgid "7d"
 msgstr "7日"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "トークンパーミット"
@@ -11744,6 +11772,10 @@ msgstr "入金可能"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "リファラルコードを入力して手数料の割引を受けましょう"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -760,6 +760,10 @@ msgstr "라이트"
 msgid "Use manual path"
 msgstr "수동 경로 사용"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "롱 / 숏"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "담보 스프레드"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "TP/SL 설정"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "최대 {MAX_REFERRAL_CODE_LENGTH}자"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "미스테이킹"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "익스프레스 + 원클릭"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "텍스트 색상"
 msgid "7d"
 msgstr "7일"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "토큰 허가"
@@ -11744,6 +11772,10 @@ msgstr "입금 가능"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "추천 코드를 입력하면 수수료 할인을 받으실 수 있습니다"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -760,6 +760,10 @@ msgstr ""
 msgid "Use manual path"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr ""
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr ""
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5495,6 +5507,10 @@ msgstr ""
 
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
 msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -8466,6 +8482,10 @@ msgstr ""
 msgid "{0}ms"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9773,6 +9793,10 @@ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
 msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -11233,6 +11257,10 @@ msgstr ""
 msgid "7d"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr ""
@@ -11743,6 +11771,10 @@ msgstr ""
 
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
 msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -760,6 +760,10 @@ msgstr "Светлый"
 msgid "Use manual path"
 msgstr "Использовать ручной маршрут"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "Лонги / шорты"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Спред обеспечения"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "Установить TP/SL"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Максимум {MAX_REFERRAL_CODE_LENGTH} символов"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "Не в стейкинге"
 msgid "{0}ms"
 msgstr "{0}мс"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "Express + One-Click"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "Цвета текста"
 msgid "7d"
 msgstr "7д"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "Разрешение токена"
@@ -11744,6 +11772,10 @@ msgstr "Доступно для депозита"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "Введите реферальный код для получения скидки на комиссии"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -760,6 +760,10 @@ msgstr "淺色"
 msgid "Use manual path"
 msgstr "使用手動路徑"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "做多 / 做空"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "抵押品價差"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "設定 TP/SL"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "最多 {MAX_REFERRAL_CODE_LENGTH} 個字元"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "未質押"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "Express + One-Click"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "文字顏色"
 msgid "7d"
 msgstr "7 天"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "代幣許可"
@@ -11744,6 +11772,10 @@ msgstr "可存入"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "輸入推薦碼以獲得手續費折扣"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -760,6 +760,10 @@ msgstr "浅色"
 msgid "Use manual path"
 msgstr "使用手动路径"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Convert to Paid-Short"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
 msgstr "做多 / 做空"
@@ -3265,6 +3269,10 @@ msgstr ""
 msgid "Ask"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "抵押品价差"
@@ -5398,6 +5406,10 @@ msgstr ""
 msgid "Vault LP"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Auto-Terminate"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transfer account"
@@ -5496,6 +5508,10 @@ msgstr "设置 TP/SL"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "最多 {MAX_REFERRAL_CODE_LENGTH} 个字符"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Convert to Paid-Short"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -8466,6 +8482,10 @@ msgstr "未质押"
 msgid "{0}ms"
 msgstr "{0}ms"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Position is closed and margin is returned when ADL is triggered."
+msgstr ""
+
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -9774,6 +9794,10 @@ msgstr "/USD"
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Express + One-Click"
 msgstr "快速 + 一键"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode:"
+msgstr ""
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -11233,6 +11257,10 @@ msgstr "文本颜色"
 msgid "7d"
 msgstr "7 天"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Close (Recommended)"
+msgstr ""
+
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
 msgstr "代币许可"
@@ -11744,6 +11772,10 @@ msgstr "可存入"
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Enter a referral code to get fee discounts"
 msgstr "输入推荐码以获得费用折扣"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Emergency Behavior (ADL)"
+msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -400,6 +400,7 @@ type PositionPanelProps = {
   collateralUsd: number;
   averagePrice: number;
   collateralToken: "USDC" | "ETH";
+  shouldConvertOnADL: boolean;
 };
 
 function CurrentPositionPanel({
@@ -409,6 +410,7 @@ function CurrentPositionPanel({
   collateralUsd,
   averagePrice,
   collateralToken,
+  shouldConvertOnADL,
 }: PositionPanelProps) {
   const tokenAmount = averagePrice > 0 ? sizeUsd / averagePrice : 0;
   const currentPrice = spotPriceUsd ?? averagePrice;
@@ -458,6 +460,20 @@ function CurrentPositionPanel({
           </div>
         </div>
       </div>
+
+      {/* ADL mode badge */}
+      <div className="mt-14 flex items-center gap-8">
+        <span className="text-11 text-slate-500">{t`ADL Mode:`}</span>
+        {shouldConvertOnADL ? (
+          <span className="bg-blue-900/40 rounded-full px-10 py-3 text-11 font-medium text-blue-300">
+            {t`Mode B — Convert to Paid-Short`}
+          </span>
+        ) : (
+          <span className="rounded-full bg-slate-700/60 px-10 py-3 text-11 font-medium text-slate-400">
+            {t`Mode A — Auto-Terminate`}
+          </span>
+        )}
+      </div>
     </>
   );
 }
@@ -478,6 +494,7 @@ export default function HedgeDetailPage() {
   const [marginToken, setMarginToken] = useState<HedgeMarginToken>("usdc");
   const [rwaAmountStr, setRwaAmountStr] = useState("");
   const [leverageStr, setLeverageStr] = useState("1");
+  const [convertOnADL, setConvertOnADL] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [timeFrame, setTimeFrame] = useState<TimeFrame>("1h");
 
@@ -551,7 +568,7 @@ export default function HedgeDetailPage() {
       setValidationError(err);
       return;
     }
-    await execute(mode, marginToken, params);
+    await execute(mode, marginToken, params, convertOnADL);
   }
 
   const canExecute = account && !isSubmitting && rwaAmount > 0 && !pageData.isHedgeDisabled;
@@ -666,6 +683,7 @@ export default function HedgeDetailPage() {
                   collateralUsd={pageData.userPosition.collateralUsd}
                   averagePrice={pageData.userPosition.averagePrice}
                   collateralToken={pageData.userPosition.collateralToken}
+                  shouldConvertOnADL={pageData.userPosition.shouldConvertOnADL}
                 />
               ) : (
                 <p className="text-13 text-slate-500">{t`No open short position. Use the form above to open one.`}</p>
@@ -739,6 +757,34 @@ export default function HedgeDetailPage() {
                 placeholder="1"
               />
               <p className="mt-4 text-11 text-slate-500">{t`1× = delta-neutral. Higher = partial hedge.`}</p>
+            </div>
+
+            {/* ADL Mode toggle */}
+            <div className="mb-16">
+              <div className="mb-8 text-12 text-slate-400">{t`Emergency Behavior (ADL)`}</div>
+              <div className="flex rounded-4 border border-stroke-primary">
+                <button
+                  onClick={() => setConvertOnADL(false)}
+                  className={`flex-1 rounded-l-4 py-8 text-12 font-medium transition-colors ${
+                    !convertOnADL ? "bg-slate-600 text-white" : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
+                  }`}
+                >
+                  {t`Close (Recommended)`}
+                </button>
+                <button
+                  onClick={() => setConvertOnADL(true)}
+                  className={`flex-1 rounded-r-4 py-8 text-12 font-medium transition-colors ${
+                    convertOnADL ? "bg-blue-700 text-white" : "text-slate-400 hover:bg-slate-700/50 hover:text-white"
+                  }`}
+                >
+                  {t`Convert to Paid-Short`}
+                </button>
+              </div>
+              <p className="mt-4 text-11 text-slate-500">
+                {convertOnADL
+                  ? t`Position is kept as a normal short. Funding rate payments apply from ADL moment.`
+                  : t`Position is closed and margin is returned when ADL is triggered.`}
+              </p>
             </div>
 
             {/* Calculated amounts */}

--- a/src/vantage/abis/HedgeController.json
+++ b/src/vantage/abis/HedgeController.json
@@ -1,8 +1,16 @@
 [
   {
     "inputs": [
-      { "internalType": "address", "name": "_lpManager",      "type": "address" },
-      { "internalType": "address", "name": "_positionRouter", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_lpManager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_positionRouter",
+        "type": "address"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
@@ -10,10 +18,30 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true,  "internalType": "address", "name": "user",            "type": "address" },
-      { "indexed": true,  "internalType": "address", "name": "rwaToken",        "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "rwaAmount",       "type": "uint256" },
-      { "indexed": false, "internalType": "bytes32", "name": "shortRequestKey", "type": "bytes32" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "rwaToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rwaAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "shortRequestKey",
+        "type": "bytes32"
+      }
     ],
     "name": "ManagedHedgeCreated",
     "type": "event"
@@ -21,24 +49,81 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true,  "internalType": "address", "name": "user",            "type": "address" },
-      { "indexed": true,  "internalType": "address", "name": "indexToken",      "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "sizeDelta",       "type": "uint256" },
-      { "indexed": false, "internalType": "bytes32", "name": "shortRequestKey", "type": "bytes32" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "shortRequestKey",
+        "type": "bytes32"
+      }
     ],
     "name": "SelfCustodyHedgeCreated",
     "type": "event"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "rwaToken",         "type": "address" },
-      { "internalType": "uint256", "name": "rwaAmount",        "type": "uint256" },
-      { "internalType": "address", "name": "collateralToken",  "type": "address" },
-      { "internalType": "uint256", "name": "collateralAmount", "type": "uint256" },
-      { "internalType": "address", "name": "indexToken",       "type": "address" },
-      { "internalType": "uint256", "name": "sizeDelta",        "type": "uint256" },
-      { "internalType": "uint256", "name": "acceptablePrice",  "type": "uint256" },
-      { "internalType": "uint256", "name": "executionFee",     "type": "uint256" }
+      {
+        "internalType": "address",
+        "name": "rwaToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rwaAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "executionFee",
+        "type": "uint256"
+      }
     ],
     "name": "createManagedHedge",
     "outputs": [],
@@ -47,12 +132,41 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "rwaToken",        "type": "address" },
-      { "internalType": "uint256", "name": "rwaAmount",       "type": "uint256" },
-      { "internalType": "address", "name": "indexToken",      "type": "address" },
-      { "internalType": "uint256", "name": "sizeDelta",       "type": "uint256" },
-      { "internalType": "uint256", "name": "acceptablePrice", "type": "uint256" },
-      { "internalType": "uint256", "name": "executionFee",    "type": "uint256" }
+      {
+        "internalType": "address",
+        "name": "rwaToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rwaAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "executionFee",
+        "type": "uint256"
+      }
     ],
     "name": "createManagedHedgeETH",
     "outputs": [],
@@ -61,12 +175,41 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "collateralToken",  "type": "address" },
-      { "internalType": "uint256", "name": "collateralAmount", "type": "uint256" },
-      { "internalType": "address", "name": "indexToken",       "type": "address" },
-      { "internalType": "uint256", "name": "sizeDelta",        "type": "uint256" },
-      { "internalType": "uint256", "name": "acceptablePrice",  "type": "uint256" },
-      { "internalType": "uint256", "name": "executionFee",     "type": "uint256" }
+      {
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "executionFee",
+        "type": "uint256"
+      }
     ],
     "name": "createSelfCustodyHedge",
     "outputs": [],
@@ -75,10 +218,31 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "indexToken",      "type": "address" },
-      { "internalType": "uint256", "name": "sizeDelta",       "type": "uint256" },
-      { "internalType": "uint256", "name": "acceptablePrice", "type": "uint256" },
-      { "internalType": "uint256", "name": "executionFee",    "type": "uint256" }
+      {
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "executionFee",
+        "type": "uint256"
+      }
     ],
     "name": "createSelfCustodyHedgeETH",
     "outputs": [],
@@ -88,14 +252,26 @@
   {
     "inputs": [],
     "name": "lpManager",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "positionRouter",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   }

--- a/src/vantage/abis/Vault.json
+++ b/src/vantage/abis/Vault.json
@@ -2118,6 +2118,16 @@
         "internalType": "uint256",
         "name": "_collateralDelta",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_convertOnADL",
+        "type": "bool"
       }
     ],
     "name": "increasePosition",
@@ -3374,5 +3384,169 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "shouldConvertOnADL",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "executeHedgeADL",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isHedgePosition",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isSoftLockedPosition",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingHedgedNotional",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgeADLTerminated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingHedgedNotional",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgeConverted",
+    "type": "event"
   }
 ]


### PR DESCRIPTION
## 概要
Issue #191 のフロントエンド対応。ヘッジポジション開設時に ADL 発動時の挙動（Mode A/B）をユーザーが選択できるトグルを追加。保有ポジションのモードも表示する。

## 変更内容
- **`useHedgeActions.ts`**: `execute()` に `convertOnADL: boolean` 引数を追加。4つのコントラクト呼び出し（createManagedHedge / ETH / createSelfCustodyHedge / ETH）に `convertOnADL` を渡す
- **`useHedgePageData.ts`**: `UserPosition.shouldConvertOnADL` を追加。`vault.shouldConvertOnADL(key)` をポーリング
- **`HedgeDetailPage.tsx`**: ADL モード選択トグル UI を追加（Leverage 入力の下）。`CurrentPositionPanel` に ADL モードバッジを追加
- **`HedgeController.json` ABI**: 4関数に `convertOnADL: bool` パラメータを追加
- **`Vault.json` ABI**: `shouldConvertOnADL`、`executeHedgeADL`、`isHedgePosition`、`isSoftLockedPosition` ゲッター、`HedgeADLTerminated` / `HedgeConverted` イベントを追加

## 影響範囲
- `src/domain/vantage/hedge/useHedgeActions.ts`
- `src/domain/vantage/hedge/useHedgePageData.ts`
- `src/pages/Hedge/HedgeDetailPage.tsx`
- `src/vantage/abis/HedgeController.json`
- `src/vantage/abis/Vault.json`

## 完了条件の確認
- [x] ヘッジ開設パネルに「Close（Recommended）」/「Convert to Paid-Short」トグルが表示される
- [x] 選択値が `createManagedHedge` 等のコントラクト呼び出しに渡される
- [x] 保有中ポジションに ADL モードバッジが表示される（Mode A / Mode B）
- [x] TypeScript エラーなし

## 動作確認
- [x] `tsc --noEmit` — エラーなし
- [x] ESLint — `lint-staged` 通過

## 関連情報
- Solidity PR: itchii-06/bcellar-monorepo#192
- Closes #191