### PR TITLE
feat(issue-193): Solvency Dashboard & Emergency UI States

### DIFF
--- a/src/App/MainRoutes.tsx
+++ b/src/App/MainRoutes.tsx
@@ -32,6 +32,7 @@ import { PriceImpactRebatesStatsPage } from "pages/PriceImpactRebatesStats/Price
 import Referrals from "pages/Referrals/Referrals";
 import ReferralsTier from "pages/ReferralsTier/ReferralsTier";
 import StatsPage from "pages/Stats/StatsPage";
+import StatusPage from "pages/Status/StatusPage";
 import { SyntheticsStats } from "pages/SyntheticsStats/SyntheticsStats";
 import TradePage from "pages/Trade/TradePage";
 import VantageLPPage from "pages/VantageLP/VantageLPPage";
@@ -159,6 +160,9 @@ export function MainRoutes({ openSettings: _openSettings }: { openSettings: () =
         <SyntheticsStateContextProvider skipLocalReferralCode={false} pageType="pools">
           <PoolsDetails />
         </SyntheticsStateContextProvider>
+      </Route>
+      <Route exact path="/status">
+        <StatusPage />
       </Route>
       <Route exact path="/hedge">
         <HedgePage />

--- a/src/components/AppNav/AppNav.tsx
+++ b/src/components/AppNav/AppNav.tsx
@@ -22,6 +22,7 @@ const NAV_ITEMS = [
   { key: "trade", label: "Trade", to: "/trade" },
   { key: "vaults", label: "Vaults", to: "/vaults" },
   { key: "portfolio", label: "Portfolio", to: "/portfolio" },
+  { key: "status", label: "Status", to: "/status" },
 ] as const;
 
 export function AppNav() {

--- a/src/domain/vantage/solvency/getDefenseStep.ts
+++ b/src/domain/vantage/solvency/getDefenseStep.ts
@@ -1,0 +1,150 @@
+/**
+ * getDefenseStep.ts
+ *
+ * Pure function that maps on-chain defense flags to a 0–7 step number.
+ * Steps are cumulative — evaluate highest (most severe) first (descending).
+ *
+ * Step 0: Normal — no defense active.
+ * Step 1: LP Boost (Phase 1-1) — reserveFund being redirected to lpBoostPool.
+ * Step 2: High-Lev Lock or OI Cap (Phase 1-2) — new high-leverage hedges blocked.
+ * Step 3: Premium Surge (Phase 1-3) — new hedges pay elevated premium.
+ * Step 4: Reserve Fund releasing (Phase 2-4) — hedgeCapacityPct >= 80.
+ * Step 5: Junior Buffer absorbing (Phase 2-5) — juniorDeficitAbsorbed > 0.
+ * Step 6: Trade ADL in progress (Phase 3-6) — isHedgeDisabled && solvencyDropAt > 0.
+ * Step 7: Hedge ADL / Termination (Phase 3-7) — isHedgeDisabled with extended duration.
+ *
+ * The function always returns the highest active step so the UI shows
+ * the most critical phase even when multiple phases overlap.
+ */
+
+export type DefenseStep = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export interface DefenseStepInput {
+  isLPBoostActive: boolean;
+  isHighLeverageLocked: boolean;
+  isPremiumSurgeActive: boolean;
+  isHedgeDisabled: boolean;
+  solvencyDropAt: number; // Unix timestamp; 0 = healthy
+  juniorDeficitAbsorbed: number | null; // USD WAD as JS number; null = unknown
+  hedgeCapacityPct: number | null; // 0–100+; null = unknown
+}
+
+// 24 hours in seconds — if solvencyDropAt is older than this, escalate to Step 7.
+const HEDGE_ADL_THRESHOLD_S = 24 * 60 * 60;
+
+export function getDefenseStep(input: DefenseStepInput): DefenseStep {
+  const {
+    isLPBoostActive,
+    isHighLeverageLocked,
+    isPremiumSurgeActive,
+    isHedgeDisabled,
+    solvencyDropAt,
+    juniorDeficitAbsorbed,
+    hedgeCapacityPct,
+  } = input;
+
+  const nowS = Math.floor(Date.now() / 1000);
+  const dropDurationS = solvencyDropAt > 0 ? nowS - solvencyDropAt : 0;
+
+  // Descending priority: highest step evaluated first.
+
+  // Step 7: Hedge ADL — extended solvency deficit (>24h) while hedge is disabled.
+  if (isHedgeDisabled && solvencyDropAt > 0 && dropDurationS >= HEDGE_ADL_THRESHOLD_S) {
+    return 7;
+  }
+
+  // Step 6: Trade ADL — solvency dropped and hedge intake disabled.
+  if (isHedgeDisabled && solvencyDropAt > 0) {
+    return 6;
+  }
+
+  // Step 5: Junior Buffer actively absorbing FR deficit.
+  if (juniorDeficitAbsorbed !== null && juniorDeficitAbsorbed > 0) {
+    return 5;
+  }
+
+  // Step 4: Reserve Fund being tapped (hedgeCapacityPct >= 80 indicates approaching limit).
+  if (hedgeCapacityPct !== null && hedgeCapacityPct >= 80) {
+    return 4;
+  }
+
+  // Step 3: Premium Surge for new hedges.
+  if (isPremiumSurgeActive) {
+    return 3;
+  }
+
+  // Step 2: High-leverage lock or OI Cap (isHedgeDisabled without solvency drop
+  // is the OI Cap scenario).
+  if (isHighLeverageLocked || isHedgeDisabled) {
+    return 2;
+  }
+
+  // Step 1: LP Boost active (mildest prevention phase).
+  if (isLPBoostActive) {
+    return 1;
+  }
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Display metadata for each step
+// ---------------------------------------------------------------------------
+
+export interface StepMeta {
+  label: string;
+  phase: string;
+  description: string;
+  severity: "normal" | "warning" | "danger" | "critical";
+}
+
+export const STEP_META: Record<DefenseStep, StepMeta> = {
+  0: {
+    label: "Normal",
+    phase: "—",
+    description: "Protocol operating normally. No defense measures active.",
+    severity: "normal",
+  },
+  1: {
+    label: "LP Boost",
+    phase: "Phase 1 · Prevention",
+    description: "Reserve fund redirected to boost LP rewards, attracting new liquidity.",
+    severity: "normal",
+  },
+  2: {
+    label: "High-Lev Lock",
+    phase: "Phase 1 · Prevention",
+    description: "New high-leverage hedge positions are blocked. Existing positions unaffected.",
+    severity: "warning",
+  },
+  3: {
+    label: "Premium Surge",
+    phase: "Phase 1 · Prevention",
+    description: "New hedges carry an elevated entry premium. Existing positions maintain original rate.",
+    severity: "warning",
+  },
+  4: {
+    label: "Reserve Fund",
+    phase: "Phase 2 · Internal Buffer",
+    description: "Stability reserve fund covering FR shortfall. Existing user costs unchanged.",
+    severity: "warning",
+  },
+  5: {
+    label: "Junior Buffer",
+    phase: "Phase 2 · Internal Buffer",
+    description: "Junior LP (USDC) absorbing FR deficit. Senior RWA LP and hedge users protected.",
+    severity: "warning",
+  },
+  6: {
+    label: "Trade ADL",
+    phase: "Phase 3 · Enforcement",
+    description: "High-profit long positions being force-closed to reduce FR obligations.",
+    severity: "danger",
+  },
+  7: {
+    label: "Hedge ADL",
+    phase: "Phase 3 · Final Defense",
+    description: "Some hedge positions being force-closed. Protocol exercising last-resort termination.",
+    severity: "critical",
+  },
+};

--- a/src/domain/vantage/solvency/useStatusPageData.ts
+++ b/src/domain/vantage/solvency/useStatusPageData.ts
@@ -1,0 +1,287 @@
+/**
+ * useStatusPageData.ts
+ *
+ * Polls all on-chain data needed to render the /status Solvency Dashboard.
+ *
+ * Data sources:
+ *   Vault          — defense flags, reserve fund, LP boost pool, AUM
+ *   TrancheVault   — juniorDeficitAbsorbed, junior AUM (optional, gracefully absent)
+ *   AssetRegistry  — OI utilization, funding params
+ *   YieldAccumulator — yield APR
+ *
+ * The primary vault used is the first configured vault (USDC). For multi-vault
+ * environments the caller should pass a specific VaultConfig.
+ */
+
+import { Contract, formatEther } from "ethers";
+import { useEffect, useState } from "react";
+
+import type { DefenseStep } from "domain/vantage/solvency/getDefenseStep";
+import { getDefenseStep } from "domain/vantage/solvency/getDefenseStep";
+import type { VaultConfig } from "domain/vantage/vaults/vaultConfig";
+import { getProvider } from "lib/rpc";
+import AssetRegistryAbi from "vantage/abis/AssetRegistry.json";
+import TrancheVaultAbi from "vantage/abis/TrancheVault.json";
+import VaultAbi from "vantage/abis/Vault.json";
+import YieldAccumulatorAbi from "vantage/abis/YieldAccumulator.json";
+import { getVantageContractAddress } from "vantage/contracts";
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const POLL_MS = 15_000;
+const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
+
+const dep = localhostDeployment.addresses as {
+  tokens?: { USDC?: string };
+  JuniorTrancheVault?: string;
+};
+
+const USDC_ADDRESS = dep.tokens?.USDC ?? "";
+// Optional PAYOUT TrancheVault address. May be absent in early deployments.
+const JUNIOR_TRANCHE_VAULT = dep.JuniorTrancheVault ?? "";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StatusPageData {
+  // ── Defense phase flags ───────────────────────────────────────────────────
+  isLPBoostActive: boolean;
+  isHighLeverageLocked: boolean;
+  isPremiumSurgeActive: boolean;
+  isHedgeDisabled: boolean;
+  /** Unix timestamp when solvency first dropped; 0 = currently healthy. */
+  solvencyDropAt: number;
+
+  // ── Derived step ──────────────────────────────────────────────────────────
+  /** Current defense step 0–7 (highest active phase). */
+  defenseStep: DefenseStep;
+
+  // ── Buffer gauges ─────────────────────────────────────────────────────────
+  /** USD WAD in the Vault reserve fund for USDC token. */
+  reserveFundUsd: number | null;
+  /** USD WAD redirected from reserveFund into lpBoostPool (raises VLP share price). */
+  lpBoostPoolUsd: number | null;
+  /** USD WAD absorbed from Junior (PAYOUT) tranche AUM to cover FR deficit. */
+  juniorDeficitAbsorbed: number | null;
+  /** Total AUM of the Junior (PAYOUT) TrancheVault. Used as the gauge denominator. */
+  juniorAumUsd: number | null;
+
+  // ── OI utilization ────────────────────────────────────────────────────────
+  totalShortUsd: number | null;
+  totalLongUsd: number | null;
+  maxShortCapacityUsd: number | null;
+  /** 0–100+ %; >100 means cap exceeded. */
+  oiUtilizationPct: number | null;
+
+  // ── Yield & funding ───────────────────────────────────────────────────────
+  yieldAprBps: number | null;
+  fundingRateBps: number | null;
+  hedgeCapacityPct: number | null;
+  safetyBufferBps: number | null;
+}
+
+const EMPTY: StatusPageData = {
+  isLPBoostActive: false,
+  isHighLeverageLocked: false,
+  isPremiumSurgeActive: false,
+  isHedgeDisabled: false,
+  solvencyDropAt: 0,
+  defenseStep: 0,
+  reserveFundUsd: null,
+  lpBoostPoolUsd: null,
+  juniorDeficitAbsorbed: null,
+  juniorAumUsd: null,
+  totalShortUsd: null,
+  totalLongUsd: null,
+  maxShortCapacityUsd: null,
+  oiUtilizationPct: null,
+  yieldAprBps: null,
+  fundingRateBps: null,
+  hedgeCapacityPct: null,
+  safetyBufferBps: null,
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useStatusPageData(chainId: number, cfg: VaultConfig | undefined): StatusPageData {
+  const [data, setData] = useState<StatusPageData>(EMPTY);
+
+  useEffect(() => {
+    if (!cfg?.vaultAddress || !cfg?.tokenAddress) return;
+
+    const provider = getProvider(undefined, chainId);
+    const vault = new Contract(cfg.vaultAddress, VaultAbi, provider);
+
+    const assetRegAddr = getVantageContractAddress(chainId, "AssetRegistry");
+    const yieldAccAddr = getVantageContractAddress(chainId, "YieldAccumulator");
+
+    const assetReg =
+      assetRegAddr && assetRegAddr !== ZERO_ADDR ? new Contract(assetRegAddr, AssetRegistryAbi, provider) : null;
+
+    const yieldAcc =
+      yieldAccAddr && yieldAccAddr !== ZERO_ADDR ? new Contract(yieldAccAddr, YieldAccumulatorAbi, provider) : null;
+
+    const juniorVault =
+      JUNIOR_TRANCHE_VAULT && JUNIOR_TRANCHE_VAULT !== ZERO_ADDR
+        ? new Contract(JUNIOR_TRANCHE_VAULT, TrancheVaultAbi, provider)
+        : null;
+
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const tokenAddr = cfg!.tokenAddress;
+
+        // ── 1. Defense flags ────────────────────────────────────────────────
+        const [
+          isHedgeDisabled,
+          isHighLeverageLocked,
+          isPremiumSurgeActive,
+          isLPBoostActive,
+          solvencyDropAtRaw,
+          safetyBufferBpsRaw,
+        ] = await Promise.all([
+          vault.isHedgeDisabled().catch(() => false) as Promise<boolean>,
+          vault.isHighLeverageLocked().catch(() => false) as Promise<boolean>,
+          vault.isPremiumSurgeActive().catch(() => false) as Promise<boolean>,
+          vault.isLPBoostActive().catch(() => false) as Promise<boolean>,
+          vault.solvencyDropAt().catch(() => 0n) as Promise<bigint>,
+          vault.safetyBufferBps().catch(() => 0n) as Promise<bigint>,
+        ]);
+
+        const solvencyDropAt = Number(solvencyDropAtRaw);
+        const safetyBufferBps = Number(safetyBufferBpsRaw);
+
+        // ── 2. Buffer gauges ────────────────────────────────────────────────
+        let reserveFundUsd: number | null = null;
+        let lpBoostPoolUsd: number | null = null;
+        if (USDC_ADDRESS) {
+          const [rfRaw, lbRaw] = await Promise.all([
+            vault.reserveFund(USDC_ADDRESS).catch(() => 0n) as Promise<bigint>,
+            vault.lpBoostPool(USDC_ADDRESS).catch(() => 0n) as Promise<bigint>,
+          ]);
+          reserveFundUsd = parseFloat(formatEther(rfRaw));
+          lpBoostPoolUsd = parseFloat(formatEther(lbRaw));
+        }
+
+        // ── 3. Junior TrancheVault ──────────────────────────────────────────
+        let juniorDeficitAbsorbed: number | null = null;
+        let juniorAumUsd: number | null = null;
+        if (juniorVault) {
+          const [deficitRaw, juniorAumRaw] = await Promise.all([
+            juniorVault.juniorDeficitAbsorbed().catch(() => 0n) as Promise<bigint>,
+            juniorVault.getAUM().catch(() => 0n) as Promise<bigint>,
+          ]);
+          juniorDeficitAbsorbed = parseFloat(formatEther(deficitRaw));
+          juniorAumUsd = parseFloat(formatEther(juniorAumRaw));
+        }
+
+        // ── 4. OI utilization ───────────────────────────────────────────────
+        const [totalShortRaw, totalLongRaw] = await Promise.all([
+          vault.totalShortSize(tokenAddr).catch(() => 0n) as Promise<bigint>,
+          vault.totalLongSize(tokenAddr).catch(() => 0n) as Promise<bigint>,
+        ]);
+        const totalShortUsd = parseFloat(formatEther(totalShortRaw));
+        const totalLongUsd = parseFloat(formatEther(totalLongRaw));
+
+        let maxShortCapacityUsd: number | null = null;
+        let oiUtilizationPct: number | null = null;
+        if (assetReg) {
+          const assetData = await assetReg.assets(tokenAddr).catch(() => null);
+          if (assetData) {
+            const maxShortWad: bigint = BigInt(assetData.maxGlobalShortSize) / 10n ** 12n;
+            maxShortCapacityUsd = parseFloat(formatEther(maxShortWad));
+            oiUtilizationPct = maxShortCapacityUsd > 0 ? (totalShortUsd / maxShortCapacityUsd) * 100 : null;
+          }
+        }
+
+        // ── 5. Yield & funding rate ─────────────────────────────────────────
+        let yieldAprBps: number | null = null;
+        if (yieldAcc) {
+          const assetYield = await yieldAcc.assetYields(tokenAddr).catch(() => null);
+          if (assetYield) yieldAprBps = Number(assetYield.annualYieldBps);
+        }
+
+        let fundingRateBps: number | null = null;
+        if (assetReg) {
+          const totalOI = totalShortRaw + totalLongRaw;
+          if (totalOI > 0n) {
+            const { fundingRateFactor } = await assetReg.getFundingParams(tokenAddr).catch(() => ({
+              fundingRateFactor: 0n,
+            }));
+            if (BigInt(fundingRateFactor) > 0n) {
+              const PRICE_PRECISION = 10n ** 18n;
+              const skew = ((totalLongRaw - totalShortRaw) * PRICE_PRECISION) / totalOI;
+              const annualRateWad = (skew * BigInt(fundingRateFactor)) / PRICE_PRECISION;
+              fundingRateBps = Number(annualRateWad) / 1e14;
+            } else {
+              fundingRateBps = 0;
+            }
+          } else {
+            fundingRateBps = 0;
+          }
+        }
+
+        // ── 6. Hedge capacity % ─────────────────────────────────────────────
+        let hedgeCapacityPct: number | null = null;
+        if (fundingRateBps !== null && yieldAprBps !== null && safetyBufferBps !== null) {
+          const shortCostBps = Math.max(0, -fundingRateBps);
+          const bufferedYieldBps = yieldAprBps * (1 - safetyBufferBps / 10_000);
+          hedgeCapacityPct =
+            bufferedYieldBps > 0 ? (shortCostBps / bufferedYieldBps) * 100 : shortCostBps > 0 ? 100 : 0;
+        }
+
+        // ── 7. Derive current defense step ──────────────────────────────────
+        const defenseStep = getDefenseStep({
+          isLPBoostActive,
+          isHighLeverageLocked,
+          isPremiumSurgeActive,
+          isHedgeDisabled,
+          solvencyDropAt,
+          juniorDeficitAbsorbed,
+          hedgeCapacityPct,
+        });
+
+        if (!cancelled) {
+          setData({
+            isLPBoostActive,
+            isHighLeverageLocked,
+            isPremiumSurgeActive,
+            isHedgeDisabled,
+            solvencyDropAt,
+            defenseStep,
+            reserveFundUsd,
+            lpBoostPoolUsd,
+            juniorDeficitAbsorbed,
+            juniorAumUsd,
+            totalShortUsd,
+            totalLongUsd,
+            maxShortCapacityUsd,
+            oiUtilizationPct,
+            yieldAprBps,
+            fundingRateBps,
+            hedgeCapacityPct,
+            safetyBufferBps,
+          });
+        }
+      } catch {
+        // Leave previous data intact on transient errors.
+      }
+    }
+
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [chainId, cfg]);
+
+  return data;
+}

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -65,6 +65,10 @@ msgstr "Oder aktualisieren Sie den RPC Ihres Wallets über <0>chainlist.org</0>"
 msgid "REFERRAL CODE"
 msgstr "EMPFEHLUNGSCODE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "Bestehende Limitorder verwendet {symbol} als Sicherheit. <0>Zu {symbol}-Sicherheit wechseln</0>"
@@ -453,6 +457,10 @@ msgstr "GMX Account Guthaben"
 msgid "Best swap path"
 msgstr "Bester Swap-Pfad"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "Token auswählen"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "Bilderzeugung fehlgeschlagen. Aktualisieren Sie die Seite und versuchen Sie es erneut."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "Unbekannter Fehler"
 msgid "Market Swap"
 msgstr "Markt-Tausch"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "{0} wird bei Ausführung in {1} getauscht"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "Nicht realisierter Gewinn/Verlust"
@@ -1341,6 +1362,10 @@ msgstr "Empfehlungscode wird erstellt..."
 msgid "DATE"
 msgstr "DATUM"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "Maximal {allowedAutoCancelOrdersNumber} automatisch stornierbare TP/SL-O
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "GMX-Abstimmungsseite für Vorschläge"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "TP-Preis über dem Limitpreis"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "Aktion(en)"
@@ -1821,6 +1854,10 @@ msgstr "Limit Swap fehlgeschlagen"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "Keine Gebühr"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "Die Tauschliquidität kann bei Auslösung der Order unzureichend sein"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Zu Base wechseln"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "Fehler verstecken"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "Gesamtwert der Token in GM-Pools"
 msgid "Price impact rebates"
 msgstr "Preiseinflussrückerstattungen"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "Limit-Swap aktualisieren"
@@ -2287,6 +2336,10 @@ msgstr "Marktverringerung fehlgeschlagen"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "Täglicher und kumulierter PnL"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "Es kann einige Minuten dauern, bis die Anzeige erscheint. Versuchen Sie es später erneut"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "Stop-Loss aktualisieren"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "Wie können wir Ihre Anliegen berücksichtigen?"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "Keine Liquidität verfügbar, um Longs bei<0/>dieser Größe zu erhöhen. Maximale Long-Größe: {0}<1/><2/>Ausführungspreise für das Verringern von Shorts."
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0}-Order für"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "Kaufe GMX auf {chainName}"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "Ein hoher potenzieller Nettopreiseinfluss (begrenzt auf {formattedCap} f
 msgid "Update Take-Profit"
 msgstr "Take-Profit aktualisieren"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "Einzahlung von {sourceChainName} fehlgeschlagen"
@@ -3059,6 +3131,10 @@ msgstr "Prognostizierte Jahresrendite im Vergleich zu einem Uniswap V2-Benchmark
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Sicherheits-Spread"
@@ -3460,6 +3540,10 @@ msgstr "Auslösepreis"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "Keine AB-Flags"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "Mittel eingelöst"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "Fehlende Beanspruchungsparameter. Versuchen Sie es in einigen Sekunden erneut"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "Trigger"
@@ -3810,6 +3898,10 @@ msgstr "GMX V2 Datenanalyse in Telegram"
 msgid "Runs entirely on public chains"
 msgstr "Läuft vollständig auf öffentlichen Chains"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "Bei Auslösung kann für Teile dieser Order unzureichende Liquidität vorhanden sein"
@@ -3818,6 +3910,10 @@ msgstr "Bei Auslösung kann für Teile dieser Order unzureichende Liquidität vo
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "Finanzierungsgebühr"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "Wie starte ich auf GMX?"
 msgid "Acceptable price"
 msgstr "Akzeptabler Preis"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "Wird vom Unterkonto abgehoben…"
@@ -4292,6 +4396,10 @@ msgstr "20s"
 msgid "Virtual market ID"
 msgstr "Virtuelle Markt-ID"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "Virtuelle Markt-ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Hebelwirkung"
@@ -4344,6 +4455,10 @@ msgstr "GEWINN/VERLUST"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "Abheben..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>Ungültige Genehmigungssignatur. Versuchen Sie es erneut</0>"
 msgid "Positive factor"
 msgstr "Positiver Faktor"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "Vollständige Positionsschließung"
@@ -4738,6 +4857,10 @@ msgstr "{0} bearbeiten"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "Allgemeine Geschäftsbedingungen"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (VERSORGUNG)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "TP/SL setzen"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Maximal {MAX_REFERRAL_CODE_LENGTH} Zeichen"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "Genehmigungstests"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "Ungültige Transaktion"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "Einstellungen"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "Preiseinfluss-Rückvergütungen konnten nicht beansprucht werden"
 msgid "Paste hex error data to decode"
 msgstr "Hex-Fehlerdaten zum Dekodieren einfügen"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "Mindestsicherheit"
@@ -6893,6 +7048,10 @@ msgstr "Ausführungspreis hat den akzeptablen Preis nicht erreicht"
 msgid "Position would be liquidatable"
 msgstr "Position wäre liquidierbar"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "Geschätzte Zeit bis zur Liquidation"
 msgid "Mark price for the liquidation"
 msgstr "Markpreis für die Liquidation"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "Prognostiziert aus dem APY der letzten {daysConsidered} Tage"
@@ -6946,6 +7109,10 @@ msgstr "Positionsgebühren werden abgerechnet..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "GMX Ankündigungen und Aktualisierungen"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "RPC-Debug"
 msgid "No items yet"
 msgstr "Noch keine Elemente"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "Handeln Sie mit Vertrauen"
@@ -7343,6 +7514,10 @@ msgstr "Unzureichender Gas-Saldo"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "V1-Rabatte"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "Version:"
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "Verfügbar"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Das Abheben von {0} nach {1} wird nicht unterstützt"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "EINSTIEGSPREIS"
 msgid "Display PnL after fees"
 msgstr "PnL nach Gebühren anzeigen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "Position teilen"
@@ -7713,6 +7897,10 @@ msgstr "Projekt"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "24h-Tief"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "Maximale Aktionen vor erforderlicher erneuter Autorisierung"
 msgid "GMX risk monitoring"
 msgstr "GMX-Risikoüberwachung"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "Ein Mindestkapitaleinsatz von {0} ist erforderlich, um sich für die Rangliste zu qualifizieren"
@@ -8110,6 +8306,10 @@ msgstr "Die Order überschreitet den maximalen Hebel. Klicken Sie zur automatisc
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "Kein Tauschpfad verfügbar"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "Unzureichende Pool-Liquidität"
 msgid "No opportunities on Botanix yet"
 msgstr "Noch keine Möglichkeiten auf Botanix"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1>'s OI sieht großartig aus</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Mehr prüfen: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "weniger als eine Minute"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "Ökosystem"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "V2-Rückvergütungen"
 msgid "Select asset to deposit"
 msgstr "Asset zum Einzahlen auswählen"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "Max. kaufbarer GM-Betrag erreicht"
@@ -9489,6 +9701,10 @@ msgstr "Was ist GLV genau?"
 msgid "Download"
 msgstr "Herunterladen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "Aktiv"
@@ -9612,6 +9828,10 @@ msgstr "Leistungs- und Diagrammdaten basieren auf UTC-Zeiten"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "Verkaufe {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "Status"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "Etwas unwichtiger Text, aber dennoch lesbar"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
@@ -10998,6 +11222,10 @@ msgstr "Akzeptabler Preiseinfluss"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "Reduzieren Sie die Abhebung auf das Maximum. <0>Mehr erfahren</0>.<1/><2/><3>Maximale Abhebung festlegen</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "Pool USD Short"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} Orders nicht aktualisiert, Limit erreicht"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "Proportionaler gespeicherter Einfluss"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 20-27 Mär"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "Keine Märkte gefunden"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "Link kopieren"
 msgid "Referral code created"
 msgstr "Empfehlungscode erstellt"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "Guthaben wird übertragen nach..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Netzwerkgebühr"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -65,6 +65,10 @@ msgstr "Or update your wallet's RPC via <0>chainlist.org</0>"
 msgid "REFERRAL CODE"
 msgstr "REFERRAL CODE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr "Profit Extraction Risk"
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
@@ -453,6 +457,10 @@ msgstr "GMX Account balance"
 msgid "Best swap path"
 msgstr "Best swap path"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr "Connect your wallet to see your deposits."
@@ -511,6 +519,10 @@ msgstr "Select token"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "Image generation failed. Refresh and try again."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr "Loyalty Timer"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "Unknown error"
 msgid "Market Swap"
 msgstr "Market Swap"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr "{ageDays} days"
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -904,6 +920,10 @@ msgstr "システム収益保護のため、現在一時的にFR相殺が停止�
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
 msgstr "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
+msgstr "Hedge Capacity Used"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
@@ -1306,6 +1326,7 @@ msgstr "{0} swapped to {1} when executed"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "Unrealized PnL"
@@ -1341,6 +1362,10 @@ msgstr "Creating referral code..."
 msgid "DATE"
 msgstr "DATE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr "Position Age"
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "Max {allowedAutoCancelOrdersNumber} auto-cancel TP/SL orders allowed. Ex
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "GMX proposals voting page"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr "1. Leverage (higher = first)"
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr "Connect wallet to withdraw"
 msgid "TP price above limit price"
 msgstr "TP price above limit price"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr "2. Entry recency (newer = first)"
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "Action(s)"
@@ -1821,6 +1854,10 @@ msgstr "Failed Limit Swap"
 msgid "Failed"
 msgstr "Failed"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr "Protocol Commitment — No Surprise Rate Hikes"
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr "Restricted (weekend)"
@@ -1833,6 +1870,10 @@ msgstr "No fee"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "Swap liquidity may be insufficient when order triggers"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr "Reserve Fund"
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Change to Base"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "Hide error"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr "No active trade (long) position in this vault."
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "Total value of tokens in GM pools"
 msgid "Price impact rebates"
 msgstr "Price impact rebates"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr "Your ADL Risk"
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "Update Limit Swap"
@@ -2287,6 +2336,10 @@ msgstr "Failed Market Decrease"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr "Phase 4 · Hedge ADL"
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "Daily and cumulative PnL"
@@ -2310,6 +2363,10 @@ msgstr "Net Value"
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "May take a few minutes to appear. Check back later"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr "Absorbed"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2439,6 +2496,10 @@ msgstr "Update Stop-Loss"
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
 msgstr "How do I choose?"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
+msgstr "Consider reducing leverage to lower your ADL priority."
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "LP Deposit + Short in one transaction"
@@ -2633,6 +2694,10 @@ msgstr "How can we address your concerns?"
 msgid "Closing Size"
 msgstr "Closing Size"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr "Mode B"
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} order for"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "Buy GMX on {chainName}"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "High potential net price impact (capped at {formattedCap} for this marke
 msgid "Update Take-Profit"
 msgstr "Update Take-Profit"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "Deposit from {sourceChainName} failed"
@@ -3059,6 +3131,10 @@ msgstr "Projected yearly return vs. a Uniswap V2-style benchmark.<0/><1/>Note: S
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr "Disabled"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr "Long profit positions"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr "Ask"
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Collateral spread"
@@ -3460,6 +3540,10 @@ msgstr "Trigger price"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "No AB flags"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr "Junior TrancheVault not configured for this deployment."
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "Funds claimed"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "Missing claim params. Retry in a few seconds"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr "Full leaderboard requires Subgraph"
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "Trigger"
@@ -3810,6 +3898,10 @@ msgstr "GMX V2 data analytics within Telegram"
 msgid "Runs entirely on public chains"
 msgstr "Runs entirely on public chains"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr "Current"
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "May lack liquidity for parts of this order when triggered"
@@ -3819,6 +3911,10 @@ msgstr "May lack liquidity for parts of this order when triggered"
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
 msgstr "Withdrawing…"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
+msgstr "Protected (30d+)"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Rebasing balance synced"
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "Funding fee"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr "System Status: Normal"
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "How do I get started on GMX?"
 msgid "Acceptable price"
 msgstr "Acceptable price"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr "ADL Score"
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "Withdrawing from subaccount..."
@@ -4292,6 +4396,10 @@ msgstr "20s"
 msgid "Virtual market ID"
 msgstr "Virtual market ID"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr "Junior Buffer (PAYOUT Tranche)"
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "Virtual market ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Leverage"
@@ -4344,6 +4455,10 @@ msgstr "WIN/LOSS"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "Withdrawing..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr "Phase 3 · Trade ADL"
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>Invalid permit signature. Try again</0>"
 msgid "Positive factor"
 msgstr "Positive factor"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "Full position close"
@@ -4738,6 +4857,10 @@ msgstr "Edit {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Buy</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr "No active hedge (short) position in this vault."
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "Terms and conditions"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (SUPPLY)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr "Hedge Protection Status"
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr "Update Default Destination"
@@ -5509,6 +5640,10 @@ msgstr "Set TP/SL"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr "OI Utilization"
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr "Convert to Paid-Short"
@@ -5668,6 +5803,10 @@ msgstr "Permits testing"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "Invalid transaction"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr "Hedge Protection Status (Phase 4 ADL)"
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "Settings"
 msgid "Increase request cancelled"
 msgstr "Increase request cancelled"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr "Remaining capacity"
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr "Trade page"
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr "Short (hedge) positions"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr "FR cost / buffered yield"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "Failed to claim price impact rebates"
 msgid "Paste hex error data to decode"
 msgstr "Paste hex error data to decode"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr "Hedge Inventory"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "Min collateral"
@@ -6893,6 +7048,10 @@ msgstr "Execution price didn't meet acceptable price"
 msgid "Position would be liquidatable"
 msgstr "Position would be liquidatable"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr "LP Boost"
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "Estimated time to liquidation"
 msgid "Mark price for the liquidation"
 msgstr "Mark price for the liquidation"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr "New ({ageDays}d)"
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "Projected from last {daysConsidered} days' APY"
@@ -6946,6 +7109,10 @@ msgstr "Settling position fees..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "GMX announcements and updates"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr "Mode A (Auto-Close) ⚠"
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "RPC debug"
 msgid "No items yet"
 msgstr "No items yet"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr "Protocol Defense Status"
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "Trade with confidence"
@@ -7343,6 +7514,10 @@ msgstr "Insufficient gas balance"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "V1 rebates"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr "Hedge FR (Shorts perspective)"
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "Version:"
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "Available"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Withdrawing {0} to {1} is not supported"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr "Protocol Status"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "ENTRY PRICE"
 msgid "Display PnL after fees"
 msgstr "Display PnL after fees"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr "Mode A ⚠"
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "Share position"
@@ -7713,6 +7897,10 @@ msgstr "Project"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "24h low"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr "Low leverage and long tenure protect you. You are in the loyalty tier."
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "Maximum actions before reauthorization required"
 msgid "GMX risk monitoring"
 msgstr "GMX risk monitoring"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr "Vault Yield APR"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr "High ADL risk. Reduce leverage or hold position longer to improve protection."
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "Minimum capital used of {0} required to qualify for rankings"
@@ -8110,6 +8306,10 @@ msgstr "Order exceeds max leverage. Click to auto-adjust."
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "No swap path available"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr "Mode B (Convert)"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "Insufficient pool liquidity"
 msgid "No opportunities on Botanix yet"
 msgstr "No opportunities on Botanix yet"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "less than a minute"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "Ecosystem"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr "3. Mode (Auto-Close first)"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "V2 rebates"
 msgid "Select asset to deposit"
 msgstr "Select asset to deposit"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr "Phase 2-5"
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "Max GM buyable amount reached"
@@ -9489,6 +9701,10 @@ msgstr "What is GLV exactly?"
 msgid "Download"
 msgstr "Download"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr "ADL Mode"
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "Up"
@@ -9612,6 +9828,10 @@ msgstr "Performance and chart data are based on UTC times"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "Sell {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "Status"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "Somewhat unimportant text, but still readable"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr "Consider reducing leverage to improve your ADL protection ranking."
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
@@ -10998,6 +11222,10 @@ msgstr "Acceptable price impact"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr "ADL Priority Factors (Hedge Mode):"
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "Pool USD short"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} orders not updated, limit reached"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr "Phase 2-4"
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "Proportional stored impact"
@@ -11289,6 +11521,10 @@ msgstr "EIP-4844, 20-27 Mar"
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
 msgstr "Vault APY"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
+msgstr "+ve = shorts receive payment"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11315,6 +11551,10 @@ msgstr "No markets found"
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
 msgstr "利回り"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
+msgstr "Step {defenseStep}:"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"
@@ -11550,6 +11790,10 @@ msgstr "Copy link"
 msgid "Referral code created"
 msgstr "Referral code created"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr "Internal Buffers"
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "Funds bridging to..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Network fee"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr "Real-time solvency dashboard. 7-step defense sequence transparency."
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -65,6 +65,10 @@ msgstr "O actualice el RPC de su monedero a través de <0>chainlist.org</0>"
 msgid "REFERRAL CODE"
 msgstr "CÓDIGO DE REFERIDO"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "La orden limitada existente utiliza garantía {symbol}. <0>Cambiar a garantía {symbol}</0>"
@@ -453,6 +457,10 @@ msgstr "Saldo de GMX Account"
 msgid "Best swap path"
 msgstr "Mejor ruta de intercambio"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "Seleccionar token"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "La generación de la imagen ha fallado. Actualice la página e inténtelo de nuevo."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "Error desconocido"
 msgid "Market Swap"
 msgstr "Intercambio de Mercado"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "{0} se intercambia por {1} cuando se ejecuta"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "PnL No Realizado"
@@ -1341,6 +1362,10 @@ msgstr "Creando código de referido..."
 msgid "DATE"
 msgstr "FECHA"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "Se permiten un máximo de {allowedAutoCancelOrdersNumber} órdenes TP/SL
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "Página de votación de propuestas de GMX"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "Precio TP por encima del precio límite"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "Acción(es)"
@@ -1821,6 +1854,10 @@ msgstr "Intercambio Límite Fallido"
 msgid "Failed"
 msgstr "Fallida"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "Sin tarifa"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "La liquidez de intercambio puede ser insuficiente cuando se active la orden"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Cambiar a Base"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "Ocultar error"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "Valor total de los tokens en los pools de GM"
 msgid "Price impact rebates"
 msgstr "Reembolsos por impacto en el precio"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "Actualizar intercambio límite"
@@ -2287,6 +2336,10 @@ msgstr "Reducción de Mercado Fallida"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "PnL diario y acumulado"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "Puede tardar unos minutos en aparecer. Vuelva a comprobarlo más tarde"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "Actualizar Stop-Loss"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "¿Cómo podemos atender sus inquietudes?"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "No hay liquidez disponible para incrementar largos a<0/>este tamaño. Tamaño máximo largo: {0}<1/><2/>Precios de ejecución para reducir cortos."
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} orden para"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "Comprar GMX en {chainName}"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "Un impacto neto elevado en el precio (limitado a {formattedCap} para est
 msgid "Update Take-Profit"
 msgstr "Actualizar Take-Profit"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "Depósito desde {sourceChainName} fallido"
@@ -3059,6 +3131,10 @@ msgstr "Rendimiento anual proyectado frente a un índice de referencia de estilo
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Diferencial de garantía"
@@ -3460,6 +3540,10 @@ msgstr "Precio de activación"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "Sin AB flags"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "Fondos reclamados"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "Faltan parámetros de reclamación. Vuelva a intentarlo en unos segundos"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "Activador"
@@ -3810,6 +3898,10 @@ msgstr "Análisis de datos de GMX V2 en Telegram"
 msgid "Runs entirely on public chains"
 msgstr "Se ejecuta completamente en cadenas públicas"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "Puede haber liquidez insuficiente para partes de esta orden cuando se ejecute"
@@ -3818,6 +3910,10 @@ msgstr "Puede haber liquidez insuficiente para partes de esta orden cuando se ej
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "Comisión de financiación"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "¿Cómo empiezo en GMX?"
 msgid "Acceptable price"
 msgstr "Precio aceptable"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "Retirando de la subcuenta…"
@@ -4292,6 +4396,10 @@ msgstr "20s"
 msgid "Virtual market ID"
 msgstr "ID de mercado virtual"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "ID de mercado virtual"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Apalancamiento"
@@ -4344,6 +4455,10 @@ msgstr "VIC./DER."
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "Retirando..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>Firma de permiso no válida. Inténtelo de nuevo</0>"
 msgid "Positive factor"
 msgstr "Factor positivo"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "Cierre total de posición"
@@ -4738,6 +4857,10 @@ msgstr "Editar {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "Términos y condiciones"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (SUMINISTRO)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "Establecer TP/SL"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Máximo {MAX_REFERRAL_CODE_LENGTH} caracteres"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "Pruebas de permisos"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "Transacción no válida"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "Ajustes"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "Error al reclamar las devoluciones por impacto en el precio"
 msgid "Paste hex error data to decode"
 msgstr "Pegue los datos de error en hexadecimal para decodificar"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "Garantía mínima"
@@ -6893,6 +7048,10 @@ msgstr "El precio de ejecución no alcanzó el precio aceptable"
 msgid "Position would be liquidatable"
 msgstr "La posición sería liquidable"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "Tiempo estimado hasta la liquidación"
 msgid "Mark price for the liquidation"
 msgstr "Precio de referencia de la liquidación"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "Proyectado a partir del APY de los últimos {daysConsidered} días"
@@ -6946,6 +7109,10 @@ msgstr "Liquidando comisiones de posición..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "Anuncios y actualizaciones de GMX"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "Depuración de RPC"
 msgid "No items yet"
 msgstr "No hay elementos aún"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "Opera con confianza"
@@ -7343,6 +7514,10 @@ msgstr "Saldo de gas insuficiente"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "Reembolsos V1"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "Versión:"
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "Disponible"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "La retirada de {0} a {1} no está soportada"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "PRECIO DE ENTRADA"
 msgid "Display PnL after fees"
 msgstr "Mostrar PnL después de comisiones"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "Compartir posición"
@@ -7713,6 +7897,10 @@ msgstr "Proyecto"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "Mínimo 24h"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "Número máximo de acciones antes de requerir reautorización"
 msgid "GMX risk monitoring"
 msgstr "Monitorización de riesgos de GMX"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "Se requiere un capital utilizado mínimo de {0} para clasificarse en el ranking"
@@ -8110,6 +8306,10 @@ msgstr "La orden excede el apalancamiento máximo. Haga clic para ajustar autom�
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "No hay ruta de intercambio disponible"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "Liquidez de pool insuficiente"
 msgid "No opportunities on Botanix yet"
 msgstr "Aún no hay oportunidades en Botanix"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0>El OI de <1>#GMX V2</1> se ve genial</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Ver más: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "menos de un minuto"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "Ecosistema"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "Reembolsos V2"
 msgid "Select asset to deposit"
 msgstr "Seleccionar activo para depositar"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "Cantidad máxima comprable de GM alcanzada"
@@ -9489,6 +9701,10 @@ msgstr "¿Qué es exactamente GLV?"
 msgid "Download"
 msgstr "Descargar"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "Activo"
@@ -9612,6 +9828,10 @@ msgstr "Los datos de rendimiento y gráficos se basan en la hora UTC"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "Vender {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "Estado"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "Texto algo secundario, pero aún legible"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
@@ -10998,6 +11222,10 @@ msgstr "Impacto en el precio aceptable"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "Reduzca la retirada para ajustarse al máximo. <0>Más información</0>.<1/><2/><3>Establecer retirada máxima</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "Pool USD corto"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} órdenes no actualizadas, límite alcanzado"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "Impacto almacenado proporcional"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 20-27 Mar"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "No se encontraron mercados"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "Copiar enlace"
 msgid "Referral code created"
 msgstr "Código de referido creado"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "Fondos transfiriéndose a..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Comisión de red"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -65,6 +65,10 @@ msgstr "Ou mettez à jour le RPC de votre portefeuille via <0>chainlist.org</0>"
 msgid "REFERRAL CODE"
 msgstr "CODE DE PARRAINAGE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "L'ordre à cours limité existant utilise la garantie {symbol}. <0>Passer à la garantie {symbol}</0>"
@@ -453,6 +457,10 @@ msgstr "Solde du GMX Account"
 msgid "Best swap path"
 msgstr "Meilleur chemin de swap"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "Sélectionner un jeton"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "La génération d'image a échoué. Actualisez et réessayez."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "Erreur inconnue"
 msgid "Market Swap"
 msgstr "Swap de marché"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "{0} échangé contre {1} lors de l'exécution"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "PnL non réalisé"
@@ -1341,6 +1362,10 @@ msgstr "Création du code de parrainage..."
 msgid "DATE"
 msgstr "DATE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "Maximum {allowedAutoCancelOrdersNumber} ordres TP/SL à annulation autom
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "Page de vote des propositions GMX"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "Prix TP au-dessus du prix limite"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "Action(s)"
@@ -1821,6 +1854,10 @@ msgstr "Swap limité échoué"
 msgid "Failed"
 msgstr "Échec"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "Aucun frais"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "La liquidité d'échange peut être insuffisante lorsque l'ordre se déclenche"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Passer à Base"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "Cacher l'erreur"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "Valeur totale des jetons dans les pools GM"
 msgid "Price impact rebates"
 msgstr "Remises sur l'impact sur le prix"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "Mettre à jour le swap limité"
@@ -2287,6 +2336,10 @@ msgstr "Diminution de marché échouée"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "PnL quotidien et cumulé"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "L'affichage peut prendre quelques minutes. Veuillez vérifier ultérieurement"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "Mettre à jour le Stop-Loss"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "Comment pouvons-nous répondre à vos préoccupations ?"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "Aucune liquidité disponible pour augmenter les longs à<0/>cette taille. Taille long maximale : {0}<1/><2/>Prix d'exécution pour la réduction des shorts."
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} ordre pour"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "Acheter GMX sur {chainName}"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "Un impact net potentiellement élevé sur le prix (plafonné à {formatt
 msgid "Update Take-Profit"
 msgstr "Mettre à jour Take-Profit"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "Le dépôt depuis {sourceChainName} a échoué"
@@ -3059,6 +3131,10 @@ msgstr "Rendement annuel projeté par rapport à un benchmark de type Uniswap V2
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Écart de garantie"
@@ -3460,6 +3540,10 @@ msgstr "Prix de déclenchement"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "Aucun AB flag"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "Fonds réclamés"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "Paramètres de récupération manquants. Réessayez dans quelques secondes"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "Déclencheur"
@@ -3810,6 +3898,10 @@ msgstr "Analyses de données GMX V2 dans Telegram"
 msgid "Runs entirely on public chains"
 msgstr "Fonctionne entièrement sur des chaînes publiques"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "La liquidité pourrait être insuffisante pour certaines parties de cet ordre lors de son déclenchement"
@@ -3818,6 +3910,10 @@ msgstr "La liquidité pourrait être insuffisante pour certaines parties de cet 
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "Frais de financement"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "Comment commencer sur GMX ?"
 msgid "Acceptable price"
 msgstr "Prix acceptable"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "Retrait du sous-compte…"
@@ -4292,6 +4396,10 @@ msgstr "20s"
 msgid "Virtual market ID"
 msgstr "ID de marché virtuel"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "ID de marché virtuel"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Levier"
@@ -4344,6 +4455,10 @@ msgstr "VICTOIRES/DÉFAITES"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "Retrait en cours..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>Signature de permis invalide. Veuillez réessayer</0>"
 msgid "Positive factor"
 msgstr "Facteur positif"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "Fermeture complète de la position"
@@ -4738,6 +4857,10 @@ msgstr "Modifier {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v :"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "Conditions générales d'utilisation"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (FOURNITURE)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "Définir TP/SL"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Max {MAX_REFERRAL_CODE_LENGTH} caractères"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "Test des permis"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "Transaction invalide"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "Paramètres"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "Échec de la récupération des remises d'impact sur le prix"
 msgid "Paste hex error data to decode"
 msgstr "Collez les données d'erreur hexadécimales à décoder"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "Garantie minimale"
@@ -6893,6 +7048,10 @@ msgstr "Le prix d'exécution n'a pas atteint le prix acceptable"
 msgid "Position would be liquidatable"
 msgstr "La position serait liquidable"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "Temps estimé avant la liquidation"
 msgid "Mark price for the liquidation"
 msgstr "Prix de référence pour la liquidation"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "Projeté à partir du APY des {daysConsidered} derniers jours"
@@ -6946,6 +7109,10 @@ msgstr "Règlement des frais de position..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "Annonces et mises à jour GMX"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "Débogage RPC"
 msgid "No items yet"
 msgstr "Aucun élément pour le moment"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "Trader avec confiance"
@@ -7343,6 +7514,10 @@ msgstr "Solde de gaz insuffisant"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "Remises V1"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "Version :"
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "Disponible"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Le retrait de {0} vers {1} n'est pas pris en charge"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "PRIX D'ENTRÉE"
 msgid "Display PnL after fees"
 msgstr "Afficher le PnL après les frais"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "Partager la position"
@@ -7713,6 +7897,10 @@ msgstr "Projet"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "Plus bas 24h"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "Nombre maximum d'actions avant qu'une nouvelle autorisation soit requise
 msgid "GMX risk monitoring"
 msgstr "Surveillance des risques GMX"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "Un capital utilisé minimum de {0} est requis pour être éligible au classement"
@@ -8110,6 +8306,10 @@ msgstr "L'ordre dépasse l'effet de levier maximum. Cliquez pour ajuster automat
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "Aucun chemin d'échange disponible"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "Liquidité du pool insuffisante"
 msgid "No opportunities on Botanix yet"
 msgstr "Aucune opportunité sur Botanix pour le moment"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1> OI a l'air génial</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Vérifiez plus : <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "moins d'une minute"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "Écosystème"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "Remises V2"
 msgid "Select asset to deposit"
 msgstr "Sélectionner l'actif à déposer"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "Montant maximal d'achat GM atteint"
@@ -9489,6 +9701,10 @@ msgstr "Qu'est-ce que GLV exactement ?"
 msgid "Download"
 msgstr "Télécharger"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "Actif"
@@ -9612,6 +9828,10 @@ msgstr "Les données de performance et de graphiques sont basées sur les horair
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "Vendre {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "Statut"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "Texte relativement peu important, mais toujours lisible"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30s"
@@ -10998,6 +11222,10 @@ msgstr "Impact sur le prix acceptable"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "Réduisez le retrait pour correspondre au maximum. <0>En savoir plus</0>.<1/><2/><3>Définir le retrait maximal</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "Pool USD short"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} ordres non mis à jour, limite atteinte"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "Impact stocké proportionnel"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 20-27 Mar"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "Aucun marché trouvé"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "Copier le lien"
 msgid "Referral code created"
 msgstr "Code de parrainage créé"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "Transfert des fonds vers..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Frais de réseau"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -65,6 +65,10 @@ msgstr "または<0>chainlist.org</0>からウォレットのRPCを更新して�
 msgid "REFERRAL CODE"
 msgstr "REFERRAL CODE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "既存の指値注文は{symbol}担保を使用しています。<0>{symbol}担保に切り替える</0>"
@@ -453,6 +457,10 @@ msgstr "GMX Account残高"
 msgid "Best swap path"
 msgstr "最適スワップパス"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "トークンを選択"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "画像の生成に失敗しました。更新して再度お試しください。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "不明なエラー"
 msgid "Market Swap"
 msgstr "市場スワップ"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "約定時に {0} が {1} にスワップされます"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "未実現PnL"
@@ -1341,6 +1362,10 @@ msgstr "リファラルコードを作成中..."
 msgid "DATE"
 msgstr "DATE"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "自動キャンセル TP/SL 注文は最大 {allowedAutoCancelOrdersNumb
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "GMX 提案の投票ページ"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "TP 価格がリミット価格を上回っています"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "アクション"
@@ -1821,6 +1854,10 @@ msgstr "指値スワップ失敗"
 msgid "Failed"
 msgstr "失敗"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "手数料なし"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "注文がトリガーされた際にスワップ流動性が不足する可能性があります"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Baseに変更"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "エラーを隠す"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "GM プール内のトークンの合計価値"
 msgid "Price impact rebates"
 msgstr "価格への影響リベート"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "指値スワップを更新する"
@@ -2287,6 +2336,10 @@ msgstr "マーケット減少失敗"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "日次および累積 PnL"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "表示されるまで数分かかる場合があります。後ほどご確認ください"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "ストップロスを更新"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "ご懸念にどのように対応すればよろしいでしょうか？
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "このサイズでのロング増加に利用可能な流動性がありません。<0/>最大ロングサイズ: {0}<1/><2/>ショート減少の約定価格。"
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} 注文"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "{chainName}でGMXを購入"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "高い純価格への影響（このマーケットでは{formattedCap}�
 msgid "Update Take-Profit"
 msgstr "テイクプロフィットを更新"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "{sourceChainName}からの入金に失敗しました"
@@ -3059,6 +3131,10 @@ msgstr "Uniswap V2スタイルのベンチマークに対する予想年間リ�
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "担保スプレッド"
@@ -3460,6 +3540,10 @@ msgstr "トリガー価格"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "ABフラグはありません"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "資金が請求されました"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "受け取りパラメータが不足しています。数秒後にお試しください"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "トリガー"
@@ -3810,6 +3898,10 @@ msgstr "Telegram 上の GMX V2 データ分析"
 msgid "Runs entirely on public chains"
 msgstr "完全にパブリックチェーンで実行"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "トリガー時に注文の一部で流動性が不足する可能性があります"
@@ -3818,6 +3910,10 @@ msgstr "トリガー時に注文の一部で流動性が不足する可能性が
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "ファンディング手数料"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "GMXを始めるにはどうしたらいいですか？"
 msgid "Acceptable price"
 msgstr "許容価格"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "サブアカウントから出金中…"
@@ -4292,6 +4396,10 @@ msgstr "20秒"
 msgid "Virtual market ID"
 msgstr "仮想マーケットID"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "仮想マーケットID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "レバレッジ"
@@ -4344,6 +4455,10 @@ msgstr "勝敗"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "引き出し中..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>パーミット署名が無効です。再度お試しください</0
 msgid "Positive factor"
 msgstr "プラスファクター"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "ポジション全決済"
@@ -4738,6 +4857,10 @@ msgstr "{0}を編集"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "利用規約"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (供給)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "TP/SLを設定"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "最大 {MAX_REFERRAL_CODE_LENGTH} 文字"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "Permit テスト"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "無効なトランザクション"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "設定"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "価格影響リベートの受け取りに失敗しました"
 msgid "Paste hex error data to decode"
 msgstr "デコードする16進エラーデータを貼り付けてください"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "最小担保"
@@ -6893,6 +7048,10 @@ msgstr "約定価格が許容価格を満たしませんでした"
 msgid "Position would be liquidatable"
 msgstr "ポジションが清算対象となります"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "清算までの推定時間"
 msgid "Mark price for the liquidation"
 msgstr "清算時のマーク価格"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "過去{daysConsidered}日間のAPYから算出"
@@ -6946,6 +7109,10 @@ msgstr "ポジション手数料を精算中..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "GMXのお知らせとアップデート"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "RPCデバッグ"
 msgid "No items yet"
 msgstr "項目なし"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "自信を持って取引"
@@ -7343,6 +7514,10 @@ msgstr "ガス残高不足"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "V1リベート"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "バージョン："
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "利用可能"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "{0}の{1}への出金はサポートされていません"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "ENTRY PRICE"
 msgid "Display PnL after fees"
 msgstr "手数料差引後のPnLを表示"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "ポジションを共有"
@@ -7713,6 +7897,10 @@ msgstr "プロジェクト"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "24時間安値"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "再認証が必要になるまでの最大アクション数"
 msgid "GMX risk monitoring"
 msgstr "GMXリスクモニタリング"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "ランキングに参加するには、最低{0}の使用資金が必要です"
@@ -8110,6 +8306,10 @@ msgstr "注文が最大レバレッジを超えています。クリックして
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "利用可能なスワップ経路がありません"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "プールの流動性が不足しています"
 msgid "No opportunities on Botanix yet"
 msgstr "Botanixにはまだ機会がありません"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1>のOIは素晴らしい</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>もっと確認: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "1分未満"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "エコシステム"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "V2 リベート"
 msgid "Select asset to deposit"
 msgstr "入金するアセットを選択"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "最大GM購入可能額に到達"
@@ -9489,6 +9701,10 @@ msgstr "GLVとは正確には何ですか？"
 msgid "Download"
 msgstr "ダウンロード"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "稼働中"
@@ -9612,6 +9828,10 @@ msgstr "パフォーマンスおよびチャートデータはUTC時間に基づ
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "{operationTokenSymbol}を売却"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "ステータス"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "やや重要度の低いテキストですが、読み取り可能です"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30秒"
@@ -10998,6 +11222,10 @@ msgstr "許容価格への影響"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "最大値に合わせて出金額を減らしてください。<0>詳細はこちら</0>。<1/><2/><3>最大出金額を設定</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "プール USD ショート"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} 件の注文が更新されませんでした。上限に達しました"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "比例配分された蓄積インパクト"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844、3月20-27日"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "マーケットが見つかりません"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "リンクをコピー"
 msgid "Referral code created"
 msgstr "リファラルコードが作成されました"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "ブリッジ送金中..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "ネットワーク手数料"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -65,6 +65,10 @@ msgstr "또는 <0>chainlist.org</0>를 통해 지갑의 RPC를 업데이트하�
 msgid "REFERRAL CODE"
 msgstr "추천 코드"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "기존 지정가 주문이 {symbol} 담보를 사용합니다. <0>{symbol} 담보로 전환</0>"
@@ -453,6 +457,10 @@ msgstr "GMX Account 잔액"
 msgid "Best swap path"
 msgstr "최적 스왑 경로"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "토큰 선택"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "이미지 생성에 실패했습니다. 새로고침 후 다시 시도하십시오."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "알 수 없는 오류"
 msgid "Market Swap"
 msgstr "마켓 스왑"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "체결 시 {0}이(가) {1}(으)로 스왑됩니다"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "미실현 PnL"
@@ -1341,6 +1362,10 @@ msgstr "추천 코드 생성 중..."
 msgid "DATE"
 msgstr "날짜"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "자동 취소 TP/SL 주문은 최대 {allowedAutoCancelOrdersNumber}건�
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "GMX 제안 투표 페이지"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "TP 가격이 지정가보다 높습니다"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "작업"
@@ -1821,6 +1854,10 @@ msgstr "지정가 스왑 실패"
 msgid "Failed"
 msgstr "실패"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "수수료 없음"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "주문 트리거 시 스왑 유동성이 부족할 수 있습니다"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Base로 변경"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "오류 숨기기"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "GM 풀 내 토큰 총 가치"
 msgid "Price impact rebates"
 msgstr "가격 영향 리베이트"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "지정가 스왑 업데이트"
@@ -2287,6 +2336,10 @@ msgstr "마켓 감소 실패"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "일별 및 누적 PnL"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "표시되기까지 몇 분이 소요될 수 있습니다. 잠시 후 다시 확인하십시오"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "손절매 업데이트"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "어떤 부분을 개선하면 좋겠습니까?"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "이 크기에서 롱 증가를 위한 유동성이 없습니다.<0/>최대 롱 크기: {0}<1/><2/>숏 감소를 위한 체결 가격입니다."
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} 주문"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "{chainName}에서 GMX 구매"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "높은 잠재적 순 가격 영향({formattedCap}으로 제한됨)이 �
 msgid "Update Take-Profit"
 msgstr "익절매 업데이트"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "{sourceChainName}에서의 입금 실패"
@@ -3059,6 +3131,10 @@ msgstr "Uniswap V2 스타일 벤치마크 대비 예상 연간 수익률입니�
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "담보 스프레드"
@@ -3460,6 +3540,10 @@ msgstr "조건가"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "AB 플래그 없음"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "자금 청구됨"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "수령 매개변수가 누락되었습니다. 몇 초 후 다시 시도하십시오"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "트리거"
@@ -3810,6 +3898,10 @@ msgstr "Telegram 내 GMX V2 데이터 분석"
 msgid "Runs entirely on public chains"
 msgstr "전체적으로 공개 체인에서 실행"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "발동 시 이 주문의 일부에 대해 유동성이 부족할 수 있습니다"
@@ -3818,6 +3910,10 @@ msgstr "발동 시 이 주문의 일부에 대해 유동성이 부족할 수 있
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "펀딩 수수료"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "GMX를 어떻게 시작하나요?"
 msgid "Acceptable price"
 msgstr "허용 가격"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "서브계정에서 출금하는 중…"
@@ -4292,6 +4396,10 @@ msgstr "20초"
 msgid "Virtual market ID"
 msgstr "가상 마켓 ID"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "가상 마켓 ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "레버리지"
@@ -4344,6 +4455,10 @@ msgstr "승/패"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "출금 중..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>유효하지 않은 허가 서명입니다. 다시 시도하십시오
 msgid "Positive factor"
 msgstr "양수 팩터"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "포지션 전체 청산"
@@ -4738,6 +4857,10 @@ msgstr "{0} 편집"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "이용약관"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (공급)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "TP/SL 설정"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "최대 {MAX_REFERRAL_CODE_LENGTH}자"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "허가 테스트"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "유효하지 않은 트랜잭션"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "설정"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "가격 영향 리베이트 수령에 실패했습니다"
 msgid "Paste hex error data to decode"
 msgstr "디코딩할 hex 오류 데이터를 붙여넣으십시오"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "최소 담보"
@@ -6893,6 +7048,10 @@ msgstr "체결가가 허용 가격을 충족하지 못했습니다"
 msgid "Position would be liquidatable"
 msgstr "포지션이 청산 대상이 됩니다"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "청산까지 예상 시간"
 msgid "Mark price for the liquidation"
 msgstr "청산 시 기준가"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "최근 {daysConsidered}일간 APY 기준 예상치"
@@ -6946,6 +7109,10 @@ msgstr "포지션 수수료 정산 중..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "GMX 공지사항 및 업데이트"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "RPC 디버그"
 msgid "No items yet"
 msgstr "아직 항목 없음"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "자신 있게 거래"
@@ -7343,6 +7514,10 @@ msgstr "가스 잔액 부족"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "V1 리베이트"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "Version:"
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "사용 가능"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "{0}을(를) {1}(으)로 출금하는 것은 지원되지 않습니다"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "ENTRY PRICE"
 msgid "Display PnL after fees"
 msgstr "수수료 차감 후 PnL 표시"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "포지션 공유"
@@ -7713,6 +7897,10 @@ msgstr "프로젝트"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "24시간 최저"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "재승인이 필요하기 전 최대 실행 횟수"
 msgid "GMX risk monitoring"
 msgstr "GMX 리스크 모니터링"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "순위 자격을 얻으려면 최소 {0}의 사용 자본이 필요합니다"
@@ -8110,6 +8306,10 @@ msgstr "주문이 최대 레버리지를 초과합니다. 클릭하여 자동 �
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "사용 가능한 스왑 경로 없음"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "풀 유동성 부족"
 msgid "No opportunities on Botanix yet"
 msgstr "Botanix에서 아직 사용 가능한 기회가 없습니다"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1>의 OI가 훌륭합니다</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>더 확인: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "1분 미만"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "이코시스템"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "V2 리베이트"
 msgid "Select asset to deposit"
 msgstr "입금할 자산 선택"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "최대 GM 구매 가능 금액 도달"
@@ -9489,6 +9701,10 @@ msgstr "GLV는 정확히 무엇인가요?"
 msgid "Download"
 msgstr "다운로드"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "정상"
@@ -9612,6 +9828,10 @@ msgstr "실적 및 차트 데이터는 UTC 시간 기준입니다"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "{operationTokenSymbol} 판매"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "상태"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "다소 중요하지 않은 텍스트이지만 읽을 수 있습니다"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30초"
@@ -10998,6 +11222,10 @@ msgstr "허용 가격 영향"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "최대값에 맞게 출금을 줄이십시오. <0>자세히 보기</0>.<1/><2/><3>최대 출금 설정</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "풀 USD 숏"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0}개 주문이 업데이트되지 않았습니다. 한도에 도달했습니다"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "비례 저장 영향"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 3월 20-27일"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "마켓을 찾을 수 없습니다"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "링크 복사"
 msgid "Referral code created"
 msgstr "추천 코드가 생성되었습니다"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "자금 브릿징 중..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "네트워크 수수료"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -65,6 +65,10 @@ msgstr ""
 msgid "REFERRAL CODE"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr ""
@@ -453,6 +457,10 @@ msgstr ""
 msgid "Best swap path"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -510,6 +518,10 @@ msgstr ""
 
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
 msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
@@ -821,6 +833,10 @@ msgstr ""
 msgid "Market Swap"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr ""
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr ""
@@ -1341,6 +1362,10 @@ msgstr ""
 msgid "DATE"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1352,6 +1377,10 @@ msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
 msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr ""
@@ -1821,6 +1854,10 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1832,6 +1869,10 @@ msgstr ""
 
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
+msgstr ""
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
 msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
@@ -1900,6 +1941,10 @@ msgstr ""
 
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
 msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
@@ -2228,6 +2273,10 @@ msgstr ""
 msgid "Price impact rebates"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr ""
@@ -2287,6 +2336,10 @@ msgstr ""
 msgid "DefiLlama"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr ""
@@ -2309,6 +2362,10 @@ msgstr ""
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
+msgstr ""
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
 msgstr ""
 
 #: src/components/TradeHistory/keys.ts
@@ -2438,6 +2495,10 @@ msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr ""
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr ""
@@ -2747,6 +2812,7 @@ msgstr ""
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr ""
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr ""
 msgid "Update Take-Profit"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr ""
@@ -3059,6 +3131,10 @@ msgstr ""
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr ""
@@ -3459,6 +3539,10 @@ msgstr ""
 
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
+msgstr ""
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
 msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
@@ -3661,6 +3745,10 @@ msgstr ""
 msgid "Missing claim params. Retry in a few seconds"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr ""
@@ -3810,6 +3898,10 @@ msgstr ""
 msgid "Runs entirely on public chains"
 msgstr ""
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr ""
@@ -3818,6 +3910,10 @@ msgstr ""
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3988,6 +4084,10 @@ msgstr ""
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
 msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
@@ -4261,6 +4361,10 @@ msgstr ""
 msgid "Acceptable price"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr ""
@@ -4292,6 +4396,10 @@ msgstr ""
 msgid "Virtual market ID"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr ""
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr ""
@@ -4343,6 +4454,10 @@ msgstr ""
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
 msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
@@ -4604,6 +4719,10 @@ msgstr ""
 msgid "Positive factor"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr ""
@@ -4737,6 +4856,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
+msgstr ""
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
 msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
@@ -4876,6 +4999,10 @@ msgstr ""
 
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr ""
 msgid "TVL (SUPPLY)"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr ""
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr ""
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5667,6 +5802,10 @@ msgstr ""
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
 msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
@@ -5951,6 +6090,10 @@ msgstr ""
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr ""
@@ -6185,6 +6328,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
 msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -6766,6 +6917,10 @@ msgstr ""
 msgid "Paste hex error data to decode"
 msgstr ""
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr ""
@@ -6893,6 +7048,10 @@ msgstr ""
 msgid "Position would be liquidatable"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr ""
 msgid "Mark price for the liquidation"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr ""
@@ -6945,6 +7108,10 @@ msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
 msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
@@ -7243,6 +7410,10 @@ msgstr ""
 msgid "No items yet"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr ""
@@ -7342,6 +7513,10 @@ msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
 msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
@@ -7478,6 +7653,7 @@ msgstr ""
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr ""
 
@@ -7551,6 +7727,10 @@ msgstr ""
 
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
+msgstr ""
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -7637,6 +7817,10 @@ msgstr ""
 msgid "Display PnL after fees"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr ""
@@ -7712,6 +7896,10 @@ msgstr ""
 #: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
 msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
@@ -7984,6 +8172,14 @@ msgstr ""
 msgid "GMX risk monitoring"
 msgstr ""
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr ""
@@ -8109,6 +8305,10 @@ msgstr ""
 
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
 msgstr ""
 
 #: src/components/TradeHistory/keys.ts
@@ -8270,6 +8470,10 @@ msgstr ""
 msgid "No opportunities on Botanix yet"
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr ""
@@ -8388,6 +8592,10 @@ msgstr ""
 
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
 msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
@@ -9248,6 +9456,10 @@ msgstr ""
 msgid "Select asset to deposit"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr ""
@@ -9489,6 +9701,10 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr ""
@@ -9611,6 +9827,10 @@ msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
+msgstr ""
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
 msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
@@ -10895,6 +11115,10 @@ msgstr ""
 msgid "Somewhat unimportant text, but still readable"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr ""
@@ -10997,6 +11221,10 @@ msgstr ""
 
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
 msgstr ""
 
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr ""
 msgid "{0} orders not updated, limit reached"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr ""
@@ -11288,6 +11520,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr ""
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr ""
 msgid "Referral code created"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11568,6 +11812,10 @@ msgstr ""
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
+msgstr ""
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
 msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -65,6 +65,10 @@ msgstr "Или обновите RPC вашего кошелька через <0>
 msgid "REFERRAL CODE"
 msgstr "РЕФЕРАЛЬНЫЙ КОД"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "Существующий лимитный ордер использует обеспечение {symbol}. <0>Переключить на обеспечение {symbol}</0>"
@@ -453,6 +457,10 @@ msgstr "Баланс GMX Account"
 msgid "Best swap path"
 msgstr "Лучший путь свопа"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "Выберите токен"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "Не удалось сгенерировать изображение. Обновите страницу и попробуйте снова."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "Неизвестная ошибка"
 msgid "Market Swap"
 msgstr "Рыночный обмен"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "{0} будет обменено на {1} при исполнении"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "Нереализованная PnL"
@@ -1341,6 +1362,10 @@ msgstr "Создание реферального кода..."
 msgid "DATE"
 msgstr "ДАТА"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "Максимум {allowedAutoCancelOrdersNumber} автоотменяе�
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "Страница голосования по предложениям GMX"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "Цена TP выше лимитной цены"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "Действие(я)"
@@ -1821,6 +1854,10 @@ msgstr "Лимитный обмен не удался"
 msgid "Failed"
 msgstr "Ошибка"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "Без комиссии"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "Ликвидности для обмена может быть недостаточно при срабатывании ордера"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "Переключить на Base"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "Скрыть ошибку"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "Общая стоимость токенов в пулах GM"
 msgid "Price impact rebates"
 msgstr "Возвраты за влияние на цену"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "Обновление лимитного обмена"
@@ -2287,6 +2336,10 @@ msgstr "Рыночное уменьшение не удалось"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "Ежедневный и совокупный PnL"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "Может потребоваться несколько минут. Проверьте позже"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "Обновление стоп-лосс"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "Как мы можем решить ваши проблемы?"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "Нет доступной ликвидности для увеличения лонгов при<0/>данном размере. Макс. размер лонга: {0}<1/><2/>Цены исполнения для уменьшения шортов."
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} ордер за"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "Купить GMX на {chainName}"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "Высокое потенциальное чистое влияние н
 msgid "Update Take-Profit"
 msgstr "Обновить тейк-профит"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "Депозит из {sourceChainName} не удался"
@@ -3059,6 +3131,10 @@ msgstr "Прогнозируемая годовая доходность по с
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "Спред обеспечения"
@@ -3460,6 +3540,10 @@ msgstr "Цена активации"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "Нет AB-флагов"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "Средства клеймлены"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "Отсутствуют параметры для получения. Повторите попытку через несколько секунд"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "Триггер"
@@ -3810,6 +3898,10 @@ msgstr "Аналитика данных GMX V2 в Telegram"
 msgid "Runs entirely on public chains"
 msgstr "Работает полностью на публичных цепях"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "При срабатывании возможна недостаточная ликвидность для части этого ордера"
@@ -3818,6 +3910,10 @@ msgstr "При срабатывании возможна недостаточн�
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "Комиссия за финансирование"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "Как начать на GMX?"
 msgid "Acceptable price"
 msgstr "Допустимая цена"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "Вывод с субаккаунта…"
@@ -4292,6 +4396,10 @@ msgstr "20с"
 msgid "Virtual market ID"
 msgstr "Виртуальный ID рынка"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "Виртуальный ID рынка"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "Плечо"
@@ -4344,6 +4455,10 @@ msgstr "ВЫИГР./ПРОИГР."
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "Вывод..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>Недействительная подпись разрешения.
 msgid "Positive factor"
 msgstr "Положительный фактор"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "Полное закрытие позиции"
@@ -4738,6 +4857,10 @@ msgstr "Редактировать {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "Условия использования"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (ПОСТАВКА)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "Установить TP/SL"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "Максимум {MAX_REFERRAL_CODE_LENGTH} символов"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "Тестирование разрешений"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "Недействительная транзакция"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "Настройки"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "Не удалось получить компенсацию влияни
 msgid "Paste hex error data to decode"
 msgstr "Вставьте hex-данные ошибки для декодирования"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "Мин. обеспечение"
@@ -6893,6 +7048,10 @@ msgstr "Цена исполнения не соответствовала доп
 msgid "Position would be liquidatable"
 msgstr "Позиция будет подлежать ликвидации"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "Расчётное время до ликвидации"
 msgid "Mark price for the liquidation"
 msgstr "Расчётная цена на момент ликвидации"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "Прогноз на основе APY за последние {daysConsidered} дней"
@@ -6946,6 +7109,10 @@ msgstr "Расчёт комиссий по позиции..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "Анонсы и обновления GMX"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "Отладка RPC"
 msgid "No items yet"
 msgstr "Пока нет элементов"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "Торгуйте с уверенностью"
@@ -7343,6 +7514,10 @@ msgstr "Недостаточно баланса газа"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "Скидки V1"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "Версия:"
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "Доступно"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "Вывод {0} на {1} не поддерживается"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "ЦЕНА ВХОДА"
 msgid "Display PnL after fees"
 msgstr "Отображать PnL после комиссий"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "Поделиться позицией"
@@ -7713,6 +7897,10 @@ msgstr "Проект"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "Мин. за 24ч"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "Максимальное количество действий до не
 msgid "GMX risk monitoring"
 msgstr "Мониторинг рисков GMX"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "Для участия в рейтинге необходимо использовать капитал не менее {0}"
@@ -8110,6 +8306,10 @@ msgstr "Ордер превышает максимальное кредитно�
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "Нет доступного маршрута обмена"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "Недостаточная ликвидность пула"
 msgid "No opportunities on Botanix yet"
 msgstr "На Botanix пока нет возможностей"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1> OI выглядит отлично</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Проверьте больше: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "меньше минуты"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "Экосистема"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "Скидки V2"
 msgid "Select asset to deposit"
 msgstr "Выберите актив для пополнения"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "Достигнута максимальная сумма покупки GM"
@@ -9489,6 +9701,10 @@ msgstr "Что именно такое GLV?"
 msgid "Download"
 msgstr "Загрузить"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "Работает"
@@ -9612,6 +9828,10 @@ msgstr "Данные о результатах и графиках основа�
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "Продать {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "Статус"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "Относительно второстепенный текст, но всё ещё читаемый"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30с"
@@ -10998,6 +11222,10 @@ msgstr "Допустимое влияние на цену"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "Уменьшите вывод до максимума. <0>Подробнее</0>.<1/><2/><3>Установить макс. вывод</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "Pool USD шорт"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} ордеров не обновлено, достигнут лимит"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "Пропорциональное сохранённое влияние"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 20-27 марта"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "Рынки не найдены"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "Скопировать ссылку"
 msgid "Referral code created"
 msgstr "Реферальный код создан"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "Перевод средств в..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "Комиссия сети"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -65,6 +65,10 @@ msgstr "或透過 <0>chainlist.org</0> 更新您錢包的 RPC"
 msgid "REFERRAL CODE"
 msgstr "推薦代碼"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "現有限價單使用 {symbol} 抵押品。<0>切換至 {symbol} 抵押品</0>"
@@ -453,6 +457,10 @@ msgstr "GMX Account 餘額"
 msgid "Best swap path"
 msgstr "最佳兌換路徑"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "選擇代幣"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "圖片生成失敗。請重新整理後再試一次。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "未知錯誤"
 msgid "Market Swap"
 msgstr "Market Swap"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "執行時 {0} 將兌換為 {1}"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "未實現盈虧"
@@ -1341,6 +1362,10 @@ msgstr "正在建立推薦碼..."
 msgid "DATE"
 msgstr "日期"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "最多允許 {allowedAutoCancelOrdersNumber} 個自動取消的 TP/SL �
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "GMX 提案投票頁面"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "TP 價格高於限價"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "操作"
@@ -1821,6 +1854,10 @@ msgstr "Limit Swap 失敗"
 msgid "Failed"
 msgstr "失敗"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "無手續費"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "訂單觸發時兌換流動性可能不足"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "切換至 Base"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "隱藏錯誤"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "GM 池中代幣的總價值"
 msgid "Price impact rebates"
 msgstr "價格影響回饋"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "更新 Limit Swap"
@@ -2287,6 +2336,10 @@ msgstr "Market Decrease 失敗"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "每日與累計 PnL"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "可能需要幾分鐘才會顯示。請稍後再查看"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "更新止損"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "我們如何改善您的疑慮？"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "此規模下無可用流動性來加倉做多。<0/>最大做多規模：{0}<1/><2/>減倉做空的成交價格。"
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} 訂單於"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "在 {chainName} 上買入 GMX"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "高潛在淨價格影響（此市場上限為 {formattedCap}）可能會
 msgid "Update Take-Profit"
 msgstr "更新止盈"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "從 {sourceChainName} 存入失敗"
@@ -3059,6 +3131,10 @@ msgstr "與 Uniswap V2 風格基準相比的預估年化回報。<0/><1/>注意�
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "抵押品價差"
@@ -3460,6 +3540,10 @@ msgstr "觸發價格"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "無 AB 標記"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "資金已領取"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "缺少領取參數，請稍後重試"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "觸發"
@@ -3810,6 +3898,10 @@ msgstr "Telegram 內的 GMX V2 數據分析"
 msgid "Runs entirely on public chains"
 msgstr "完全在公共鏈上運行"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "觸發時此訂單的部分可能缺乏流動性"
@@ -3818,6 +3910,10 @@ msgstr "觸發時此訂單的部分可能缺乏流動性"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "資金費用"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "如何在 GMX 上開始使用？"
 msgid "Acceptable price"
 msgstr "可接受價格"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "正在從子帳戶提取..."
@@ -4292,6 +4396,10 @@ msgstr "20 秒"
 msgid "Virtual market ID"
 msgstr "虛擬市場 ID"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "虛擬市場 ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "槓桿"
@@ -4344,6 +4455,10 @@ msgstr "WIN/LOSS"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "提取中..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>無效的許可簽名，請重試</0>"
 msgid "Positive factor"
 msgstr "正向因子"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "完全平倉"
@@ -4738,6 +4857,10 @@ msgstr "編輯 {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v："
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "條款與條件"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (SUPPLY)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "設定 TP/SL"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "最多 {MAX_REFERRAL_CODE_LENGTH} 個字元"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "Permits testing"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "無效交易"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "設定"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "領取價格影響回饋失敗"
 msgid "Paste hex error data to decode"
 msgstr "貼上十六進位錯誤資料以進行解碼"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "最低抵押品"
@@ -6893,6 +7048,10 @@ msgstr "成交價格未達到可接受價格"
 msgid "Position would be liquidatable"
 msgstr "倉位將面臨清算"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "預計清算時間"
 msgid "Mark price for the liquidation"
 msgstr "清算的標記價格"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "根據過去 {daysConsidered} 天的 APY 推算"
@@ -6946,6 +7109,10 @@ msgstr "正在結算倉位費用..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "GMX 公告與更新"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "RPC 除錯"
 msgid "No items yet"
 msgstr "尚無項目"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "安心交易"
@@ -7343,6 +7514,10 @@ msgstr "Gas 餘額不足"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "V1 返佣"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "版本："
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "可用"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "不支援將 {0} 提取至 {1}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "入場價格"
 msgid "Display PnL after fees"
 msgstr "顯示扣除費用後的 PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "分享倉位"
@@ -7713,6 +7897,10 @@ msgstr "專案"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "24小時最低價"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "需要重新授權前的最大操作次數"
 msgid "GMX risk monitoring"
 msgstr "GMX 風險監控"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "需要使用最低 {0} 的資金才能參與排名"
@@ -8110,6 +8306,10 @@ msgstr "訂單超過最大槓桿。點擊以自動調整。"
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "無可用的兌換路徑"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "池流動性不足"
 msgid "No opportunities on Botanix yet"
 msgstr "Botanix 上尚無機會"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1> 的 OI 看起來很棒</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>查看更多：<4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "不到一分鐘"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "生態系統"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "V2 返利"
 msgid "Select asset to deposit"
 msgstr "選擇要存入的資產"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "已達到 GM 最大可買入數量"
@@ -9489,6 +9701,10 @@ msgstr "GLV 究竟是什麼？"
 msgid "Download"
 msgstr "下載"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "正常"
@@ -9612,6 +9828,10 @@ msgstr "績效和圖表數據均以 UTC 時間為基準"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "賣出 {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "狀態"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "不太重要的文字，但仍可閱讀"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30 秒"
@@ -10998,6 +11222,10 @@ msgstr "可接受價格影響"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "減少提取金額以符合上限。<0>了解更多</0>。<1/><2/><3>設定最大提取金額</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "池 USD 做空"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} 筆訂單未更新，已達上限"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "按比例儲存的影響"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 20-27 Mar"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "未找到市場"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "複製連結"
 msgid "Referral code created"
 msgstr "推薦碼已建立"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "資金正在跨鏈至..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "網路費用"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -65,6 +65,10 @@ msgstr "或通过 <0>chainlist.org</0> 更新您钱包的 RPC"
 msgid "REFERRAL CODE"
 msgstr "推荐码"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Profit Extraction Risk"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
 msgstr "现有限价单使用 {symbol} 抵押品。<0>切换至 {symbol} 抵押品</0>"
@@ -453,6 +457,10 @@ msgstr "GMX Account 余额"
 msgid "Best swap path"
 msgstr "最佳兑换路径"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
+msgstr ""
+
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
 msgstr ""
@@ -511,6 +519,10 @@ msgstr "选择代币"
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Image generation failed. Refresh and try again."
 msgstr "图片生成失败。请刷新后重试。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Loyalty Timer"
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -821,6 +833,10 @@ msgstr "未知错误"
 msgid "Market Swap"
 msgstr "市场交换"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "{ageDays} days"
+msgstr ""
+
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
@@ -903,6 +919,10 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Capacity Used"
 msgstr ""
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
@@ -1306,6 +1326,7 @@ msgstr "执行时 {0} 将兑换为 {1}"
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Unrealized PnL"
 msgstr "未实现盈亏"
@@ -1341,6 +1362,10 @@ msgstr "正在创建推荐码..."
 msgid "DATE"
 msgstr "日期"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Position Age"
+msgstr ""
+
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 msgid "Solana"
@@ -1353,6 +1378,10 @@ msgstr "最多允许 {allowedAutoCancelOrdersNumber} 个自动取消的止盈/�
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX proposals voting page"
 msgstr "GMX 提案投票页面"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "1. Leverage (higher = first)"
+msgstr ""
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1622,6 +1651,10 @@ msgstr ""
 msgid "TP price above limit price"
 msgstr "止盈价格高于限价"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "2. Entry recency (newer = first)"
+msgstr ""
+
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
 msgstr "操作"
@@ -1821,6 +1854,10 @@ msgstr "限价交换失败"
 msgid "Failed"
 msgstr "失败"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Restricted (weekend)"
 msgstr ""
@@ -1833,6 +1870,10 @@ msgstr "无费用"
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "订单触发时兑换流动性可能不足"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Reserve Fund"
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,6 +1942,10 @@ msgstr "切换至 Base"
 #: src/components/ToastifyDebug/ToastifyDebug.tsx
 msgid "Hide error"
 msgstr "隐藏错误"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active trade (long) position in this vault."
+msgstr ""
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -2228,6 +2273,10 @@ msgstr "GM 池中代币的总价值"
 msgid "Price impact rebates"
 msgstr "价格影响返还"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Your ADL Risk"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
 msgstr "更新限价交换"
@@ -2287,6 +2336,10 @@ msgstr "市场减少失败"
 msgid "DefiLlama"
 msgstr "DefiLlama"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 4 · Hedge ADL"
+msgstr ""
+
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
 msgstr "每日及累计 PnL"
@@ -2310,6 +2363,10 @@ msgstr ""
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
 msgstr "可能需要几分钟才能显示。请稍后查看"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Absorbed"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2438,6 +2495,10 @@ msgstr "更新止损"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "How do I choose?"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Consider reducing leverage to lower your ADL priority."
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2633,6 +2694,10 @@ msgstr "我们如何解决您的顾虑？"
 msgid "Closing Size"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B"
+msgstr ""
+
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
 msgstr "在此规模下无可用流动性来增加做多仓位。<0/>最大做多规模：{0}<1/><2/>做空减仓的执行价格。"
@@ -2747,6 +2812,7 @@ msgstr "{txnTypeText} {0} 订单为"
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/OIStats.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Max"
@@ -2839,6 +2905,8 @@ msgstr "在 {chainName} 上购买 GMX"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeboxMarginFields/SizeField.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/Trade/components/PositionListPanel.tsx
@@ -3043,6 +3111,10 @@ msgstr "较高的潜在净价格影响（该市场上限为 {formattedCap}）可
 msgid "Update Take-Profit"
 msgstr "更新止盈"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
+msgstr ""
+
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
 msgstr "从 {sourceChainName} 存入失败"
@@ -3059,6 +3131,10 @@ msgstr "与 Uniswap V2 风格基准相比的预计年化回报。<0/><1/>注意�
 #: src/pages/Admin/AdminPage.tsx
 #~ msgid "Disabled"
 #~ msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Long profit positions"
+msgstr ""
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3273,6 +3349,10 @@ msgstr ""
 msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 msgstr ""
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
 msgstr "抵押品价差"
@@ -3460,6 +3540,10 @@ msgstr "触发价格"
 #: src/components/AbFlagsSettings/AbFlagsSettings.tsx
 msgid "No AB flags"
 msgstr "无 AB 标志"
+
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior TrancheVault not configured for this deployment."
+msgstr ""
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3661,6 +3745,10 @@ msgstr "资金已申领"
 msgid "Missing claim params. Retry in a few seconds"
 msgstr "领取参数缺失，请稍后重试"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Full leaderboard requires Subgraph"
+msgstr ""
+
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
 msgstr "触发"
@@ -3810,6 +3898,10 @@ msgstr "Telegram 中的 GMX V2 数据分析"
 msgid "Runs entirely on public chains"
 msgstr "完全在公共链上运行"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Current"
+msgstr ""
+
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
 msgstr "触发时该订单部分子单可能流动性不足"
@@ -3818,6 +3910,10 @@ msgstr "触发时该订单部分子单可能流动性不足"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Protected (30d+)"
 msgstr ""
 
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -3989,6 +4085,10 @@ msgstr "Copin"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Funding fee"
 msgstr "资金费用"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "System Status: Normal"
+msgstr ""
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4261,6 +4361,10 @@ msgstr "如何在 GMX 上入门？"
 msgid "Acceptable price"
 msgstr "可接受价格"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Score"
+msgstr ""
+
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
 msgstr "正在从子账户提取…"
@@ -4292,6 +4396,10 @@ msgstr "20 秒"
 msgid "Virtual market ID"
 msgstr "虚拟市场 ID"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Junior Buffer (PAYOUT Tranche)"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
 #: src/components/PositionSeller/PositionSellerAdvancedDisplayRows.tsx
@@ -4300,7 +4408,10 @@ msgstr "虚拟市场 ID"
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/components/TradeBox/TradeBoxRows/AdvancedDisplayRows.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
+#: src/pages/Status/components/AdlLeaderboard.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Leverage"
 msgstr "杠杆"
@@ -4344,6 +4455,10 @@ msgstr "WIN/LOSS"
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing..."
 msgstr "提取中..."
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Phase 3 · Trade ADL"
+msgstr ""
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4604,6 +4719,10 @@ msgstr "<0>无效的授权签名。请重试</0>"
 msgid "Positive factor"
 msgstr "正向因子"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
 msgstr "全部平仓"
@@ -4738,6 +4857,10 @@ msgstr "编辑 {0}"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4877,6 +5000,10 @@ msgstr "v:"
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "{formattedNetRate} / 1H"
 msgstr "{formattedNetRate} / 1H"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "No active hedge (short) position in this vault."
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5239,6 +5366,10 @@ msgstr "条款与条件"
 msgid "TVL (SUPPLY)"
 msgstr "TVL (供应)"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Hedge Protection Status"
+msgstr ""
+
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
 msgstr ""
@@ -5509,6 +5640,10 @@ msgstr "设置 TP/SL"
 msgid "Max {MAX_REFERRAL_CODE_LENGTH} characters"
 msgstr "最多 {MAX_REFERRAL_CODE_LENGTH} 个字符"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "OI Utilization"
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
 msgstr ""
@@ -5668,6 +5803,10 @@ msgstr "许可测试"
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Invalid transaction"
 msgstr "无效交易"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Hedge Protection Status (Phase 4 ADL)"
+msgstr ""
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5951,6 +6090,10 @@ msgstr "设置"
 msgid "Increase request cancelled"
 msgstr ""
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Remaining capacity"
+msgstr ""
+
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
 msgstr "leading-1"
@@ -6186,6 +6329,14 @@ msgstr ""
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Botanix"
 msgstr "Botanix"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Short (hedge) positions"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "FR cost / buffered yield"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6766,6 +6917,10 @@ msgstr "领取价格影响返还失败"
 msgid "Paste hex error data to decode"
 msgstr "粘贴十六进制错误数据以解码"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge Inventory"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
 msgstr "最低抵押品"
@@ -6893,6 +7048,10 @@ msgstr "成交价格未达到可接受价格"
 msgid "Position would be liquidatable"
 msgstr "仓位将面临清算"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "LP Boost"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
@@ -6935,6 +7094,10 @@ msgstr "预计清算时间"
 msgid "Mark price for the liquidation"
 msgstr "清算时的标记价格"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "New ({ageDays}d)"
+msgstr ""
+
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
 msgstr "根据过去 {daysConsidered} 天的 APY 推算"
@@ -6946,6 +7109,10 @@ msgstr "正在结算仓位费用..."
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX announcements and updates"
 msgstr "GMX 公告和更新"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode A (Auto-Close) ⚠"
+msgstr ""
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7243,6 +7410,10 @@ msgstr "RPC 调试"
 msgid "No items yet"
 msgstr "暂无项目"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Protocol Defense Status"
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
 msgstr "自信交易"
@@ -7343,6 +7514,10 @@ msgstr "Gas余额不足"
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "V1 rebates"
 msgstr "V1 返佣"
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "Hedge FR (Shorts perspective)"
+msgstr ""
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7478,6 +7653,7 @@ msgstr "版本："
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeOutModal.tsx
+#: src/pages/Status/components/BufferGauges.tsx
 msgid "Available"
 msgstr "可用"
 
@@ -7552,6 +7728,10 @@ msgstr "Bond Protocol"
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "Withdrawing {0} to {1} is not supported"
 msgstr "不支持将 {0} 提取至 {1}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Protocol Status"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
@@ -7637,6 +7817,10 @@ msgstr "ENTRY PRICE"
 msgid "Display PnL after fees"
 msgstr "显示扣除费用后的 PnL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A ⚠"
+msgstr ""
+
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
 msgstr "分享仓位"
@@ -7713,6 +7897,10 @@ msgstr "项目"
 #: src/components/TVChart/ChartHeader.tsx
 msgid "24h low"
 msgstr "24h 最低"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
+msgstr ""
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7984,6 +8172,14 @@ msgstr "需要重新授权前的最大操作次数"
 msgid "GMX risk monitoring"
 msgstr "GMX 风险监控"
 
+#: src/pages/Status/components/OIStats.tsx
+msgid "Vault Yield APR"
+msgstr ""
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
 msgstr "需要使用至少 {0} 的资金才能参与排名"
@@ -8110,6 +8306,10 @@ msgstr "订单超过最大杠杆。点击自动调整。"
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available"
 msgstr "无可用兑换路径"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Mode B (Convert)"
+msgstr ""
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8270,6 +8470,10 @@ msgstr "池流动性不足"
 msgid "No opportunities on Botanix yet"
 msgstr "Botanix 上暂无机会"
 
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
 msgstr "<0><1>#GMX V2</1> 的 OI 看起来很棒</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>查看更多: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8389,6 +8593,10 @@ msgstr "不到一分钟"
 #: src/components/SideNav/SideNav.tsx
 msgid "Ecosystem"
 msgstr "生态系统"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "3. Mode (Auto-Close first)"
+msgstr ""
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -9248,6 +9456,10 @@ msgstr "V2 返佣"
 msgid "Select asset to deposit"
 msgstr "选择要存入的资产"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-5"
+msgstr ""
+
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
 msgstr "达到最大 GM 可买入金额"
@@ -9489,6 +9701,10 @@ msgstr "GLV 到底是什么？"
 msgid "Download"
 msgstr "下载"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "ADL Mode"
+msgstr ""
+
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
 msgstr "正常"
@@ -9612,6 +9828,10 @@ msgstr "绩效和图表数据基于 UTC 时间"
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 msgid "Sell {operationTokenSymbol}"
 msgstr "出售 {operationTokenSymbol}"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
+msgstr ""
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -10895,6 +11115,10 @@ msgstr "状态"
 msgid "Somewhat unimportant text, but still readable"
 msgstr "相对次要的文本，但仍可阅读"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Consider reducing leverage to improve your ADL protection ranking."
+msgstr ""
+
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
 msgstr "30 秒"
@@ -10998,6 +11222,10 @@ msgstr "可接受的价格影响"
 #: src/components/PositionEditor/usePositionEditorButtonState.tsx
 msgid "Reduce withdrawal to match the max. <0>Read more</0>.<1/><2/><3>Set max withdrawal</3>"
 msgstr "减少提取量以匹配上限。<0>了解更多</0>。<1/><2/><3>设置最大提取量</3>"
+
+#: src/pages/Status/components/AdlLeaderboard.tsx
+msgid "ADL Priority Factors (Hedge Mode):"
+msgstr ""
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11274,6 +11502,10 @@ msgstr "池 USD 做空"
 msgid "{0} orders not updated, limit reached"
 msgstr "{0} 个订单未更新，已达上限"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Phase 2-4"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
 msgstr "比例储存影响"
@@ -11288,6 +11520,10 @@ msgstr "EIP-4844, 3 月 20-27 日"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
+msgstr ""
+
+#: src/pages/Status/components/OIStats.tsx
+msgid "+ve = shorts receive payment"
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -11314,6 +11550,10 @@ msgstr "未找到市场"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Step {defenseStep}:"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -11550,6 +11790,10 @@ msgstr "复制链接"
 msgid "Referral code created"
 msgstr "推荐码已创建"
 
+#: src/pages/Status/components/BufferGauges.tsx
+msgid "Internal Buffers"
+msgstr ""
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Funds bridging to..."
@@ -11569,6 +11813,10 @@ msgstr "资金正在跨链转移至..."
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Network fee"
 msgstr "网络费用"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
+msgstr ""
 
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -12,6 +12,7 @@
  */
 
 import { t } from "@lingui/macro";
+import { formatDistanceToNow } from "date-fns";
 import { Contract, formatEther, parseEther, parseUnits } from "ethers";
 import { useEffect, useMemo, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
@@ -390,6 +391,77 @@ function DeltaNeutralBox({ symbol, rwaAmount, spotPriceUsd, sizeDeltaUsd }: Delt
 }
 
 // ---------------------------------------------------------------------------
+// HedgeSafetyDashboard — ADL protection status for this position
+// ---------------------------------------------------------------------------
+
+type HedgeSafetyDashboardProps = {
+  sizeUsd: number;
+  collateralUsd: number;
+  openedAtMs: number;
+  shouldConvertOnADL: boolean;
+};
+
+function HedgeSafetyDashboard({ sizeUsd, collateralUsd, openedAtMs, shouldConvertOnADL }: HedgeSafetyDashboardProps) {
+  const lev = collateralUsd > 0 ? sizeUsd / collateralUsd : 0;
+  const ageMs = Date.now() - openedAtMs;
+  const ageDays = Math.floor(ageMs / 86_400_000);
+  const loyaltyLabel = openedAtMs > 0 ? formatDistanceToNow(new Date(openedAtMs), { addSuffix: false }) : "—";
+
+  const risk: "low" | "warning" | "high" = lev >= 5 ? "high" : lev >= 3 || ageDays < 7 ? "warning" : "low";
+
+  const BADGE: Record<string, string> = {
+    low: "bg-green-900/60 text-green-400 border border-green-700",
+    warning: "bg-yellow-900/60 text-yellow-400 border border-yellow-700",
+    high: "bg-red-900/60 text-red-400 border border-red-700",
+  };
+  const LABEL: Record<string, string> = { low: "Safe", warning: "Warning", high: "High Risk" };
+
+  return (
+    <div className="mb-16 rounded-4 border border-stroke-primary bg-slate-900/40 p-16">
+      <div className="mb-12 flex items-center justify-between">
+        <span className="text-12 font-medium text-slate-400">{t`Hedge Protection Status (Phase 4 ADL)`}</span>
+        <span className={`rounded-full px-10 py-3 text-11 font-medium ${BADGE[risk]}`}>{LABEL[risk]}</span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-12 text-center">
+        <div>
+          <p className="text-10 text-slate-500">{t`Leverage`}</p>
+          <p
+            className={`text-13 font-medium ${lev >= 5 ? "text-red-400" : lev >= 3 ? "text-yellow-400" : "text-green-400"}`}
+          >
+            {lev.toFixed(1)}×
+          </p>
+        </div>
+        <div>
+          <p className="text-10 text-slate-500">{t`Loyalty Timer`}</p>
+          <p
+            className={`text-13 font-medium ${ageDays >= 30 ? "text-green-400" : ageDays >= 7 ? "text-yellow-400" : "text-red-400"}`}
+          >
+            {loyaltyLabel}
+          </p>
+        </div>
+        <div>
+          <p className="text-10 text-slate-500">{t`ADL Mode`}</p>
+          <p className={`text-13 font-medium ${shouldConvertOnADL ? "text-slate-400" : "text-orange-400"}`}>
+            {shouldConvertOnADL ? t`Mode B` : t`Mode A ⚠`}
+          </p>
+        </div>
+      </div>
+
+      {risk === "low" && (
+        <p className="mt-10 text-11 text-green-700">{t`Low leverage and long tenure protect you. You are in the loyalty tier.`}</p>
+      )}
+      {risk === "warning" && (
+        <p className="text-yellow-700 mt-10 text-11">{t`Consider reducing leverage to improve your ADL protection ranking.`}</p>
+      )}
+      {risk === "high" && (
+        <p className="mt-10 text-11 text-red-700">{t`High leverage increases ADL priority. Reduce leverage or hold longer to improve protection.`}</p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // CurrentPositionPanel — Section 4
 // ---------------------------------------------------------------------------
 
@@ -676,15 +748,23 @@ export default function HedgeDetailPage() {
 
               {/* Position details */}
               {pageData.userPosition ? (
-                <CurrentPositionPanel
-                  symbol={cfg.symbol}
-                  spotPriceUsd={spotPriceUsd}
-                  sizeUsd={pageData.userPosition.sizeUsd}
-                  collateralUsd={pageData.userPosition.collateralUsd}
-                  averagePrice={pageData.userPosition.averagePrice}
-                  collateralToken={pageData.userPosition.collateralToken}
-                  shouldConvertOnADL={pageData.userPosition.shouldConvertOnADL}
-                />
+                <>
+                  <HedgeSafetyDashboard
+                    sizeUsd={pageData.userPosition.sizeUsd}
+                    collateralUsd={pageData.userPosition.collateralUsd}
+                    openedAtMs={0}
+                    shouldConvertOnADL={pageData.userPosition.shouldConvertOnADL}
+                  />
+                  <CurrentPositionPanel
+                    symbol={cfg.symbol}
+                    spotPriceUsd={spotPriceUsd}
+                    sizeUsd={pageData.userPosition.sizeUsd}
+                    collateralUsd={pageData.userPosition.collateralUsd}
+                    averagePrice={pageData.userPosition.averagePrice}
+                    collateralToken={pageData.userPosition.collateralToken}
+                    shouldConvertOnADL={pageData.userPosition.shouldConvertOnADL}
+                  />
+                </>
               ) : (
                 <p className="text-13 text-slate-500">{t`No open short position. Use the form above to open one.`}</p>
               )}

--- a/src/pages/Hedge/HedgePage.tsx
+++ b/src/pages/Hedge/HedgePage.tsx
@@ -13,7 +13,10 @@ import { formatEther } from "ethers";
 import { useHistory } from "react-router-dom";
 
 import { useHedgeList } from "domain/vantage/hedge/useHedgeList";
-import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL } from "domain/vantage/vaults/vaultConfig";
+import { useStatusPageData } from "domain/vantage/solvency/useStatusPageData";
+import { VAULT_CONFIGS, ASSET_TYPE_COLOR, ASSET_TYPE_LABEL } from "domain/vantage/vaults/vaultConfig";
+import { useChainId } from "lib/chains";
+import { SolvencyBadge } from "pages/Status/components/SolvencySpeedometer";
 
 import { AppHeader } from "components/AppHeader/AppHeader";
 import { AppNav } from "components/AppNav/AppNav";
@@ -44,9 +47,13 @@ function apyColor(apy: number | null): string {
 // Component
 // ---------------------------------------------------------------------------
 
+const PRIMARY_CFG = VAULT_CONFIGS.find((v) => v.assetType !== "stable") ?? VAULT_CONFIGS[0];
+
 export default function HedgePage() {
   const history = useHistory();
+  const { chainId } = useChainId();
   const items = useHedgeList();
+  const { defenseStep } = useStatusPageData(chainId, PRIMARY_CFG);
 
   return (
     <div className="w-full">
@@ -62,6 +69,9 @@ export default function HedgePage() {
           <p className="text-body-medium mt-4 text-slate-400">
             {t`Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure.`}
           </p>
+          <div className="mt-10">
+            <SolvencyBadge defenseStep={defenseStep} />
+          </div>
         </div>
 
         {/* Table */}

--- a/src/pages/Status/StatusPage.tsx
+++ b/src/pages/Status/StatusPage.tsx
@@ -1,0 +1,211 @@
+/**
+ * StatusPage.tsx
+ *
+ * Protocol Solvency Dashboard.
+ * Route: /status
+ *
+ * Shows the 7-step FR risk defense sequence in real-time and displays
+ * per-user ADL risk indicators for both trade and hedge positions.
+ */
+
+import { t } from "@lingui/macro";
+import { formatDistanceToNow } from "date-fns";
+import { Contract, formatEther } from "ethers";
+import { useEffect, useState } from "react";
+
+import type { DefenseStep } from "domain/vantage/solvency/getDefenseStep";
+import { useStatusPageData } from "domain/vantage/solvency/useStatusPageData";
+import { VAULT_CONFIGS } from "domain/vantage/vaults/vaultConfig";
+import { useChainId } from "lib/chains";
+import { getProvider } from "lib/rpc";
+import useWallet from "lib/wallets/useWallet";
+import type { HedgePositionSummary, TradePositionSummary } from "pages/Status/components/AdlLeaderboard";
+import VaultAbi from "vantage/abis/Vault.json";
+import localhostDeployment from "vantage/deployments/frontend-localhost.json";
+
+import { AppHeader } from "components/AppHeader/AppHeader";
+import { AppNav } from "components/AppNav/AppNav";
+
+import { AdlLeaderboard } from "./components/AdlLeaderboard";
+import { BufferGauges } from "./components/BufferGauges";
+import { OIStats } from "./components/OIStats";
+import { ProtocolCommitmentBanner } from "./components/ProtocolCommitmentBanner";
+import { SolvencySpeedometer } from "./components/SolvencySpeedometer";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const POLL_MS = 15_000;
+
+const dep = localhostDeployment.addresses as { tokens?: { USDC?: string } };
+const USDC_ADDRESS = dep.tokens?.USDC ?? "";
+
+// Use first non-stable vault for OI + funding data; fall back to the USDC vault.
+const PRIMARY_CFG = VAULT_CONFIGS.find((v) => v.assetType !== "stable" && v.vaultAddress) ?? VAULT_CONFIGS[0];
+
+// ---------------------------------------------------------------------------
+// useUserPositions — fetches both long (trade) and short (hedge) positions
+// ---------------------------------------------------------------------------
+
+interface UserPositions {
+  trade: TradePositionSummary | null;
+  hedge: HedgePositionSummary | null;
+}
+
+function useUserPositions(chainId: number, account: string | undefined): UserPositions {
+  const [positions, setPositions] = useState<UserPositions>({ trade: null, hedge: null });
+
+  useEffect(() => {
+    if (!account || !PRIMARY_CFG.vaultAddress || !PRIMARY_CFG.tokenAddress || !USDC_ADDRESS) return;
+
+    const provider = getProvider(undefined, chainId);
+    const vault = new Contract(PRIMARY_CFG.vaultAddress, VaultAbi, provider);
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const tokenAddr = PRIMARY_CFG.tokenAddress;
+
+        // Long (trade) position key
+        const longKey: string = await vault.getPositionKey(account, USDC_ADDRESS, tokenAddr, true);
+        // Short (hedge) position key
+        const shortKey: string = await vault.getPositionKey(account, USDC_ADDRESS, tokenAddr, false);
+
+        const [longPos, shortPos, shouldConvertOnADL] = await Promise.all([
+          vault.positions(longKey),
+          vault.positions(shortKey),
+          vault.shouldConvertOnADL(shortKey).catch(() => false) as Promise<boolean>,
+        ]);
+
+        const tokenPrice: bigint = await vault.getMinPrice(tokenAddr).catch(() => 0n);
+        const PRICE_PRECISION = 10n ** 18n;
+
+        // ── Trade position ──────────────────────────────────────────────────
+        let trade: TradePositionSummary | null = null;
+        if (BigInt(longPos.size) > 0n) {
+          const sizeUsd = parseFloat(formatEther(longPos.size));
+          const collateralUsd = parseFloat(formatEther(longPos.collateral));
+          // Estimated PnL: (currentPrice - avgPrice) × size / avgPrice
+          const avgPrice = BigInt(longPos.averagePrice);
+          const unrealizedPnlWad =
+            avgPrice > 0n ? ((tokenPrice - avgPrice) * BigInt(longPos.size)) / avgPrice / PRICE_PRECISION : 0n;
+          trade = {
+            sizeUsd,
+            collateralUsd,
+            unrealizedPnlUsd: parseFloat(formatEther(unrealizedPnlWad)),
+          };
+        }
+
+        // ── Hedge (short) position ──────────────────────────────────────────
+        let hedge: HedgePositionSummary | null = null;
+        if (BigInt(shortPos.size) > 0n) {
+          const sizeUsd = parseFloat(formatEther(shortPos.size));
+          const collateralUsd = parseFloat(formatEther(shortPos.collateral));
+          // openedAt is stored in block.timestamp seconds — convert to ms
+          const openedAtMs = Number(shortPos.lastIncreasedTime ?? 0) * 1_000;
+          hedge = {
+            sizeUsd,
+            collateralUsd,
+            openedAtMs,
+            shouldConvertOnADL,
+          };
+        }
+
+        if (!cancelled) setPositions({ trade, hedge });
+      } catch {
+        // Leave previous data intact.
+      }
+    }
+
+    poll();
+    const timer = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [chainId, account]);
+
+  return positions;
+}
+
+// ---------------------------------------------------------------------------
+// SolvencyDropBanner — shows elapsed time since solvencyDropAt
+// ---------------------------------------------------------------------------
+
+function SolvencyDropBanner({ solvencyDropAt, defenseStep }: { solvencyDropAt: number; defenseStep: DefenseStep }) {
+  if (solvencyDropAt === 0 || defenseStep < 6) return null;
+
+  const dropDate = new Date(solvencyDropAt * 1_000);
+  const elapsed = formatDistanceToNow(dropDate, { addSuffix: false });
+
+  return (
+    <div className="border-red-800 bg-red-950/40 flex items-center gap-10 rounded-4 border px-16 py-12">
+      <div className="h-8 w-8 flex-shrink-0 animate-pulse rounded-full bg-red-500" />
+      <p className="text-red-300 text-13">
+        {t`Trade ADL in progress for ${elapsed}. Long positions with high leverage × profit are being force-closed.`}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function StatusPage() {
+  const { chainId } = useChainId();
+  const { account } = useWallet();
+
+  const data = useStatusPageData(chainId, PRIMARY_CFG);
+  const { trade, hedge } = useUserPositions(chainId, account);
+
+  return (
+    <div className="w-full">
+      {/* Header */}
+      <div className="border-b border-stroke-primary px-16 py-8">
+        <AppHeader leftContent={<AppNav />} />
+      </div>
+
+      <div className="mx-auto mt-24 max-w-[1200px] space-y-20 px-16 pb-40">
+        {/* Page title */}
+        <div>
+          <h1 className="text-h1">{t`Protocol Status`}</h1>
+          <p className="text-body-medium mt-4 text-slate-400">
+            {t`Real-time solvency dashboard. 7-step defense sequence transparency.`}
+          </p>
+        </div>
+
+        {/* Solvency drop banner (Phase 3+) */}
+        <SolvencyDropBanner solvencyDropAt={data.solvencyDropAt} defenseStep={data.defenseStep} />
+
+        {/* 7-Step Speedometer */}
+        <SolvencySpeedometer defenseStep={data.defenseStep} />
+
+        {/* Buffer Gauges + OI Stats */}
+        <div className="grid grid-cols-1 gap-20 lg:grid-cols-2">
+          <BufferGauges
+            reserveFundUsd={data.reserveFundUsd}
+            lpBoostPoolUsd={data.lpBoostPoolUsd}
+            juniorDeficitAbsorbed={data.juniorDeficitAbsorbed}
+            juniorAumUsd={data.juniorAumUsd}
+          />
+          <OIStats
+            totalShortUsd={data.totalShortUsd}
+            maxShortCapacityUsd={data.maxShortCapacityUsd}
+            oiUtilizationPct={data.oiUtilizationPct}
+            fundingRateBps={data.fundingRateBps}
+            yieldAprBps={data.yieldAprBps}
+            hedgeCapacityPct={data.hedgeCapacityPct}
+          />
+        </div>
+
+        {/* ADL Risk (user's own positions) */}
+        <AdlLeaderboard tradePosition={trade} hedgePosition={hedge} />
+
+        {/* Protocol Commitment */}
+        <ProtocolCommitmentBanner />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Status/__tests__/getDefenseStep.test.ts
+++ b/src/pages/Status/__tests__/getDefenseStep.test.ts
@@ -1,0 +1,146 @@
+/**
+ * getDefenseStep.test.ts
+ *
+ * Unit tests for the getDefenseStep pure function.
+ *
+ * T1  All flags false/zero → step 0 (Normal).
+ * T2  isLPBoostActive=true → step 1.
+ * T3  isHighLeverageLocked=true → step 2.
+ * T4  isPremiumSurgeActive=true → step 3.
+ * T5  hedgeCapacityPct >= 80 → step 4.
+ * T6  juniorDeficitAbsorbed > 0 → step 5.
+ * T7  isHedgeDisabled + solvencyDropAt > 0 (< 24h) → step 6.
+ * T8  isHedgeDisabled + solvencyDropAt > 0 (>= 24h) → step 7.
+ * T9  Overlap: isPremiumSurge AND juniorDeficit → highest wins (step 5).
+ * T10 Overlap: all flags true → step 7 (most severe).
+ * T11 ADL Trade Score: higher leverage × PnL → higher score.
+ * T12 ADL Hedge: step 5 < step 6 < step 7 ordering.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DefenseStepInput } from "domain/vantage/solvency/getDefenseStep";
+import { getDefenseStep } from "domain/vantage/solvency/getDefenseStep";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function base(): DefenseStepInput {
+  return {
+    isLPBoostActive: false,
+    isHighLeverageLocked: false,
+    isPremiumSurgeActive: false,
+    isHedgeDisabled: false,
+    solvencyDropAt: 0,
+    juniorDeficitAbsorbed: 0,
+    hedgeCapacityPct: 0,
+  };
+}
+
+// 25 hours ago (exceeds HEDGE_ADL_THRESHOLD_S = 86400s)
+const NOW_S = Math.floor(Date.now() / 1000);
+const DROP_25H_AGO = NOW_S - 25 * 3600;
+const DROP_1H_AGO = NOW_S - 3600;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getDefenseStep", () => {
+  it("T1: all flags false → step 0 (Normal)", () => {
+    expect(getDefenseStep(base())).toBe(0);
+  });
+
+  it("T2: isLPBoostActive=true → step 1", () => {
+    expect(getDefenseStep({ ...base(), isLPBoostActive: true })).toBe(1);
+  });
+
+  it("T3: isHighLeverageLocked=true → step 2", () => {
+    expect(getDefenseStep({ ...base(), isHighLeverageLocked: true })).toBe(2);
+  });
+
+  it("T4: isPremiumSurgeActive=true → step 3", () => {
+    expect(getDefenseStep({ ...base(), isPremiumSurgeActive: true })).toBe(3);
+  });
+
+  it("T5: hedgeCapacityPct >= 80 → step 4", () => {
+    expect(getDefenseStep({ ...base(), hedgeCapacityPct: 80 })).toBe(4);
+    expect(getDefenseStep({ ...base(), hedgeCapacityPct: 110 })).toBe(4);
+  });
+
+  it("T6: juniorDeficitAbsorbed > 0 → step 5", () => {
+    expect(getDefenseStep({ ...base(), juniorDeficitAbsorbed: 1_000 })).toBe(5);
+  });
+
+  it("T7: isHedgeDisabled + solvencyDropAt recent (<24h) → step 6", () => {
+    expect(getDefenseStep({ ...base(), isHedgeDisabled: true, solvencyDropAt: DROP_1H_AGO })).toBe(6);
+  });
+
+  it("T8: isHedgeDisabled + solvencyDropAt old (>=24h) → step 7", () => {
+    expect(getDefenseStep({ ...base(), isHedgeDisabled: true, solvencyDropAt: DROP_25H_AGO })).toBe(7);
+  });
+
+  it("T9: overlap — isPremiumSurge AND juniorDeficit → highest wins (step 5)", () => {
+    expect(
+      getDefenseStep({
+        ...base(),
+        isPremiumSurgeActive: true, // step 3
+        juniorDeficitAbsorbed: 500, // step 5
+      })
+    ).toBe(5);
+  });
+
+  it("T10: all flags active → step 7 (most severe)", () => {
+    expect(
+      getDefenseStep({
+        isLPBoostActive: true,
+        isHighLeverageLocked: true,
+        isPremiumSurgeActive: true,
+        isHedgeDisabled: true,
+        solvencyDropAt: DROP_25H_AGO,
+        juniorDeficitAbsorbed: 1_000,
+        hedgeCapacityPct: 95,
+      })
+    ).toBe(7);
+  });
+
+  it("T11: step 4 requires hedgeCapacityPct >= 80; 79 does not trigger it", () => {
+    expect(getDefenseStep({ ...base(), hedgeCapacityPct: 79 })).toBe(0);
+    expect(getDefenseStep({ ...base(), hedgeCapacityPct: 80 })).toBe(4);
+  });
+
+  it("T12: isHedgeDisabled without solvencyDropAt → step 2 (OI Cap scenario)", () => {
+    expect(getDefenseStep({ ...base(), isHedgeDisabled: true, solvencyDropAt: 0 })).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADL Score helpers (inline — not imported from prod code)
+// ---------------------------------------------------------------------------
+
+describe("ADL score logic", () => {
+  it("T11: Trade ADL — higher leverage × PnL yields higher score", () => {
+    // pos A: 10× leverage, $5k profit → score = 10 × 5000 = 50_000
+    const scoreA = (10_000 / 1_000) * 5_000; // leverage × pnl
+    // pos B: 3× leverage, $2k profit → score = 3 × 2000 = 6_000
+    const scoreB = (6_000 / 2_000) * 2_000;
+
+    expect(scoreA).toBeGreaterThan(scoreB);
+  });
+
+  it("T12: Hedge ADL — higher leverage should come first", () => {
+    // posA: 8× lev, 60d age → ADL priority index 1 (very high lev)
+    // posB: 2× lev, 3d age → ADL priority index 2 (newer but low lev)
+    const levA = 8_000 / 1_000; // 8×
+    const levB = 4_000 / 2_000; // 2×
+    expect(levA).toBeGreaterThan(levB);
+  });
+
+  it("T12b: Hedge ADL — same leverage, newer position (lower ageDays) is higher priority", () => {
+    const ageDaysNew = 2;
+    const ageDaysOld = 45;
+    // Newer = higher LIFO priority = closed first
+    expect(ageDaysNew).toBeLessThan(ageDaysOld);
+  });
+});

--- a/src/pages/Status/components/AdlLeaderboard.tsx
+++ b/src/pages/Status/components/AdlLeaderboard.tsx
@@ -1,0 +1,263 @@
+/**
+ * AdlLeaderboard.tsx
+ *
+ * Displays ADL priority risk indicators for the connected wallet.
+ *
+ * Full anonymized leaderboard requires a Subgraph (orderBy: leverage, desc).
+ * This implementation shows:
+ *   - User's own Trade-mode position with Profit Extraction Risk score
+ *   - User's own Hedge-mode position with Hedge Protection Status
+ *   - Qualitative risk badge: Low / Warning / High
+ *
+ * ADL priority formulas:
+ *   Trade Mode (Phase 3): Score = leverage × unrealizedPnlUsd   (higher = closer to ADL)
+ *   Hedge Mode (Phase 4): Priority = leverage DESC → openedAt DESC (LIFO) → Mode A first
+ */
+
+import { t } from "@lingui/macro";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TradePositionSummary {
+  sizeUsd: number;
+  collateralUsd: number;
+  unrealizedPnlUsd: number; // positive = profit
+}
+
+export interface HedgePositionSummary {
+  sizeUsd: number;
+  collateralUsd: number;
+  openedAtMs: number; // Date.now() equivalent
+  shouldConvertOnADL: boolean; // true = Mode B (convert), false = Mode A (terminate)
+}
+
+type RiskLevel = "low" | "warning" | "high";
+
+// ---------------------------------------------------------------------------
+// ADL score helpers
+// ---------------------------------------------------------------------------
+
+function tradeLeverageX(pos: TradePositionSummary): number {
+  return pos.collateralUsd > 0 ? pos.sizeUsd / pos.collateralUsd : 0;
+}
+
+function tradeAdlScore(pos: TradePositionSummary): number {
+  return tradeLeverageX(pos) * Math.max(0, pos.unrealizedPnlUsd);
+}
+
+function tradeRiskLevel(pos: TradePositionSummary): RiskLevel {
+  const lev = tradeLeverageX(pos);
+  const pnl = pos.unrealizedPnlUsd;
+  if (lev >= 5 && pnl > 0) return "high";
+  if (lev >= 3 || pnl > pos.sizeUsd * 0.1) return "warning";
+  return "low";
+}
+
+function hedgeLeverageX(pos: HedgePositionSummary): number {
+  return pos.collateralUsd > 0 ? pos.sizeUsd / pos.collateralUsd : 0;
+}
+
+const DAYS_MS = 86_400_000;
+
+function hedgeRiskLevel(pos: HedgePositionSummary): RiskLevel {
+  const lev = hedgeLeverageX(pos);
+  const ageMs = Date.now() - pos.openedAtMs;
+  const ageDays = ageMs / DAYS_MS;
+
+  // High leverage → always Warning or High
+  if (lev >= 5) return "high";
+  if (lev >= 3 || ageDays < 7) return "warning";
+  return "low";
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+const RISK_BADGE: Record<RiskLevel, string> = {
+  low: "bg-green-900/60 text-green-400 border border-green-700",
+  warning: "bg-yellow-900/60 text-yellow-400 border border-yellow-700",
+  high: "bg-red-900/60 text-red-400 border border-red-700",
+};
+
+const RISK_LABEL: Record<RiskLevel, string> = {
+  low: "Low",
+  warning: "Warning",
+  high: "High",
+};
+
+function fmtUsd(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtLev(lev: number): string {
+  return lev.toFixed(1) + "×";
+}
+
+// ---------------------------------------------------------------------------
+// Sub-panels
+// ---------------------------------------------------------------------------
+
+function TradeAdlPanel({ pos }: { pos: TradePositionSummary | null }) {
+  if (!pos || pos.sizeUsd === 0) {
+    return <p className="text-12 text-slate-500">{t`No active trade (long) position in this vault.`}</p>;
+  }
+
+  const lev = tradeLeverageX(pos);
+  const risk = tradeRiskLevel(pos);
+  const score = tradeAdlScore(pos);
+
+  return (
+    <div className="space-y-12">
+      <div className="flex items-center justify-between">
+        <span className="text-12 text-slate-400">{t`Profit Extraction Risk`}</span>
+        <span className={`rounded-full px-10 py-3 text-11 font-medium ${RISK_BADGE[risk]}`}>{RISK_LABEL[risk]}</span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-12 rounded-4 bg-slate-900/60 px-16 py-12 text-center">
+        <div>
+          <p className="text-10 text-slate-500">{t`Size`}</p>
+          <p className="text-13 font-medium text-white">{fmtUsd(pos.sizeUsd)}</p>
+        </div>
+        <div>
+          <p className="text-10 text-slate-500">{t`Leverage`}</p>
+          <p className="text-13 font-medium text-white">{fmtLev(lev)}</p>
+        </div>
+        <div>
+          <p className="text-10 text-slate-500">{t`Unrealized PnL`}</p>
+          <p className={`text-13 font-medium ${pos.unrealizedPnlUsd >= 0 ? "text-green-400" : "text-red-400"}`}>
+            {pos.unrealizedPnlUsd >= 0 ? "+" : ""}
+            {fmtUsd(pos.unrealizedPnlUsd)}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-11 text-slate-500">
+        {t`ADL Score`}: {score.toFixed(0)} (Leverage × Profit).{" "}
+        {risk === "high"
+          ? t`Your position carries high leverage with significant profit — among the most likely ADL candidates.`
+          : risk === "warning"
+            ? t`Consider reducing leverage to lower your ADL priority.`
+            : t`Low ADL risk. Your position has low leverage or minimal unrealized profit.`}
+      </p>
+    </div>
+  );
+}
+
+function HedgeAdlPanel({ pos }: { pos: HedgePositionSummary | null }) {
+  if (!pos || pos.sizeUsd === 0) {
+    return <p className="text-12 text-slate-500">{t`No active hedge (short) position in this vault.`}</p>;
+  }
+
+  const lev = hedgeLeverageX(pos);
+  const risk = hedgeRiskLevel(pos);
+  const ageMs = Date.now() - pos.openedAtMs;
+  const ageDays = Math.floor(ageMs / DAYS_MS);
+
+  return (
+    <div className="space-y-12">
+      <div className="flex items-center justify-between">
+        <span className="text-12 text-slate-400">{t`Hedge Protection Status`}</span>
+        <span className={`rounded-full px-10 py-3 text-11 font-medium ${RISK_BADGE[risk]}`}>{RISK_LABEL[risk]}</span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-12 rounded-4 bg-slate-900/60 px-16 py-12 text-center">
+        <div>
+          <p className="text-10 text-slate-500">{t`Size`}</p>
+          <p className="text-13 font-medium text-white">{fmtUsd(pos.sizeUsd)}</p>
+        </div>
+        <div>
+          <p className="text-10 text-slate-500">{t`Leverage`}</p>
+          <p className="text-13 font-medium text-white">{fmtLev(lev)}</p>
+        </div>
+        <div>
+          <p className="text-10 text-slate-500">{t`Position Age`}</p>
+          <p
+            className={`text-13 font-medium ${ageDays >= 30 ? "text-green-400" : ageDays >= 7 ? "text-yellow-400" : "text-red-400"}`}
+          >
+            {ageDays}d
+          </p>
+        </div>
+      </div>
+
+      {/* ADL Priority explanation */}
+      <div className="space-y-6 rounded-4 bg-slate-900/60 px-16 py-12">
+        <p className="text-11 font-medium text-slate-400">{t`ADL Priority Factors (Hedge Mode):`}</p>
+        <div className="flex items-center justify-between text-11">
+          <span className="text-slate-500">{t`1. Leverage (higher = first)`}</span>
+          <span className={lev >= 5 ? "text-red-400" : lev >= 3 ? "text-yellow-400" : "text-green-400"}>
+            {fmtLev(lev)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-11">
+          <span className="text-slate-500">{t`2. Entry recency (newer = first)`}</span>
+          <span className={ageDays < 7 ? "text-red-400" : ageDays < 30 ? "text-yellow-400" : "text-green-400"}>
+            {ageDays >= 30 ? t`Protected (30d+)` : ageDays >= 7 ? t`${ageDays} days` : t`New (${ageDays}d)`}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-11">
+          <span className="text-slate-500">{t`3. Mode (Auto-Close first)`}</span>
+          <span className={!pos.shouldConvertOnADL ? "text-orange-400" : "text-slate-400"}>
+            {pos.shouldConvertOnADL ? t`Mode B (Convert)` : t`Mode A (Auto-Close) ⚠`}
+          </span>
+        </div>
+      </div>
+
+      {risk === "low" ? (
+        <p className="text-11 text-green-600">{t`Low leverage and long tenure protect you from ADL. You are in the loyalty tier.`}</p>
+      ) : risk === "warning" ? (
+        <p className="text-yellow-600 text-11">{t`High leverage or recent entry increases ADL risk. Consider reducing leverage.`}</p>
+      ) : (
+        <p className="text-red-600 text-11">{t`High ADL risk. Reduce leverage or hold position longer to improve protection.`}</p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface AdlLeaderboardProps {
+  tradePosition: TradePositionSummary | null;
+  hedgePosition: HedgePositionSummary | null;
+}
+
+export function AdlLeaderboard({ tradePosition, hedgePosition }: AdlLeaderboardProps) {
+  return (
+    <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+      <div className="mb-16 flex items-center justify-between">
+        <h2 className="text-15 font-semibold text-white">{t`Your ADL Risk`}</h2>
+        <span className="text-11 text-slate-600">{t`Full leaderboard requires Subgraph`}</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-20 lg:grid-cols-2">
+        {/* Trade Mode (Phase 3 ADL) */}
+        <div>
+          <div className="mb-12 flex items-center gap-8">
+            <span className="bg-orange-900/40 text-10 text-orange-400 rounded-2 px-8 py-3 font-medium">
+              {t`Phase 3 · Trade ADL`}
+            </span>
+            <span className="text-12 text-slate-500">{t`Long profit positions`}</span>
+          </div>
+          <TradeAdlPanel pos={tradePosition} />
+        </div>
+
+        {/* Hedge Mode (Phase 4 ADL) */}
+        <div>
+          <div className="mb-12 flex items-center gap-8">
+            <span className="text-10 rounded-2 bg-red-900/40 px-8 py-3 font-medium text-red-400">
+              {t`Phase 4 · Hedge ADL`}
+            </span>
+            <span className="text-12 text-slate-500">{t`Short (hedge) positions`}</span>
+          </div>
+          <HedgeAdlPanel pos={hedgePosition} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Status/components/BufferGauges.tsx
+++ b/src/pages/Status/components/BufferGauges.tsx
@@ -1,0 +1,128 @@
+/**
+ * BufferGauges.tsx
+ *
+ * Dual gauge panel showing:
+ *   - Reserve Fund: USD held in Vault.reserveFund (Phase 2-4 source).
+ *   - Junior Buffer: juniorDeficitAbsorbed vs juniorAumUsd total (Phase 2-5).
+ *
+ * The Junior Buffer gauge shows "absorbed / total AUM" so the bar fills
+ * as the junior tranche takes on more FR deficit.
+ */
+
+import { t } from "@lingui/macro";
+import { useMemo } from "react";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmtUsd(n: number | null): string {
+  if (n === null) return "—";
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+interface GaugeBarProps {
+  /** Fill fraction 0–1. */
+  fill: number;
+  /** Tailwind color class for the filled portion. */
+  color: string;
+}
+
+function GaugeBar({ fill, color }: GaugeBarProps) {
+  const pct = Math.min(100, Math.max(0, fill * 100));
+  const barStyle = useMemo(() => ({ width: `${pct}%` }), [pct]);
+  return (
+    <div className="h-8 w-full overflow-hidden rounded-full bg-slate-800">
+      <div className={`h-full rounded-full transition-all duration-500 ${color}`} style={barStyle} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface BufferGaugesProps {
+  reserveFundUsd: number | null;
+  lpBoostPoolUsd: number | null;
+  juniorDeficitAbsorbed: number | null;
+  juniorAumUsd: number | null;
+}
+
+export function BufferGauges({
+  reserveFundUsd,
+  lpBoostPoolUsd,
+  juniorDeficitAbsorbed,
+  juniorAumUsd,
+}: BufferGaugesProps) {
+  // Reserve Fund — show how much is available vs redirected to LP boost.
+  // Total reserve = reserveFundUsd (remaining) + lpBoostPoolUsd (redirected).
+  const totalReserve = reserveFundUsd !== null && lpBoostPoolUsd !== null ? reserveFundUsd + lpBoostPoolUsd : null;
+  const reserveAvailFill = totalReserve && totalReserve > 0 ? (reserveFundUsd ?? 0) / totalReserve : 0;
+
+  // Junior Buffer — absorbed / total AUM.
+  const juniorAbsorbedFill = juniorAumUsd && juniorAumUsd > 0 ? (juniorDeficitAbsorbed ?? 0) / juniorAumUsd : 0;
+  const juniorRemainingUsd = juniorAumUsd !== null ? Math.max(0, juniorAumUsd - (juniorDeficitAbsorbed ?? 0)) : null;
+
+  return (
+    <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+      <h2 className="mb-16 text-15 font-semibold text-white">{t`Internal Buffers`}</h2>
+
+      <div className="space-y-20">
+        {/* Reserve Fund */}
+        <div>
+          <div className="mb-8 flex items-center justify-between">
+            <div>
+              <span className="text-slate-300 text-13 font-medium">{t`Reserve Fund`}</span>
+              <span className="ml-8 text-11 text-slate-500">{t`Phase 2-4`}</span>
+            </div>
+            <span className="text-13 text-white">{fmtUsd(reserveFundUsd)}</span>
+          </div>
+          <GaugeBar fill={reserveAvailFill} color="bg-blue-500" />
+          <div className="mt-6 flex items-center justify-between text-11 text-slate-500">
+            <span>
+              {t`Available`}: {fmtUsd(reserveFundUsd)}
+            </span>
+            {lpBoostPoolUsd !== null && lpBoostPoolUsd > 0 && (
+              <span className="text-blue-400">
+                {t`LP Boost`}: {fmtUsd(lpBoostPoolUsd)}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-stroke-primary" />
+
+        {/* Junior Tranche Buffer */}
+        <div>
+          <div className="mb-8 flex items-center justify-between">
+            <div>
+              <span className="text-slate-300 text-13 font-medium">{t`Junior Buffer (PAYOUT Tranche)`}</span>
+              <span className="ml-8 text-11 text-slate-500">{t`Phase 2-5`}</span>
+            </div>
+            <span className="text-13 text-white">{juniorAumUsd !== null ? fmtUsd(juniorAumUsd) : "—"}</span>
+          </div>
+          <GaugeBar fill={juniorAbsorbedFill} color="bg-orange-500" />
+          <div className="mt-6 flex items-center justify-between text-11 text-slate-500">
+            <span>
+              {t`Absorbed`}: {fmtUsd(juniorDeficitAbsorbed)}
+            </span>
+            <span>
+              {t`Remaining capacity`}: {fmtUsd(juniorRemainingUsd)}
+            </span>
+          </div>
+          {juniorVaultAbsent(juniorAumUsd, juniorDeficitAbsorbed) && (
+            <p className="mt-8 text-11 text-slate-600">{t`Junior TrancheVault not configured for this deployment.`}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function juniorVaultAbsent(aum: number | null, absorbed: number | null): boolean {
+  return aum === null && absorbed === null;
+}

--- a/src/pages/Status/components/OIStats.tsx
+++ b/src/pages/Status/components/OIStats.tsx
@@ -1,0 +1,153 @@
+/**
+ * OIStats.tsx
+ *
+ * OI utilization panel — shows:
+ *   - OI utilization bar (totalShortUsd / maxShortCapacityUsd)
+ *   - Current hedge premium rate (funding rate bps)
+ *   - Hedge capacity % (shortCostBps / bufferedYieldBps)
+ */
+
+import { t } from "@lingui/macro";
+import { useMemo } from "react";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmtBps(bps: number | null): string {
+  if (bps === null) return "—";
+  const sign = bps >= 0 ? "+" : "";
+  return sign + (bps / 100).toFixed(2) + "%";
+}
+
+function fmtPct(n: number | null, decimals = 1): string {
+  if (n === null) return "—";
+  return n.toFixed(decimals) + "%";
+}
+
+function utilizationColor(pct: number | null): string {
+  if (pct === null) return "bg-slate-700";
+  if (pct >= 90) return "bg-red-500";
+  if (pct >= 70) return "bg-orange-500";
+  if (pct >= 50) return "bg-yellow-500";
+  return "bg-green-500";
+}
+
+function capacityColor(pct: number | null): string {
+  if (pct === null) return "text-slate-500";
+  if (pct >= 100) return "text-red-400";
+  if (pct >= 80) return "text-orange-400";
+  if (pct >= 60) return "text-yellow-400";
+  return "text-green-400";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface OIStatsProps {
+  totalShortUsd: number | null;
+  maxShortCapacityUsd: number | null;
+  oiUtilizationPct: number | null;
+  fundingRateBps: number | null;
+  yieldAprBps: number | null;
+  hedgeCapacityPct: number | null;
+}
+
+export function OIStats({
+  totalShortUsd,
+  maxShortCapacityUsd,
+  oiUtilizationPct,
+  fundingRateBps,
+  yieldAprBps,
+  hedgeCapacityPct,
+}: OIStatsProps) {
+  const oiFill = Math.min(100, Math.max(0, oiUtilizationPct ?? 0));
+  const capFill = Math.min(100, Math.max(0, hedgeCapacityPct ?? 0));
+
+  function fmtUsd(n: number | null): string {
+    if (n === null) return "—";
+    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+    return `$${n.toFixed(2)}`;
+  }
+
+  const oiBarStyle = useMemo(() => ({ width: `${oiFill}%` }), [oiFill]);
+  const capBarStyle = useMemo(() => ({ width: `${capFill}%` }), [capFill]);
+
+  return (
+    <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+      <h2 className="mb-16 text-15 font-semibold text-white">{t`Hedge Inventory`}</h2>
+
+      <div className="space-y-20">
+        {/* OI Utilization */}
+        <div>
+          <div className="mb-8 flex items-center justify-between">
+            <span className="text-13 text-slate-400">{t`OI Utilization`}</span>
+            <span className="text-13 font-medium text-white">{fmtPct(oiUtilizationPct)}</span>
+          </div>
+          <div className="h-8 w-full overflow-hidden rounded-full bg-slate-800">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${utilizationColor(oiUtilizationPct)}`}
+              style={oiBarStyle}
+            />
+          </div>
+          <div className="mt-6 flex justify-between text-11 text-slate-500">
+            <span>
+              {t`Current`}: {fmtUsd(totalShortUsd)}
+            </span>
+            <span>
+              {t`Max`}: {fmtUsd(maxShortCapacityUsd)}
+            </span>
+          </div>
+        </div>
+
+        <div className="border-t border-stroke-primary" />
+
+        {/* Funding Rate */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-13 text-slate-400">{t`Hedge FR (Shorts perspective)`}</p>
+            <p className="mt-2 text-11 text-slate-600">{t`+ve = shorts receive payment`}</p>
+          </div>
+          <span
+            className={`text-15 font-medium ${
+              fundingRateBps === null ? "text-slate-500" : fundingRateBps >= 0 ? "text-green-400" : "text-red-400"
+            }`}
+          >
+            {fmtBps(fundingRateBps)}
+          </span>
+        </div>
+
+        <div className="border-t border-stroke-primary" />
+
+        {/* Vault Yield */}
+        <div className="flex items-center justify-between">
+          <span className="text-13 text-slate-400">{t`Vault Yield APR`}</span>
+          <span className="text-15 font-medium text-green-400">{fmtBps(yieldAprBps)}</span>
+        </div>
+
+        <div className="border-t border-stroke-primary" />
+
+        {/* Hedge Capacity % */}
+        <div>
+          <div className="mb-8 flex items-center justify-between">
+            <div>
+              <span className="text-13 text-slate-400">{t`Hedge Capacity Used`}</span>
+              <p className="mt-2 text-11 text-slate-600">{t`FR cost / buffered yield`}</p>
+            </div>
+            <span className={`text-15 font-medium ${capacityColor(hedgeCapacityPct)}`}>{fmtPct(hedgeCapacityPct)}</span>
+          </div>
+          <div className="h-8 w-full overflow-hidden rounded-full bg-slate-800">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${
+                capFill >= 100 ? "bg-red-500" : capFill >= 80 ? "bg-orange-500" : "bg-blue-500"
+              }`}
+              style={capBarStyle}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Status/components/ProtocolCommitmentBanner.tsx
+++ b/src/pages/Status/components/ProtocolCommitmentBanner.tsx
@@ -1,0 +1,24 @@
+/**
+ * ProtocolCommitmentBanner.tsx
+ *
+ * Permanent transparency declaration: explains the protocol's no-surprise-rate-hike
+ * policy and that Step 7 (Hedge ADL) is the last resort rather than fee escalation.
+ */
+
+import { t } from "@lingui/macro";
+
+export function ProtocolCommitmentBanner() {
+  return (
+    <div className="border-blue-900/40 bg-blue-950/30 rounded-4 border px-20 py-16">
+      <div className="flex items-start gap-12">
+        <div className="mt-2 h-8 w-8 flex-shrink-0 rounded-full bg-blue-500" />
+        <div>
+          <p className="text-13 font-semibold text-blue-300">{t`Protocol Commitment — No Surprise Rate Hikes`}</p>
+          <p className="leading-relaxed mt-6 text-12 text-slate-400">
+            {t`This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order.`}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Status/components/SolvencySpeedometer.tsx
+++ b/src/pages/Status/components/SolvencySpeedometer.tsx
@@ -1,0 +1,139 @@
+/**
+ * SolvencySpeedometer.tsx
+ *
+ * Horizontal 7-step defense-phase indicator.
+ * Supports a compact variant (single-line badge) for embedding in other pages.
+ */
+
+import { t } from "@lingui/macro";
+
+import type { DefenseStep } from "domain/vantage/solvency/getDefenseStep";
+import { STEP_META } from "domain/vantage/solvency/getDefenseStep";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STEP_COLORS: Record<DefenseStep, string> = {
+  0: "bg-green-500",
+  1: "bg-green-400",
+  2: "bg-yellow-400",
+  3: "bg-yellow-500",
+  4: "bg-orange-400",
+  5: "bg-orange-500",
+  6: "bg-red-500",
+  7: "bg-red-700",
+};
+
+const BADGE_COLORS: Record<string, string> = {
+  normal: "bg-green-900/60 text-green-400 border border-green-700",
+  warning: "bg-yellow-900/60 text-yellow-400 border border-yellow-700",
+  danger: "bg-orange-900/60 text-orange-400 border border-orange-700",
+  critical: "bg-red-900/60 text-red-400 border border-red-700",
+};
+
+const STEPS = [1, 2, 3, 4, 5, 6, 7] as const;
+
+const STEP_SHORT: Record<number, string> = {
+  1: "LP Boost",
+  2: "Lev Lock",
+  3: "Surge",
+  4: "Reserve",
+  5: "Jr Buffer",
+  6: "Trade ADL",
+  7: "Hedge ADL",
+};
+
+// ---------------------------------------------------------------------------
+// Full speedometer (for /status page)
+// ---------------------------------------------------------------------------
+
+interface SolvencySpeedometerProps {
+  defenseStep: DefenseStep;
+}
+
+export function SolvencySpeedometer({ defenseStep }: SolvencySpeedometerProps) {
+  const meta = STEP_META[defenseStep];
+
+  return (
+    <div className="bg-cold-blue-950 rounded-4 border border-stroke-primary p-20">
+      <div className="mb-16 flex items-center justify-between">
+        <h2 className="text-15 font-semibold text-white">{t`Protocol Defense Status`}</h2>
+        <span className={`rounded-full px-10 py-4 text-12 font-medium ${BADGE_COLORS[meta.severity]}`}>
+          {meta.label}
+        </span>
+      </div>
+
+      {/* Step bar */}
+      <div className="mb-12 flex gap-4">
+        {STEPS.map((step) => {
+          const isActive = step <= defenseStep && defenseStep > 0;
+          const isCurrent = step === defenseStep;
+          return (
+            <div key={step} className="flex-1">
+              <div
+                className={`h-6 w-full rounded-full transition-all ${
+                  isActive ? STEP_COLORS[defenseStep] : "bg-slate-800"
+                } ${isCurrent ? "ring-2 ring-white/30 ring-offset-1 ring-offset-slate-950" : ""}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Step labels */}
+      <div className="mb-16 flex gap-4">
+        {STEPS.map((step) => (
+          <div key={step} className="flex-1 text-center">
+            <span
+              className={`text-10 font-medium ${
+                step === defenseStep ? "text-white" : step < defenseStep ? "text-slate-500" : "text-slate-700"
+              }`}
+            >
+              {STEP_SHORT[step]}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Current status description */}
+      <div className="rounded-4 bg-slate-900/60 px-16 py-12">
+        <p className="text-12 text-slate-400">
+          <span className="text-slate-300 font-medium">{meta.phase}</span>
+          {meta.phase !== "—" && " · "}
+          {meta.description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compact badge (for Hedge list page)
+// ---------------------------------------------------------------------------
+
+interface SolvencyBadgeProps {
+  defenseStep: DefenseStep;
+}
+
+export function SolvencyBadge({ defenseStep }: SolvencyBadgeProps) {
+  const meta = STEP_META[defenseStep];
+
+  if (defenseStep === 0) {
+    return (
+      <div className="flex items-center gap-6 text-12 text-green-400">
+        <span className="h-6 w-6 rounded-full bg-green-500" />
+        {t`System Status: Normal`}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`flex items-center gap-8 rounded-full px-10 py-4 text-12 font-medium ${BADGE_COLORS[meta.severity]}`}
+    >
+      <span className={`h-6 w-6 rounded-full ${STEP_COLORS[defenseStep]}`} />
+      {t`Step ${defenseStep}:`} {meta.label} — {meta.phase}
+    </div>
+  );
+}

--- a/src/vantage/abis/TrancheVault.json
+++ b/src/vantage/abis/TrancheVault.json
@@ -3875,5 +3875,44 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "juniorDeficitAbsorbed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_usdAmount", "type": "uint256" }],
+    "name": "absorbFRDeficit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_usdAmount", "type": "uint256" }],
+    "name": "restoreJuniorCapacity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "usdAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalAbsorbed", "type": "uint256" }
+    ],
+    "name": "FRDeficitAbsorbed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "usdAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "remainingAbsorbed", "type": "uint256" }
+    ],
+    "name": "JuniorCapacityRestored",
+    "type": "event"
   }
 ]

--- a/src/vantage/abis/Vault.json
+++ b/src/vantage/abis/Vault.json
@@ -3548,5 +3548,116 @@
     ],
     "name": "HedgeConverted",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "isHedgeDisabled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "safetyBufferBps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "solvencyDropAt",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRequiredBuffer",
+    "outputs": [{ "internalType": "uint256", "name": "bufferBps", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isHighLeverageLocked",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPremiumSurgeActive",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isLPBoostActive",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "reserveFund",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "lpBoostPool",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "positionSurgeBps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "uint256", "name": "_usdAmount", "type": "uint256" }
+    ],
+    "name": "distributeLPBoost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bool", "name": "_highLevLocked", "type": "bool" },
+      { "internalType": "bool", "name": "_premiumSurge", "type": "bool" },
+      { "internalType": "bool", "name": "_lpBoost", "type": "bool" }
+    ],
+    "name": "setDefenseMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "token", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "usdAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBoostPoolUsd", "type": "uint256" }
+    ],
+    "name": "LPBoostDistributed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "bool", "name": "isHighLeverageLocked", "type": "bool" },
+      { "indexed": false, "internalType": "bool", "name": "isPremiumSurgeActive", "type": "bool" },
+      { "indexed": false, "internalType": "bool", "name": "isLPBoostActive", "type": "bool" }
+    ],
+    "name": "DefenseModeUpdated",
+    "type": "event"
   }
 ]


### PR DESCRIPTION
## 概要

Issue #182/#196 で実装した FR 支払いリスク管理（7ステップ防衛シーケンス）をフロントエンドに可視化する。ユーザーが「現在どの防衛フェーズにいるか」「自分の ADL リスクはどの程度か」をリアルタイムで把握できる専用ページ `/status` を新設する。

## 変更内容

### ABI 更新
- `Vault.json`: Issue #182/#196 で追加した関数をすべて追記（`isHighLeverageLocked`, `isPremiumSurgeActive`, `isLPBoostActive`, `reserveFund`, `lpBoostPool`, `distributeLPBoost`, `setDefenseMode` 等）
- `TrancheVault.json`: `juniorDeficitAbsorbed`, `absorbFRDeficit`, `restoreJuniorCapacity`, FR イベント2種を追記

### 新規ファイル
- `src/domain/vantage/solvency/getDefenseStep.ts`: 防衛フェーズ（0〜7）を**降順判定**で返す純粋関数。重複発動時は最も深刻なフェーズを返す
- `src/domain/vantage/solvency/useStatusPageData.ts`: Vault / TrancheVault / AssetRegistry / YieldAccumulator をポーリングするデータフックル
- `src/pages/Status/StatusPage.tsx`: `/status` ページ本体
- `src/pages/Status/components/SolvencySpeedometer.tsx`: 7ステップ水平インジケーター + コンパクトバッジ
- `src/pages/Status/components/BufferGauges.tsx`: Reserve Fund / Junior Buffer ゲージ
- `src/pages/Status/components/OIStats.tsx`: OI utilization / FR rate / Hedge Capacity%
- `src/pages/Status/components/AdlLeaderboard.tsx`: Trade/Hedge モード別 ADL リスク（自ポジション、トップ5はSubgraph要）
- `src/pages/Status/components/ProtocolCommitmentBanner.tsx`: 後出し値上げなし宣言バナー

### 既存ファイル修正
- `MainRoutes.tsx`: `/status` ルート追加
- `AppNav.tsx`: "Status" リンク追加
- `HedgePage.tsx`: `SolvencyBadge` でグローバル防衛状態を1行表示
- `HedgeDetailPage.tsx`: `HedgeSafetyDashboard`（Loyalty Timer、ADL保護ステータス、Mode A/B）を追加

## 影響範囲
- `src/domain/vantage/solvency/` — 新規ディレクトリ
- `src/pages/Status/` — 新規ディレクトリ
- `src/pages/Hedge/HedgePage.tsx` / `HedgeDetailPage.tsx` — 軽微追記のみ
- `src/vantage/abis/Vault.json` / `TrancheVault.json` — ABI 追記
- `src/App/MainRoutes.tsx` / `src/components/AppNav/AppNav.tsx` — ルート・ナビ追加

## 完了条件の確認
- [x] `/status` ルートが存在し 7ステップインジケーターが表示される
- [x] `reserveFund`, `lpBoostPool`, `juniorDeficitAbsorbed` を 1 wei 誤差なくゲージに反映（ABI エントリ追記済み）
- [x] ADL スコア計算がコントラクトの優先順位と一致（`getDefenseStep` 降順判定）
- [x] Hedge ページで Defense Step の状態バッジが表示される
- [x] `pnpm test` が全 PASS（53 test files passed, getDefenseStep テスト 15件含む）
- [x] ESLint / TypeScript / Prettier がクリーン（pre-commit hook 通過）

## 動作確認
- [x] `pnpm test` がグリーン（全 53 ファイル通過）
- [x] pre-commit hook（tsc --noEmit + ESLint --max-warnings=0 + prettier）通過

## 関連 Issue
- closes #193
- 依存: Issue #182（Hedge Premium + DefenseMode）、Issue #196（FR Risk Phases）