### PR TITLE
feat(issue-201): Auto Mode A/B Display from AssetRegistry in HedgeDetailPage

### DIFF
--- a/src/domain/vantage/hedge/useHedgePageData.ts
+++ b/src/domain/vantage/hedge/useHedgePageData.ts
@@ -53,6 +53,13 @@ export interface UserPosition {
 }
 
 export interface HedgePageData {
+  /**
+   * Whether the collateral token is YIELD_BEARING in AssetRegistry (Issue #201).
+   * true  → Mode A: yield earned offsets hedge premium (show "Yield + Premium Offset" UI)
+   * false → Mode B: premium-only cost (show "Premium Only" UI)
+   * undefined → loading (assetType not yet fetched)
+   */
+  isYieldBearing: boolean | undefined;
   /** Vault total AUM in USD (WAD) */
   vaultAumUsd: number | null;
   /** Total open short size for this token in USD */
@@ -105,6 +112,7 @@ export interface HedgePageData {
 }
 
 const EMPTY: HedgePageData = {
+  isYieldBearing: undefined,
   vaultAumUsd: null,
   totalShortUsd: null,
   maxShortCapacityUsd: null,
@@ -162,15 +170,18 @@ export function useHedgePageData(
         const totalLongRaw: bigint = await vault.totalLongSize(tokenAddr);
         const totalShortUsd = parseFloat(formatEther(totalShortRaw));
 
-        // ── 3. Max short capacity from AssetRegistry ────────────────────────
+        // ── 3. Max short capacity + assetType from AssetRegistry ───────────
         let maxShortCapacityUsd: number | null = null;
         let remainingCapacityUsd: number | null = null;
+        let isYieldBearing: boolean | undefined = undefined;
         if (assetReg) {
           const assetData = await assetReg.assets(tokenAddr);
           // maxGlobalShortSize is stored in 1e30; divide by 1e12 to get WAD
           const maxShortWad: bigint = BigInt(assetData.maxGlobalShortSize) / 10n ** 12n;
           maxShortCapacityUsd = parseFloat(formatEther(maxShortWad));
           remainingCapacityUsd = Math.max(0, maxShortCapacityUsd - totalShortUsd);
+          // AssetType: 0 = SPOT (Mode B), 1 = YIELD_BEARING (Mode A)
+          isYieldBearing = Number(assetData.assetType) === 1;
         }
 
         // ── 4. Yield APR ────────────────────────────────────────────────────
@@ -276,6 +287,7 @@ export function useHedgePageData(
 
         if (!cancelled) {
           setData({
+            isYieldBearing,
             vaultAumUsd,
             totalShortUsd,
             maxShortCapacityUsd,

--- a/src/domain/vantage/solvency/getDefenseStep.ts
+++ b/src/domain/vantage/solvency/getDefenseStep.ts
@@ -17,7 +17,7 @@
  * the most critical phase even when multiple phases overlap.
  */
 
-export type DefenseStep = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+export type DefenseStep = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
 export interface DefenseStepInput {
   isLPBoostActive: boolean;
@@ -142,6 +142,18 @@ export const STEP_META: Record<DefenseStep, StepMeta> = {
     severity: "danger",
   },
   7: {
+    label: "Hedge ADL",
+    phase: "Phase 3 · Final Defense",
+    description: "Some hedge positions being force-closed. Protocol exercising last-resort termination.",
+    severity: "critical",
+  },
+  8: {
+    label: "Trade ADL",
+    phase: "Phase 3 · Enforcement",
+    description: "High-profit long positions being force-closed to reduce FR obligations.",
+    severity: "danger",
+  },
+  9: {
     label: "Hedge ADL",
     phase: "Phase 3 · Final Defense",
     description: "Some hedge positions being force-closed. Protocol exercising last-resort termination.",

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -316,10 +316,6 @@ msgstr "Virtueller Bestand für Positionen"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "Verteilt Liquidität dynamisch auf die am stärksten genutzten Märkte und maximiert so Kapitaleffizienz und Rendite"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "Doppeltes {indexSymbol}-Exposure durch Position und Sicherheit. Höherer
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "GMX Account Guthaben"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "Positionen"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "Anreize, Airdrops und Preise werden hier angezeigt"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "GMX auf zentralen Börsen kaufen"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "Für Rückfragen teilen"
@@ -906,6 +914,10 @@ msgstr "Die Website ist eine von der Community bereitgestellte Instanz des Open-
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "Gesamter PnL (realisiert + unrealisiert) nach Gebühren und Preiseinfluss"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "Finanzierungsabnahmefaktor"
@@ -921,6 +933,10 @@ msgstr "In Liquidität"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "Gebührenwerte werden bei Erhalt berechnet. Ohne Anreize."
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL in Vaults und Pools"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "MARKT"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "Aktiver Empfehlungscode"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "One-Click-Trading ist deaktiviert. Zeitlimit abgelaufen."
 msgid "Session generation failed"
 msgstr "Sitzungserstellung fehlgeschlagen"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "Onchain-Quests und Belohnungen"
@@ -1858,10 +1891,6 @@ msgstr "Fehlgeschlagen"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "Die Tauschliquidität kann bei Auslösung der Order unzureichend sein"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "Schlüssel"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "Verteilungen"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (Chinesisch)"
 msgid "Search"
 msgstr "Suchen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "Bestehende Position im WETH-USDC Pool, aber unzureichende Liquidität für diese Order"
@@ -2409,6 +2447,10 @@ msgstr "Gebühren für die Vergangenheit"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "Maximales Open Interest {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "Open-Interest-Reservefaktor Longs"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Layer 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade (ehemals GMX Solana) wird auf einer anderen Website gehostet und
 msgid "Token categories"
 msgstr "Tokenkategorien"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "Sie haben im ausgewählten Zeitraum nicht gehandelt"
@@ -3169,6 +3223,10 @@ msgstr "Ungültige Verringerungsgröße"
 msgid "It's just a wrap"
 msgstr "Es ist nur ein Wrap"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Abonnieren"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "Dune Analytics für GMX"
 msgid "Pending borrowing fees from all open positions"
 msgstr "Ausstehende Leihgebühren aus allen offenen Positionen"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "Marktgraph"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "Nur Buchstaben, Zahlen und Unterstriche erlaubt"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Solana-Unterstützung</0><1>Botanix-Unterstützung</1><2>GMX Express<
 msgid "Funds are now in your GMX Account"
 msgstr "Die Mittel befinden sich jetzt in Ihrem GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "Unzureichende Liquidität. Die Order wird ausgeführt, sobald Liquidität verfügbar ist."
@@ -3945,6 +4011,10 @@ msgstr "Min. Sicherheitsfaktor OI Short"
 msgid "Failed TWAP Swap part"
 msgstr "Fehlgeschlagener TWAP-Tauschteil"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "Annualisierte Daten basierend auf den letzten 7 Tagen"
@@ -4002,6 +4072,10 @@ msgstr "Handeln Sie in großem Umfang, ohne sich über dünne Orderbücher oder 
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading ist mit dem nativen Token des Netzwerks {0} nicht verfügbar. Erwägen Sie stattdessen die Verwendung von {1}."
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "GMX-Feedback teilen"
 msgid "Withdraw failed"
 msgstr "Abhebung fehlgeschlagen"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "Regeln lesen"
 msgid "Source chain supports single token only"
 msgstr "Quellchain unterstützt nur einzelne Token"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "Fehlende Beanspruchungsparameter. Versuchen Sie es in wenigen Sekunden e
 msgid "AVG. LEV."
 msgstr "DURCHSCHN. HEB."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "Gib ein neues Verhältnis oder zulässiges Slippage ein"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "Marktdaten werden geladen..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "{longOrShort}-Positionen zahlen weder eine Finanzierungsgebühr noch eine Leihgebühr"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "in {0}"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Preiseinflussrückvergütungen aufgelaufen. Nach 5 Tagen beanspruchbar. <0>Mehr erfahren</0>."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "{0} bearbeiten"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Kaufe</0> {wrappedNativeTokenSymbol}."
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "Rückvergütungsverteilungsverlauf"
 msgid "Active orders"
 msgstr "Aktive Orders"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Einzahlungen auf Avalanche sind deaktiviert. Handeln Sie direkt über Ihr Avalanche-Wallet."
@@ -4931,10 +5035,6 @@ msgstr "Markt auswählen"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "Keine Tokens passen"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "Externe Swaps fehlschlagen lassen"
 msgid "Withdraw"
 msgstr "Abheben"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "Stop Market aktualisieren"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "Shift-Anfrage gesendet"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "Positive Finanzierungsgebühren"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "Das Guthaben wird in Kürze in Ihrem GMX Account erscheinen"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "Bestehende Limitorder im WETH-USDC Pool.<0>Zum WETH-USDC Pool wechseln</
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "Maximaler Long-USD-Betrag des Pools für Einzahlung"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Verschiebung nur verfügbar auf {chainNames} oder {lastChainName}. Wechseln Sie das Netzwerk, um fortzufahren."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "Kein Tauschpfad verfügbar. <0>Tausche {0} zu {swapToTokenSymbol}</0>, dann zu {1}."
@@ -5938,6 +6074,11 @@ msgstr "AUSFÜHRUNGSPREIS"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "Ladeanimation"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "Anzahl der Teile"
 msgid "No open orders"
 msgstr "Keine offenen Orders"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "Unzureichende Liquidität. Verfügbar: {availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "Airdrop"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "App starten"
@@ -6420,10 +6569,6 @@ msgstr "{gasPaymentTokensText} einzahlen"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portugiesisch)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "Position wäre liquidierbar"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "Medienpaket"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "Hoher Hebel erhöht das Liquidationsrisiko"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "Ungültige Signatur.<0/><1/>Versuchen Sie einen anderen Wallet-Anbieter oder wechseln Sie zu Classic Trading oder One-Click Trading in den <2>Einstellungen</2>"
@@ -7835,6 +7982,12 @@ msgstr "Zusammenfassung"
 msgid "ENTRY PRICE"
 msgstr "EINSTIEGSPREIS"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "PnL nach Gebühren anzeigen"
@@ -7874,10 +8027,6 @@ msgstr "Positionsgebührenfaktor (negativer PI)"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90T"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "Maximalbetrag überschritten"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "Limit-Erhöhung"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "Übertragung läuft..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "Nicht gestakt"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Benachrichtigungen"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "Protokoll-Analytik"
 msgid "Show positions on chart"
 msgstr "Positionen im Chart anzeigen"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "Erhalten"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "Anzahl der Trader, die Ihren Empfehlungscode verwenden"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "Max. reserviert {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "GMX-Belohnungen:"
 msgid "Wallet trading only on these networks"
 msgstr "Nur Wallet-Trading auf diesen Netzwerken"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "Auslösepreis"
@@ -9714,6 +9880,10 @@ msgstr "Keine Quell-Token-Adresse"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "Großes Konto"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "{0} Token für Vesting reserviert"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "Die Position kann allein durch Gebühren (Finanzierung + Leihgebühren) 
 msgid "Claim price impact rebates"
 msgstr "Preiseinfluss-Rabatte beanspruchen"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "Shift-Anfrage wird ausgeführt…"
@@ -10712,6 +10882,10 @@ msgstr "Erhalten Sie Benachrichtigungen und Ankündigungen von GMX, um über Ihr
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} erfolgreich gekauft, aber die Bridge zu Base ist fehlgeschlagen. Ihre Mittel sind sicher in Ihrem GMX Account. Versuchen Sie die Bridge erneut oder gehen Sie zum {indexName}-Pool, um Ihre GM-Token abzuheben."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) ist die verbesserte Version von GLP in GMX V2. Es ist ein renditeoptimierender Kryptoindextoken, der:"
@@ -10724,10 +10898,6 @@ msgstr "{0} Token wurden aus den {1} für das Vesting eingezahlten esGMX in GMX 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Auslösepreis über dem Liquidationspreis"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "Seite neu laden"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "Order wird nicht ausgeführt: Auslösepreis jenseits des Liquidationspreises"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "Abrechnung..."
@@ -11042,6 +11216,10 @@ msgstr "Finanzierungsgebühren beanspruchen"
 msgid "Token permit testing"
 msgstr "Token-Permit-Tests"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "GMX direkt kaufen"
@@ -11097,10 +11275,6 @@ msgstr "Empfehlungscode aktualisiert"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "um die Filterung umzuschalten. Um dieses Debug-Tool für Tauschen zu verwenden, bleiben Sie auf dem MARKET GRAPH Tab und wechseln Sie zu Tauschen. Einstellungen werden im lokalen Speicher gespeichert; vergessen Sie nicht, diesen nach Abschluss zu leeren."
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "Kaufen Sie APE auf Arbitrum mit <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Wird eingezahlt…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "Adresse kopiert"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>Delegiere deine nicht delegierte {0} GMX DAO</0> Stimmkraft vor dem Beanspruchen."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "Mittel einlösen"
@@ -11208,6 +11387,7 @@ msgstr "Empfehlungscode generieren"
 msgid "NET VALUE"
 msgstr "NETTOWERT"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "EREIGNIS"
 msgid "Distribution"
 msgstr "Verteilung"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}s"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 Aktionen"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "Dashboards"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "Verbleibendes Kollateral unter {0} USD"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "Guthaben wird übertragen nach..."
 msgid "Network fee"
 msgstr "Netzwerkgebühr"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "Deaktiviert"
@@ -12053,10 +12230,6 @@ msgstr "Geben Sie einen Empfehlungscode ein, um Gebührenrabatte zu erhalten"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -316,10 +316,6 @@ msgstr "Virtual inventory for positions"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr "FR Risk Defense — How it works"
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "Double {indexSymbol} exposure from position and collateral. Higher liqui
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "GMX Account balance"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "Positions"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "Incentives, airdrops, and prizes will appear here"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr "Reserve Fund Utilization"
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "Buy GMX on centralized exchanges"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr "New Entry Restriction"
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "Share for follow-up questions"
@@ -906,6 +914,10 @@ msgstr "The website is a community-deployed instance of the open source <0>GMX f
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "Total PnL (realized + unrealized) after fees and price impact"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr "Mode A — Yield-Bearing"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "Funding decrease factor"
@@ -922,6 +934,10 @@ msgstr "in liquidity"
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
 msgstr "システム収益保護のため、現在一時的にFR相殺が停止されています"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
+msgstr "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
@@ -1016,6 +1032,14 @@ msgstr "Fee values calculated when earned. Excludes incentives."
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL in vaults and pools"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr "Mode B — Stablecoin"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "MARKET"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "Active referral code"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr "Steps 1–3"
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "One-Click Trading is disabled. Time limit expired."
 msgid "Session generation failed"
 msgstr "Session generation failed"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr "Phase 2 · Internal Buffer"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "Onchain quests and rewards"
@@ -1858,10 +1891,6 @@ msgstr "Failed"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr "Protocol Commitment — No Surprise Rate Hikes"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr "Restricted (weekend)"
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "Swap liquidity may be insufficient when order triggers"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr "Reserve Fund"
 
@@ -1997,6 +2027,10 @@ msgstr "Key"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "Distributions"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr "Senior LP yield will be used to make FR payments"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (Chinese)"
 msgid "Search"
 msgstr "Search"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr "Mode B — Premium Only"
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "Existing position in WETH-USDC pool but lacks liquidity for this order"
@@ -2409,6 +2447,10 @@ msgstr "Fees for the past"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "Max open interest {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr "No yield earned. Hedge cost = funding rate only."
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2507,6 +2549,10 @@ msgstr "How do I choose?"
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
 msgstr "Consider reducing leverage to lower your ADL priority."
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
+msgstr "Select your preferred language"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "LP Deposit + Short in one transaction"
@@ -2646,6 +2692,10 @@ msgstr "Open interest reserve factor longs"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Layer 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr "Normal Operation"
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade (previously GMX Solana) is hosted on another website and run by 
 msgid "Token categories"
 msgstr "Token categories"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr "Normal"
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "You have not traded during the selected period"
@@ -3169,6 +3223,10 @@ msgstr "Invalid decrease size"
 msgid "It's just a wrap"
 msgstr "It's just a wrap"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr "High-Lev Lock"
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Subscribe"
@@ -3348,10 +3406,6 @@ msgstr "Transaction submitted"
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr "Ask"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr "Position is kept as a normal short. Funding rate payments apply from ADL moment."
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "Dune Analytics for GMX"
 msgid "Pending borrowing fees from all open positions"
 msgstr "Pending borrowing fees from all open positions"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr "Surge"
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr "Set Long Take Profit @ {0}"
@@ -3644,6 +3702,10 @@ msgstr "Market graph"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "Only letters, numbers, and underscores allowed"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr "Real-time solvency dashboard. 8-step defense sequence transparency."
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Solana support</0><1>Botanix support</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "Funds are now in your GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr "Junior Vault Buffer"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "Insufficient liquidity. Order will fill when liquidity is available."
@@ -3945,6 +4011,10 @@ msgstr "Min collateral factor OI short"
 msgid "Failed TWAP Swap part"
 msgstr "Failed TWAP Swap part"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr "Phase 1 — Prevention"
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "Annualized data based on the past 7 days"
@@ -4003,6 +4073,10 @@ msgstr "Trade at scale without worrying about thin order books or slippage"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
 msgstr "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
+msgstr "Your staking yield offsets the hedge premium. Net cost may be positive."
 
 #: src/components/Claims/SettleAccruedCard.tsx
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading is unavailable with the network's native token {0}. Consider using {1} instead."
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,9 +4372,19 @@ msgstr "Share GMX feedback"
 msgid "Withdraw failed"
 msgstr "Withdraw failed"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr "Hedge ADL"
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
 msgstr "Saving…"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
+msgstr "This token earns no yield. Hedge cost = funding rate only."
 
 #. chainname balance
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
@@ -4532,6 +4617,10 @@ msgstr "Read the rules"
 msgid "Source chain supports single token only"
 msgstr "Source chain supports single token only"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "Missing claim parameters. Retry in a few seconds"
 msgid "AVG. LEV."
 msgstr "AVG. LEV."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr "Detecting mode…"
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "Enter a new ratio or allowed slippage"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr "ADL for Hedge-Shorts"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "Loading markets data..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "{longOrShort} positions do not pay a funding fee or a borrow fee"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr "Phase 1 · Prevention"
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "in {0}"
@@ -4799,6 +4902,7 @@ msgstr "Price -20%"
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "Edit {0}"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Buy</0> {wrappedNativeTokenSymbol}."
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "Rebates distribution history"
 msgid "Active orders"
 msgstr "Active orders"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr "Jr Buffer"
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
@@ -4931,10 +5035,6 @@ msgstr "Select a market"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "No tokens matched"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr "Est. USDC received"
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "Fail external swaps"
 msgid "Withdraw"
 msgstr "Withdraw"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr "Phase 0 · Normal"
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "Update Stop Market"
@@ -5218,6 +5326,11 @@ msgstr "+5% Rebase"
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "Shift request sent"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr "Safe"
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "Positive funding fees"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr "Loading…"
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "Funds will appear in your GMX Account soon"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr "Phase 3 · Final Defense"
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr "Senior Yield"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "Pool max long USD for deposit"
@@ -5551,6 +5675,10 @@ msgstr "Vault LP"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
 msgstr "Mode A — Auto-Terminate"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
+msgstr "System working as intended"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5910,6 +6038,14 @@ msgstr "Depositing…"
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr "Supply-Side Incentive"
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
@@ -5938,6 +6074,11 @@ msgstr "EXECUTION PRICE"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "spinner"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr "Phase 3 · Enforcement"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "Number of parts"
 msgid "No open orders"
 msgstr "No open orders"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr "Premium Surge"
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "Insufficient liquidity. Available: {availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr "Balance (LP ↔ Short)"
 msgid "Airdrop"
 msgstr "Airdrop"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr "Steps 7–8"
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "Launch app"
@@ -6420,10 +6569,6 @@ msgstr "Deposit {gasPaymentTokensText}"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portuguese)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr "Oracle Price"
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "Position would be liquidatable"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr "LP Boost"
 
@@ -7075,10 +7222,6 @@ msgstr "LP Boost"
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "Media kit"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr "Exceeds your VLP balance"
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "High leverage increases liquidation risk"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr "Junior Buffer"
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
@@ -7835,6 +7982,12 @@ msgstr "Summary"
 msgid "ENTRY PRICE"
 msgstr "ENTRY PRICE"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr "Trade ADL"
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "Display PnL after fees"
@@ -7874,10 +8027,6 @@ msgstr "Position fee factor (negative PI)"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90d"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr "LP Withdrawal"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7969,6 +8118,10 @@ msgstr "Max amount exceeded"
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
 msgstr "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
+msgstr "Mode A — Yield + Premium Offset"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "You chose to send the remaining collateral to your <0>{chosenLabel}</0>. Do you want to make this the default destination when closing positions?"
@@ -8093,6 +8246,10 @@ msgstr "Limit Increase"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "Transferring..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr "Reserve"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "Not staked"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr "Position is closed and margin is returned when ADL is triggered."
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Notifications"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr "Managed Net APY"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "Protocol analytics"
 msgid "Show positions on chart"
 msgstr "Show positions on chart"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr "Detecting collateral mode…"
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "Receive"
 msgid "Execution Fee"
 msgstr "Execution Fee"
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "Number of traders using your referral code"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "Max reserved {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr "ADL for Long Profits"
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "GMX rewards:"
 msgid "Wallet trading only on these networks"
 msgstr "Wallet trading only on these networks"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "Trigger Price"
@@ -9714,6 +9880,10 @@ msgstr "No from token address"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "Large account"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr "Phase 3 — Last Resort"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "{0} tokens reserved for vesting"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "Something went wrong"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr "FR Offset"
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "Position may liquidate from fees alone (funding + borrowing), reducing c
 msgid "Claim price impact rebates"
 msgstr "Claim price impact rebates"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr "Next redemption:"
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "Fulfilling shift request..."
@@ -10712,6 +10882,10 @@ msgstr "Get alerts and announcements from GMX to stay on top of your trades, liq
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr "Steps 4–5"
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
@@ -10724,10 +10898,6 @@ msgstr "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Trigger price above liquidation price"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr "Self-Custody APY"
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "Reload page"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "Order won't execute: trigger price beyond liquidation price"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr "Phase 2 — Internal Defense"
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "Settling..."
@@ -11042,6 +11216,10 @@ msgstr "Claim funding fees"
 msgid "Token permit testing"
 msgstr "Token permit testing"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr "Lev Lock"
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "Buy GMX directly"
@@ -11097,10 +11275,6 @@ msgstr "Referral code updated"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr "Withdraw VLP"
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "Buy APE on Arbitrum with <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Depositing..."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "Address copied"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr "New Entry Premium Surge"
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "Claim funds"
@@ -11208,6 +11387,7 @@ msgstr "Generate referral code"
 msgid "NET VALUE"
 msgstr "NET VALUE"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "EVENT"
 msgid "Distribution"
 msgstr "Distribution"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}s"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 actions"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11494,10 +11679,6 @@ msgstr "Dashboards"
 msgid "Leftover collateral below {0} USD"
 msgstr "Leftover collateral below {0} USD"
 
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr "{label}"
-
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
 msgstr "trigger"
@@ -11517,10 +11698,6 @@ msgstr "Text colors"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "7d"
 msgstr "7d"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Close (Recommended)"
-#~ msgstr "Close (Recommended)"
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit"
@@ -11842,10 +12019,6 @@ msgstr "Funds bridging to..."
 msgid "Network fee"
 msgstr "Network fee"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr "Real-time solvency dashboard. 7-step defense sequence transparency."
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "Deactivated"
@@ -12057,10 +12230,6 @@ msgstr "Enter a referral code to get fee discounts"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr "Margin Token"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr "Emergency Behavior (ADL)"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -316,10 +316,6 @@ msgstr "Inventario virtual para posiciones"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "Asigna liquidez dinámicamente a los mercados de mayor utilización, maximizando la eficiencia del capital y el rendimiento"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "Doble exposición a {indexSymbol} por posición y garantía. Precio de l
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "Saldo de GMX Account"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "Posiciones"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "Los incentivos, airdrops y premios aparecerán aquí"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "Comprar GMX en exchanges centralizados"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "Compartir para preguntas de seguimiento"
@@ -906,6 +914,10 @@ msgstr "El sitio web es una instancia desplegada por la comunidad del código ab
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "PnL total (realizado + no realizado) después de comisiones e impacto en el precio"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "Factor de disminución de financiación"
@@ -921,6 +933,10 @@ msgstr "en liquidez"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "Valores de comisiones calculados en el momento en que se obtienen. No in
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL en bóvedas y pools"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "MERCADO"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "Código de referido activo"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "Trading en Un Clic desactivado. Límite de tiempo expirado."
 msgid "Session generation failed"
 msgstr "Error en la generación de sesión"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "Misiones y recompensas onchain"
@@ -1858,10 +1891,6 @@ msgstr "Fallida"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "La liquidez de intercambio puede ser insuficiente cuando se active la orden"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "Clave"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "Distribuciones"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (Chino)"
 msgid "Search"
 msgstr "Buscar"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "La posición existente en el pool WETH-USDC carece de liquidez para esta orden"
@@ -2409,6 +2447,10 @@ msgstr "Comisiones para el pasado"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "Interés abierto máximo {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "Factor de reserva de interés abierto largos"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Capa 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade (anteriormente GMX Solana) está alojado en otro sitio web y ges
 msgid "Token categories"
 msgstr "Categorías de tokens"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "No ha operado durante el período seleccionado"
@@ -3169,6 +3223,10 @@ msgstr "Tamaño de reducción no válido"
 msgid "It's just a wrap"
 msgstr "Es solo un wrap"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Suscribirse"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "Dune Analytics para GMX"
 msgid "Pending borrowing fees from all open positions"
 msgstr "Comisiones de préstamo pendientes de todas las posiciones abiertas"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "Gráfico de mercado"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "Solo se permiten letras, números y guiones bajos"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Soporte de Solana</0><1>Soporte de Botanix</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "Los fondos están ahora en su GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "Liquidez insuficiente. La orden se ejecutará cuando haya liquidez disponible."
@@ -3945,6 +4011,10 @@ msgstr "Factor mínimo de garantía OI corto"
 msgid "Failed TWAP Swap part"
 msgstr "Parte de TWAP Swap fallida"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "Datos anualizados basados en los últimos 7 días"
@@ -4002,6 +4072,10 @@ msgstr "Opere a gran escala sin preocuparse por libros de órdenes con poca prof
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading no está disponible con el token nativo de la red {0}. Considere utilizar {1} en su lugar."
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "Compartir opinión sobre GMX"
 msgid "Withdraw failed"
 msgstr "Error en el retiro"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "Lee las reglas"
 msgid "Source chain supports single token only"
 msgstr "La cadena de origen solo admite un único token"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "Faltan parámetros de reclamación. Reintente en unos segundos"
 msgid "AVG. LEV."
 msgstr "APAL. MED."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "Ingresa una nueva proporción o deslizamiento permitido"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "Cargando datos de mercados..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "Las posiciones {longOrShort} no pagan comisión de financiación ni comisión de préstamo"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "en {0}"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Reembolsos por impacto en el precio acumulados. Reclamables después de 5 días. <0>Más información</0>."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "Editar {0}"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Comprar</0> {wrappedNativeTokenSymbol}."
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "Historial de distribución de reembolsos"
 msgid "Active orders"
 msgstr "Órdenes activas"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Los depósitos en Avalanche están desactivados. Opere directamente desde su monedero de Avalanche."
@@ -4931,10 +5035,6 @@ msgstr "Seleccionar un mercado"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "No hay tokens coincidentes"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "Forzar fallo de intercambios externos"
 msgid "Withdraw"
 msgstr "Retirar"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "Actualizar Stop Mercado"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "Solicitud de cambio enviada"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "Comisiones de financiación positivas"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "Los fondos aparecerán pronto en su GMX Account"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "Orden limitada existente en el pool WETH-USDC.<0>Cambiar al pool WETH-US
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "Máximo USD largo del pool para depósito"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Shifting solo disponible en {chainNames} o {lastChainName}. Cambie de red para continuar."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "No hay ruta de intercambio disponible. <0>Intercambiar {0} a {swapToTokenSymbol}</0>, luego a {1}."
@@ -5938,6 +6074,11 @@ msgstr "PRECIO DE EJECUCIÓN"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "indicador de carga"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "Número de partes"
 msgid "No open orders"
 msgstr "No hay órdenes abiertas."
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "Liquidez insuficiente. Disponible: {availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "Airdrop"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "Iniciar aplicación"
@@ -6420,10 +6569,6 @@ msgstr "Depositar {gasPaymentTokensText}"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portugués)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "La posición sería liquidable"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "Kit de medios"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "Un apalancamiento elevado aumenta el riesgo de liquidación"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "Firma no válida.<0/><1/>Pruebe con otro proveedor de monedero o cambie a Classic Trading o One-Click Trading en <2>configuración</2>"
@@ -7835,6 +7982,12 @@ msgstr "Resumen"
 msgid "ENTRY PRICE"
 msgstr "PRECIO DE ENTRADA"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "Mostrar PnL después de comisiones"
@@ -7874,10 +8027,6 @@ msgstr "Factor de comisión de posición (PI negativo)"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90d"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "Superado el importe máximo"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "Aumento Límite"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "Transfiriendo..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "Sin staking"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Notificaciones"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "Análisis de datos del protocolo"
 msgid "Show positions on chart"
 msgstr "Mostrar posiciones en el gráfico"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "Recibir"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "Número de operadores que utilizan su código de referencia"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "Máximo reservado {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "Recompensas GMX:"
 msgid "Wallet trading only on these networks"
 msgstr "Operaciones solo con monedero en estas redes"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "Precio de activación"
@@ -9714,6 +9880,10 @@ msgstr "Sin dirección del token de origen"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "Cuenta grande"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "{0} tokens reservados para el periodo de consolidación"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "Algo ha salido mal"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "La posición podría liquidarse únicamente por comisiones (financiació
 msgid "Claim price impact rebates"
 msgstr "Reclamar reembolsos por impacto en el precio"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "Ejecutando solicitud de cambio…"
@@ -10712,6 +10882,10 @@ msgstr "Reciba alertas y anuncios de GMX para estar al día de sus operaciones, 
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} comprado con éxito, pero el puente a Base ha fallado. Sus fondos están seguros en su GMX Account. Reintente el puente o vaya al pool {indexName} para retirar sus tokens GM."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) es la versión mejorada de GLP en GMX V2. Es un token de criptoíndice que optimiza el rendimiento y que:"
@@ -10724,10 +10898,6 @@ msgstr "{0} tokens convertidos a GMX de los {1} esGMX depositados para el period
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "El precio de activación está por encima del precio de liquidación"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "Recargar página"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "La orden no se ejecutará: el precio de activación supera el precio de liquidación"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "Liquidando..."
@@ -11042,6 +11216,10 @@ msgstr "Reclamar comisiones de financiación"
 msgid "Token permit testing"
 msgstr "Pruebas de permisos de tokens"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "Comprar GMX directamente"
@@ -11097,10 +11275,6 @@ msgstr "Código de referido actualizado"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "para alternar su filtrado. Para utilizar esta herramienta de depuración en intercambio, permanezca en la pestaña MARKET GRAPH y cambie a intercambio. La configuración se guarda en el almacenamiento local; no olvide borrarla cuando termine."
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "Comprar APE en Arbitrum con <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Depositando…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "Dirección copiada"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>Delega tu poder de voto {0} GMX DAO no delegado</0> antes de reclamar."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "Reclamar fondos"
@@ -11208,6 +11387,7 @@ msgstr "Generar código de referido"
 msgid "NET VALUE"
 msgstr "VALOR NETO"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "EVENTO"
 msgid "Distribution"
 msgstr "Distribución"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}s"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "Acciones de GMX V1"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "Paneles"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "Garantía restante por debajo de {0} USD"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "Fondos transfiriéndose a..."
 msgid "Network fee"
 msgstr "Comisión de red"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "Desactivado"
@@ -12053,10 +12230,6 @@ msgstr "Introduzca un código de referido para obtener descuentos en las comisio
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -316,10 +316,6 @@ msgstr "Inventaire virtuel pour les positions"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "Alloue dynamiquement la liquidité aux marchés les plus utilisés, maximisant l'efficacité du capital et le rendement"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "Double exposition {indexSymbol} liée à la position et à la garantie. 
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "Solde du GMX Account"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "Positions"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "Les incitations, airdrops et récompenses apparaîtront ici"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "Acheter des GMX sur des plateformes centralisées"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "Partager pour les questions de suivi"
@@ -906,6 +914,10 @@ msgstr "Le site est une instance déployée par la communauté du <0>front end G
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "PnL total (réalisé + non réalisé) après frais et impact sur le prix"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "Facteur de diminution du financement"
@@ -921,6 +933,10 @@ msgstr "en liquidité"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "Valeurs des frais calculées au moment où ils sont perçus. Hors incita
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL dans les coffres et les pools"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "MARCHÉ"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "Code de parrainage actif"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "Trading en un clic désactivé. Limite de temps expirée."
 msgid "Session generation failed"
 msgstr "Échec de la génération de la session"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "Quêtes et récompenses onchain"
@@ -1858,10 +1891,6 @@ msgstr "Échec"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "La liquidité d'échange peut être insuffisante lorsque l'ordre se déclenche"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "Clé"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "Distributions"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (Chinois)"
 msgid "Search"
 msgstr "Rechercher"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "Position existante dans le pool WETH-USDC mais liquidité insuffisante pour cet ordre"
@@ -2409,6 +2447,10 @@ msgstr "Frais pour le passé"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "Positions ouvertes maximales {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "Facteur de réserve des positions ouvertes longs"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Layer 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade (anciennement GMX Solana) est hébergé sur un autre site web et
 msgid "Token categories"
 msgstr "Catégories de tokens"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "Vous n'avez pas effectué de transactions durant la période sélectionnée"
@@ -3169,6 +3223,10 @@ msgstr "Taille de réduction invalide"
 msgid "It's just a wrap"
 msgstr "C'est un simple wrap"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "S'abonner"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "Analyses Dune pour GMX"
 msgid "Pending borrowing fees from all open positions"
 msgstr "Frais d'emprunt en attente de toutes les positions ouvertes"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "Graphique du marché"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "Seuls les lettres, chiffres et underscores sont autorisés"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Support Solana</0><1>Support Botanix</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "Les fonds sont maintenant dans votre GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "Liquidité insuffisante. L'ordre sera exécuté lorsque la liquidité sera disponible."
@@ -3945,6 +4011,10 @@ msgstr "Facteur de garantie min. OI short"
 msgid "Failed TWAP Swap part"
 msgstr "Partie TWAP Swap échouée"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "Données annualisées basées sur les 7 derniers jours"
@@ -4002,6 +4072,10 @@ msgstr "Tradez à grande échelle sans vous soucier de carnets d'ordres peu prof
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading n'est pas disponible avec le jeton natif du réseau {0}. Envisagez d'utiliser {1} à la place."
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "Partagez votre avis sur GMX"
 msgid "Withdraw failed"
 msgstr "Échec du retrait"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "Lire les règles"
 msgid "Source chain supports single token only"
 msgstr "La chaîne source ne prend en charge qu'un seul jeton"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "Paramètres de réclamation manquants. Réessayez dans quelques secondes
 msgid "AVG. LEV."
 msgstr "LEV. MOY."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "Entrez un nouveau ratio ou glissement autorisé"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "Chargement des données de marché..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "Les positions {longOrShort} ne paient pas de frais de financement ni de frais d'emprunt"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "dans {0}"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Remises sur l'impact sur le prix accumulées. Récupérables après 5 jours. <0>En savoir plus</0>."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "Modifier {0}"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Acheter</0> {wrappedNativeTokenSymbol}."
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "Historique de distribution des remises"
 msgid "Active orders"
 msgstr "Ordres actifs"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Les dépôts vers Avalanche sont désactivés. Effectuez vos transactions directement depuis votre portefeuille Avalanche."
@@ -4931,10 +5035,6 @@ msgstr "Sélectionner un marché"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "Aucun jeton correspondant"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "Forcer l'échec des swaps externes"
 msgid "Withdraw"
 msgstr "Retirer"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "Actualiser Stop Market"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "Demande de transfert envoyée"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "Frais de financement positifs"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "Les fonds apparaîtront bientôt sur votre GMX Account"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "Ordre à cours limité existant dans le pool WETH-USDC.<0>Passer au pool
 msgid "GM: {0}"
 msgstr "GM : {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "Plafond USD long du pool pour les dépôts"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Le shifting est uniquement disponible sur {chainNames} ou {lastChainName}. Changez de réseau pour continuer."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "Aucun chemin d'échange disponible. <0>Échanger {0} contre {swapToTokenSymbol}</0>, puis contre {1}."
@@ -5938,6 +6074,11 @@ msgstr "PRIX D'EXÉCUTION"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "indicateur de chargement"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "Nombre de parties"
 msgid "No open orders"
 msgstr "Aucun ordre ouvert"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "Liquidité insuffisante. Disponible : {availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "Airdrop"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "Lancer l'application"
@@ -6420,10 +6569,6 @@ msgstr "Déposer {gasPaymentTokensText}"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (Portugais)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "La position serait liquidable"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "Kit média"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "Un effet de levier élevé augmente le risque de liquidation"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "Signature invalide.<0/><1/>Essayez un autre fournisseur de portefeuille ou passez à Classic Trading ou One-Click Trading dans les <2>paramètres</2>"
@@ -7835,6 +7982,12 @@ msgstr "Résumé"
 msgid "ENTRY PRICE"
 msgstr "PRIX D'ENTRÉE"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "Afficher le PnL après les frais"
@@ -7874,10 +8027,6 @@ msgstr "Facteur de frais de position (PI négatif)"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90j"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "Montant maximal dépassé"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "Augmentation limite"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "Transfert en cours..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "Non staké"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Notifications"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "Analyses du protocole"
 msgid "Show positions on chart"
 msgstr "Afficher les positions sur le graphique"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "Recevoir"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "Nombre de traders utilisant votre code de parrainage"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "Maximum réservé {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "Récompenses GMX :"
 msgid "Wallet trading only on these networks"
 msgstr "Trading via portefeuille uniquement sur ces réseaux"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "Prix de déclenchement"
@@ -9714,6 +9880,10 @@ msgstr "Aucune adresse de jeton source"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "Compte important"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "{0} jetons réservés pour l'acquisition progressive"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "Une erreur est survenue"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "La position peut être liquidée uniquement par les frais (financement +
 msgid "Claim price impact rebates"
 msgstr "Récupérer les remises d'impact sur le prix"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "Exécution de la demande de transfert…"
@@ -10712,6 +10882,10 @@ msgstr "Recevez des alertes et des annonces de GMX pour suivre vos transactions,
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} acheté avec succès, mais le pont vers Base a échoué. Vos fonds sont en sécurité dans votre GMX Account. Réessayez le pont ou accédez au pool {indexName} pour retirer vos jetons GM."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) est la version améliorée de GLP dans GMX V2. C'est un jeton crypto-indice optimisant le rendement qui :"
@@ -10724,10 +10898,6 @@ msgstr "{0} jetons convertis en GMX à partir des {1} esGMX déposés pour l'acq
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Prix de déclenchement supérieur au prix de liquidation"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "Recharger la page"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "L'ordre ne sera pas exécuté : prix de déclenchement au-delà du prix de liquidation"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "Règlement..."
@@ -11042,6 +11216,10 @@ msgstr "Récupérer les frais de financement"
 msgid "Token permit testing"
 msgstr "Test de permis de jeton"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "Acheter des GMX directement"
@@ -11097,10 +11275,6 @@ msgstr "Code de parrainage mis à jour"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "pour activer/désactiver son filtrage. Pour utiliser cet outil de débogage sur l'échange, restez sur l'onglet MARKET GRAPH et passez à l'échange. Les paramètres sont enregistrés dans le stockage local ; n'oubliez pas de le vider une fois terminé."
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "Acheter APE sur Arbitrum avec <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Dépôt en cours…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "Adresse copiée"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>Déléguez votre pouvoir de vote {0} GMX DAO non délégué</0> avant de réclamer."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "Réclamer des fonds"
@@ -11208,6 +11387,7 @@ msgstr "Générer un code de parrainage"
 msgid "NET VALUE"
 msgstr "VALEUR NETTE"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "ÉVÉNEMENT"
 msgid "Distribution"
 msgstr "Distribution"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}s"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "Actions GMX V1"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "Tableaux de bord"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "Collatéral restant inférieur à {0} USD"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "Transfert des fonds vers..."
 msgid "Network fee"
 msgstr "Frais de réseau"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "Désactivé"
@@ -12053,10 +12230,6 @@ msgstr "Entrez un code de parrainage pour obtenir des réductions sur les frais"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -67,7 +67,7 @@ msgstr "REFERRAL CODE"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Profit Extraction Risk"
-msgstr ""
+msgstr "利益抽出リスク"
 
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing limit order uses {symbol} collateral. <0>Switch to {symbol} collateral</0>"
@@ -236,7 +236,7 @@ msgstr "(リベート済)"
 
 #: src/pages/Trade/components/PriceChart.tsx
 msgid "Hover over the chart to see candle details"
-msgstr ""
+msgstr "チャートにカーソルを合わせてローソク足の詳細を確認"
 
 #: src/components/PositionShare/PositionShare.tsx
 msgid "Show rPnL amounts"
@@ -316,10 +316,6 @@ msgstr "ポジションのバーチャルインベントリ"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "流動性を最も利用率の高いマーケットに動的に配分し、資本効率と利回りを最大化します"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -336,7 +332,7 @@ msgstr "設定"
 #: src/components/TVChartContainer/TVChartContainer.tsx
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Short"
-msgstr ""
+msgstr "ショートを開く"
 
 #: src/components/Claims/ClaimableCard.tsx
 msgid "Price impact rebates ready to claim. <0>Read more</0>."
@@ -461,17 +457,21 @@ msgstr "ポジションと担保による{indexSymbol}の二重エクスポー�
 msgid "GMX Account balance"
 msgstr "GMX Account残高"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr "高利回りジュニアLP（USDC）の利益が赤字を吸収し、シニアLP（RWA）とヘッジユーザーのコストを守ります。"
+
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
 msgstr "最適スワップパス"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Your position carries high leverage with significant profit — among the most likely ADL candidates."
-msgstr ""
+msgstr "このポジションは高レバレッジかつ含み益が大きく、ADL対象の最上位候補です。"
 
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Connect your wallet to see your deposits."
-msgstr ""
+msgstr "ウォレットを接続して預入額を確認してください。"
 
 #: src/components/NpsModal/NpsModal.tsx
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -530,7 +530,7 @@ msgstr "画像の生成に失敗しました。更新して再度お試しくだ
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Loyalty Timer"
-msgstr ""
+msgstr "ロイヤルティタイマー"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Admin Dashboard"
@@ -538,7 +538,7 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Funding"
-msgstr ""
+msgstr "ファンディング"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Unstaking..."
@@ -614,7 +614,7 @@ msgstr "ロングOI"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Net Yield"
-msgstr ""
+msgstr "ネット利回り"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Traders referred on Avalanche"
@@ -644,7 +644,7 @@ msgstr "ADDRESS"
 
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Bid"
-msgstr ""
+msgstr "買値"
 
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Additional opportunities"
@@ -652,7 +652,7 @@ msgstr "追加の機会"
 
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Avg Entry"
-msgstr ""
+msgstr "平均エントリー価格"
 
 #: src/pages/AccountDashboard/HistoricalLists.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -662,6 +662,10 @@ msgstr "ポジション"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "インセンティブ、エアドロップ、賞品はこちらに表示されます"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr "準備基金の活用"
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -698,7 +702,7 @@ msgstr "{0}/USDプールに流動性不足"
 
 #: src/pages/Trade/components/PriceChart.tsx
 msgid "Open"
-msgstr ""
+msgstr "始値"
 
 #: src/pages/Dashboard/StatsCard.tsx
 msgid "Treasury"
@@ -723,7 +727,7 @@ msgstr "..."
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Required Margin (Auto-Calculated)"
-msgstr ""
+msgstr "必要証拠金（自動計算）"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Classic"
@@ -781,7 +785,7 @@ msgstr "手動パスを使用"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode B — Convert to Paid-Short"
-msgstr ""
+msgstr "モードB — 有料ショートに転換"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Longs / shorts"
@@ -841,12 +845,12 @@ msgstr "市場スワップ"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "{ageDays} days"
-msgstr ""
+msgstr "{ageDays} 日"
 
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Loading positions…"
-msgstr ""
+msgstr "ポジションを読み込み中…"
 
 #: src/components/GmList/GmListItem.tsx
 msgid "View details"
@@ -877,7 +881,7 @@ msgstr "無効な担保トークンです。{tokenSymbol}は担保としてサ�
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "No hedgeable vaults configured. Deploy contracts first."
-msgstr ""
+msgstr "ヘッジ可能なVaultが設定されていません。まずコントラクトをデプロイしてください。"
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Lorem ipsum dolor"
@@ -886,6 +890,10 @@ msgstr "Lorem ipsum dolor"
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX on centralized exchanges"
 msgstr "中央集権型取引所でGMXを購入"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr "新規エントリー制限"
 
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
@@ -906,6 +914,10 @@ msgstr "このウェブサイトは、分散型ピアツーピア<1>IPFSネッ�
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "手数料および価格への影響を差し引いた合計PnL（実現 + 未実現）"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "ファンディング減少係数"
@@ -921,15 +933,19 @@ msgstr "流動性で"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
-msgstr ""
+msgstr "システム収益保護のため、現在一時的にFR相殺が停止されています"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
+msgstr "最終防衛ライン。LPの支払い不能とプロトコル停止を防ぐため、一部のヘッジショートが強制クローズ（または有料ショートに転換）されます。コストの遡及引き上げは行いません。"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "You have a shortfall debt of {0}. This will be settled when the insurance fund is sufficient."
-msgstr ""
+msgstr "{0} のショートフォール債務があります。保険基金が十分になり次第、精算されます。"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "Hedge Capacity Used"
-msgstr ""
+msgstr "ヘッジ使用容量"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized money market"
@@ -987,7 +1003,7 @@ msgstr "お取引による価格への影響とフィーの差引額です。<0>
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Hedge Positions"
-msgstr ""
+msgstr "ヘッジポジション"
 
 #: src/domain/synthetics/orders/simulateExecuteTxn.tsx
 msgid "Prices are volatile. <0>Increase allowed slippage</0>"
@@ -1017,9 +1033,17 @@ msgstr "手数料は獲得時に計算されます。インセンティブは含
 msgid "TVL in vaults and pools"
 msgstr "ボールトおよびプール内のTVL"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr "準備基金がLP報酬を一時的に引き上げ、新規RWA預入を誘致してプール容量を拡大します。"
+
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
-msgstr ""
+msgstr "完了を消去"
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -1054,7 +1078,7 @@ msgstr "DeltaPrime"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "h"
-msgstr ""
+msgstr "時"
 
 #: src/pages/LeaderboardPage/components/CompetitionPrizes.tsx
 #: src/pages/LeaderboardPage/components/CompetitionPrizes.tsx
@@ -1063,7 +1087,7 @@ msgstr "1位"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "New hedge positions are temporarily blocked due to the Safety Buffer Lock. Trade mode remains available."
-msgstr ""
+msgstr "セーフティバッファーロックのため、新規ヘッジポジションは一時的にブロックされています。トレードモードは引き続き利用可能です。"
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Caption"
@@ -1072,7 +1096,7 @@ msgstr "キャプション"
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Approve USDC"
-msgstr ""
+msgstr "USDCを承認"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -1113,7 +1137,7 @@ msgstr "{0} <0/><1> から </1>{1} <2/>"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "前より赤字検知"
-msgstr ""
+msgstr "前より赤字検知"
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/Referrals/AddAffiliateCode.tsx
@@ -1135,7 +1159,7 @@ msgstr "{networkName}でのガスに必要な{0}が不足しています<0/><1/>
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Wallet balances are not included in Total Net Worth. Net Yield is annualized; past rates are not indicative of future returns."
-msgstr ""
+msgstr "ウォレット残高は総資産に含まれません。ネット利回りは年率換算であり、過去の実績は将来のリターンを保証しません。"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Yield Yak Swap"
@@ -1166,6 +1190,10 @@ msgstr "マーケット"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "有効なリファラルコード"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr "ステップ1–3"
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1220,7 +1248,7 @@ msgstr "スワップ手数料係数（マイナスPI）"
 
 #: src/pages/Trade/components/ChartPanel.tsx
 msgid "OI"
-msgstr ""
+msgstr "建玉（OI）"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Claimable balance"
@@ -1365,7 +1393,7 @@ msgstr "DATE"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Position Age"
-msgstr ""
+msgstr "ポジション保有期間"
 
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
@@ -1382,7 +1410,7 @@ msgstr "GMX 提案の投票ページ"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "1. Leverage (higher = first)"
-msgstr ""
+msgstr "1. レバレッジ（高いほど優先）"
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Liquidity only available on {chainNames}. Switch networks to continue."
@@ -1398,7 +1426,7 @@ msgstr "ストップロス"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
-msgstr ""
+msgstr "トランザクション"
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "External swap {0} to {1}"
@@ -1406,7 +1434,7 @@ msgstr "外部スワップ {0} → {1}"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Short size / Your LP value"
-msgstr ""
+msgstr "ショートサイズ / あなたのLP評価額"
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "To buy GMX on {0}, <0>change your network</0>"
@@ -1426,7 +1454,7 @@ msgstr "入金手数料"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "LP + Trade collateral ± PnL"
-msgstr ""
+msgstr "LP ＋ トレード証拠金 ± 損益"
 
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "<0>Botanix</0> supports"
@@ -1438,7 +1466,7 @@ msgstr "{symbol}を売却中..."
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Opening…"
-msgstr ""
+msgstr "注文中…"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "The difference between expected and actual execution price due to volatility. Orders won't execute if slippage exceeds your maximum.<0/><1/>Slippage differs from price impact, which is based on open interest imbalances."
@@ -1569,7 +1597,7 @@ msgstr "高いネットワーク手数料"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Paid to you"
-msgstr ""
+msgstr "あなたへの受取"
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Overview"
@@ -1634,6 +1662,11 @@ msgstr "ワンクリックトレーディング無効。時間制限超過。"
 msgid "Session generation failed"
 msgstr "セッションの生成に失敗しました"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr "フェーズ2 · 内部バッファー"
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "オンチェーンクエストと報酬"
@@ -1645,7 +1678,7 @@ msgstr "トークン"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to withdraw"
-msgstr ""
+msgstr "ウォレットを接続して出金"
 
 #: src/domain/synthetics/sidecarOrders/utils.ts
 msgid "TP price above limit price"
@@ -1653,7 +1686,7 @@ msgstr "TP 価格がリミット価格を上回っています"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "2. Entry recency (newer = first)"
-msgstr ""
+msgstr "2. エントリーの新しさ（新しいほど優先）"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Action(s)"
@@ -1661,7 +1694,7 @@ msgstr "アクション"
 
 #: src/pages/Trade/components/PriceChart.tsx
 msgid "Fetching price data…"
-msgstr ""
+msgstr "価格データを取得中…"
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "May be higher on other sites that include position collateral"
@@ -1760,7 +1793,7 @@ msgstr "べスト"
 
 #: src/pages/Trade/TradePage.tsx
 msgid "Connect wallet to see positions"
-msgstr ""
+msgstr "ウォレットを接続してポジションを表示"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Bridge transaction hash"
@@ -1776,7 +1809,7 @@ msgstr "Arbitrum DAO STIP の提供です。"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Withdrawals restricted (weekend)"
-msgstr ""
+msgstr "週末は出金制限中"
 
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "Select pool"
@@ -1856,11 +1889,7 @@ msgstr "失敗"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
-msgstr ""
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
+msgstr "プロトコルの約束 — 予告なき金利引き上げはしない"
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
@@ -1872,8 +1901,9 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "注文がトリガーされた際にスワップ流動性が不足する可能性があります"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
-msgstr ""
+msgstr "準備基金"
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "Canceling {ordersText}..."
@@ -1901,7 +1931,7 @@ msgstr "流動性プール内"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Connect wallet to view hedge positions"
-msgstr ""
+msgstr "ウォレットを接続してヘッジポジションを表示"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -1945,7 +1975,7 @@ msgstr "エラーを隠す"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "No active trade (long) position in this vault."
-msgstr ""
+msgstr "このVaultにアクティブなトレード（ロング）ポジションはありません。"
 
 #: src/components/AlertInfo/AlertInfo.tsx
 msgid "Alert icon"
@@ -1971,7 +2001,7 @@ msgstr "アイコンと画像"
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Approved"
-msgstr ""
+msgstr "承認済み"
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Borrow fee / day"
@@ -1997,6 +2027,10 @@ msgstr "キー"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "分配"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr "シニアLP利回りがFR支払いに充当されます"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2086,7 +2120,7 @@ msgstr "仮想ショートトークン ID"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Unrealized P&L"
-msgstr ""
+msgstr "含み損益"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 msgid "account"
@@ -2176,7 +2210,7 @@ msgstr "Avalanche上の価格"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Avg. Hedge Ratio"
-msgstr ""
+msgstr "平均ヘッジ比率"
 
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Chart positions"
@@ -2194,11 +2228,11 @@ msgstr "価格影響リベートを請求中…"
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/TradePage.tsx
 msgid "Close Position"
-msgstr ""
+msgstr "ポジションをクローズ"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "No open short position. Use the form above to open one."
-msgstr ""
+msgstr "オープンしているショートポジションがありません。上のフォームからポジションを作成してください。"
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityCard.tsx
 msgid "Explore"
@@ -2255,7 +2289,7 @@ msgstr "マーケットは一時的に無効です"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Auto-growing"
-msgstr ""
+msgstr "自動増殖"
 
 #: src/domain/synthetics/markets/createShiftTxn.ts
 msgid "Shift error"
@@ -2269,7 +2303,7 @@ msgstr "受け取りに失敗しました"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "不足しています"
-msgstr ""
+msgstr "不足しています"
 
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Total value of tokens in GM pools"
@@ -2283,7 +2317,7 @@ msgstr "価格への影響リベート"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Your ADL Risk"
-msgstr ""
+msgstr "あなたのADLリスク"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Update Limit Swap"
@@ -2334,7 +2368,7 @@ msgstr "V2 Avalanche"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "プロトコル・ソルベンシー"
-msgstr ""
+msgstr "プロトコル・ソルベンシー"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed Market Decrease"
@@ -2346,7 +2380,7 @@ msgstr "DefiLlama"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Phase 4 · Hedge ADL"
-msgstr ""
+msgstr "フェーズ4 · ヘッジADL"
 
 #: src/pages/AccountDashboard/DailyAndCumulativePnL.tsx
 msgid "Daily and cumulative PnL"
@@ -2366,7 +2400,7 @@ msgstr "ファンディング増加ファクター"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Net Value"
-msgstr ""
+msgstr "純資産額"
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 msgid "May take a few minutes to appear. Check back later"
@@ -2374,7 +2408,7 @@ msgstr "表示されるまで数分かかる場合があります。後ほどご
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Absorbed"
-msgstr ""
+msgstr "吸収済み"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Failed deposit"
@@ -2398,6 +2432,10 @@ msgstr "GMX (中国語)"
 msgid "Search"
 msgstr "検索"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "WETH-USDCプールに既存のポジションがありますが、この注文に対する流動性が不足しています"
@@ -2409,6 +2447,10 @@ msgstr "過去の手数料"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "最大建玉 {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2427,7 +2469,7 @@ msgstr "スワップパスが見つかりません"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "LP Deposit"
-msgstr ""
+msgstr "LP預入"
 
 #: src/components/MarketsList/MarketsList.tsx
 msgid "MARKETS"
@@ -2446,7 +2488,7 @@ msgstr "清算時の担保"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Your delta-neutral positions, trade history, and LP status across all vaults."
-msgstr ""
+msgstr "全Vaultのデルタニュートラルポジション、トレード履歴、LP状態を確認できます。"
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Sender has withdrawn all tokens from GMX vesting vault"
@@ -2506,11 +2548,15 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
-msgstr ""
+msgstr "ADLの優先度を下げるため、レバレッジの引き下げを検討してください。"
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
+msgstr "表示言語を選択"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "LP Deposit + Short in one transaction"
-msgstr ""
+msgstr "LP預入＋ショートを1トランザクションで実行"
 
 #: src/components/TenderlySettings/TenderlySettings.tsx
 #: src/pages/AccountDashboard/AccountDashboard.tsx
@@ -2610,7 +2656,7 @@ msgstr "入金可能な資産がありません"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "s"
-msgstr ""
+msgstr "秒"
 
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Short Stop Loss @ {0}"
@@ -2647,11 +2693,15 @@ msgstr "建玉リザーブファクター（ロング）"
 msgid "Layer 2"
 msgstr "レイヤー2"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr "フェーズ0 — 正常稼働"
+
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Approving…"
-msgstr ""
+msgstr "承認中…"
 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "Allow {0} spending"
@@ -2682,7 +2732,7 @@ msgstr "アクションを検索"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to zap in"
-msgstr ""
+msgstr "ウォレットを接続してZap In"
 
 #: src/pages/Dashboard/GmxCard.tsx
 msgid "GMX is the utility and governance token. 27% of protocol fees accumulate in the Treasury for GMX buybacks and will be distributed to stakers when GMX reaches $90."
@@ -2698,11 +2748,11 @@ msgstr "ご懸念にどのように対応すればよろしいでしょうか？
 
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Closing Size"
-msgstr ""
+msgstr "クローズサイズ"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode B"
-msgstr ""
+msgstr "モードB"
 
 #: src/components/DepthChart/DepthChartTooltip.tsx
 msgid "No liquidity available for increasing longs at<0/>this size. Max long size: {0}<1/><2/>Execution prices for decreasing shorts."
@@ -2722,7 +2772,7 @@ msgstr "1CTを無効化"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Redemption pending — yield continues to accrue"
-msgstr ""
+msgstr "償還待機中 — 利回りは継続して発生中"
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "/ USD"
@@ -2790,7 +2840,7 @@ msgstr "プロトコルリスクエクスプローラーと統計"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "FRコスト"
-msgstr ""
+msgstr "FRコスト"
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Generating shareable image..."
@@ -2803,7 +2853,7 @@ msgstr "RANK"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Estimated VLP received"
-msgstr ""
+msgstr "受取予定VLP"
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "{txnTypeText} {0} order for"
@@ -2845,7 +2895,7 @@ msgstr "GMXの改善にご協力ください。セキュリティのため、こ
 
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Slippage"
-msgstr ""
+msgstr "スリッページ"
 
 #: src/components/TradeBox/TradeBoxRows/CollateralSelectorField.tsx
 msgid "Existing position uses {0} collateral. This order won't apply to it. <0>Switch to {1} collateral</0>"
@@ -2921,7 +2971,7 @@ msgstr "サイズ"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/TradePage.tsx
 msgid "Current Position"
-msgstr ""
+msgstr "現在のポジション"
 
 #: src/components/PositionSeller/PositionSeller.tsx
 msgid "Loading Express params..."
@@ -2939,13 +2989,17 @@ msgstr "GMTrade（旧GMX Solana）は別のウェブサイトでホストされ�
 msgid "Token categories"
 msgstr "トークンカテゴリ"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr "正常"
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "選択した期間中に取引はありませんでした"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Token Balance"
-msgstr ""
+msgstr "トークン残高"
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Default parts for TWAP orders"
@@ -2958,7 +3012,7 @@ msgstr "エクスプローラーで表示"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "FR / Buffered Yield"
-msgstr ""
+msgstr "FR / バッファー利回り"
 
 #: src/components/SettingsModal/ThemeSelector.tsx
 msgid "System"
@@ -2983,7 +3037,7 @@ msgstr "ティッカーシミュレーション"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "FR Payment Response"
-msgstr ""
+msgstr "FR支払い対応"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -3009,7 +3063,7 @@ msgstr "オープンポジション"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "exceeds the buffered RWA yield"
-msgstr ""
+msgstr "バッファー利回りを超過しています"
 
 #: src/components/PositionShare/PositionShareCard.tsx
 msgid "Coin"
@@ -3049,7 +3103,7 @@ msgstr "{positionText}に{0}を入金"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Price Yield"
-msgstr ""
+msgstr "価格利回り"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -3122,7 +3176,7 @@ msgstr "テイクプロフィットを更新"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "High leverage or recent entry increases ADL risk. Consider reducing leverage."
-msgstr ""
+msgstr "高レバレッジまたは最近のエントリーはADLリスクを高めます。レバレッジの引き下げを検討してください。"
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Deposit from {sourceChainName} failed"
@@ -3138,7 +3192,7 @@ msgstr "Uniswap V2スタイルのベンチマークに対する予想年間リ�
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Long profit positions"
-msgstr ""
+msgstr "ロング含み益ポジション"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Create referral code"
@@ -3155,7 +3209,7 @@ msgstr "GMXマーケットトークン価格チャート"
 
 #: src/pages/Trade/components/OIChart.tsx
 msgid "No position data yet"
-msgstr ""
+msgstr "ポジションデータがありません"
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "Lifetime LP rewards"
@@ -3169,17 +3223,21 @@ msgstr "無効な減少サイズ"
 msgid "It's just a wrap"
 msgstr "ラップのみです"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr "高レバレッジロック"
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "購読"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Asset not found."
-msgstr ""
+msgstr "アセットが見つかりません。"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Next redemption execution:"
-msgstr ""
+msgstr "次の償還実行予定:"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Decentralized finance dashboard"
@@ -3334,7 +3392,7 @@ msgstr "注文タイプ"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "risking insolvency. New hedge positions are blocked. Trade mode remains available."
-msgstr ""
+msgstr "支払い不能リスクがあります。新規ヘッジポジションはブロックされています。トレードモードは引き続き利用可能です。"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/lp/useVantageLPActions.ts
@@ -3347,15 +3405,11 @@ msgstr ""
 
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
-msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
+msgstr "売値"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
-msgstr ""
+msgstr "低レバレッジと長期保有がADLからあなたを守ります。ロイヤルティ層に属しています。"
 
 #: src/components/TradeBox/TradeBoxRows/CollateralSpreadRow.tsx
 msgid "Collateral spread"
@@ -3373,7 +3427,7 @@ msgstr "シフト注文が約定されました"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Active"
-msgstr ""
+msgstr "アクティブ"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useTokensToApprove.tsx
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -3428,7 +3482,7 @@ msgstr "GMX Accountの残高です。対応するすべてのチェーンから�
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "TVL Protected"
-msgstr ""
+msgstr "保護済みTVL"
 
 #: src/components/AllowedSwapSlippageInputRowImpl/AllowedSwapSlippageInputRowImpl.tsx
 #: src/components/AllowedSwapSlippageInputRowImpl/AllowedSwapSlippageInputRowImpl.tsx
@@ -3482,7 +3536,7 @@ msgstr "GLVボールト"
 
 #: src/pages/Trade/TradePage.tsx
 msgid "Hub balance is low — ADL may trigger soon. Cover ratio: {0}%"
-msgstr ""
+msgstr "Hubの残高が低下しています — まもなくADLが発動する可能性があります。カバー比率: {0}%"
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 #: src/pages/BuyGMX/BuyGMX.tsx
@@ -3492,7 +3546,7 @@ msgstr "中央集権型サービスからGMXを購入"
 #: src/components/TVChartContainer/TVChartContainer.tsx
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Short"
-msgstr ""
+msgstr "ショートをクローズ"
 
 #: src/pages/RpcDebug/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -3543,7 +3597,7 @@ msgstr "ABフラグはありません"
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Junior TrancheVault not configured for this deployment."
-msgstr ""
+msgstr "このデプロイにはジュニアトランシュVaultが設定されていません。"
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "Line heights"
@@ -3569,6 +3623,10 @@ msgstr "GMXのDuneアナリティクス"
 msgid "Pending borrowing fees from all open positions"
 msgstr "すべてのオープンポジションからの未払い借入手数料"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr "サージ"
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3587,7 +3645,7 @@ msgstr "コミュニティ主導のTelegramグループ"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Vault"
-msgstr ""
+msgstr "Vault"
 
 #: src/domain/multichain/SettlementChainWarningContainer.tsx
 msgid "Change to {0}"
@@ -3599,7 +3657,7 @@ msgstr "アンラップのみです"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Debug Panel"
-msgstr ""
+msgstr "デバッグパネル"
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Relayer request failed"
@@ -3644,6 +3702,10 @@ msgstr "マーケットグラフ"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "英字、数字、アンダースコアのみ使用可能です"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr "リアルタイムのソルベンシーダッシュボード。8段階防衛シーケンスの透明性確保。"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3747,7 +3809,7 @@ msgstr "受け取りパラメータが不足しています。数秒後にお試
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Full leaderboard requires Subgraph"
-msgstr ""
+msgstr "リーダーボード全体の表示にはSubgraphが必要です"
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "Trigger"
@@ -3764,7 +3826,7 @@ msgstr "Permit が署名されました"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Withdrawals are restricted on weekends due to RWA liquidity protection. Please try again on Monday UTC."
-msgstr ""
+msgstr "RWA流動性保護のため、週末は出金が制限されています。月曜日（UTC）以降に再度お試しください。"
 
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
@@ -3784,7 +3846,7 @@ msgstr "手数料（スワップを含む）"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "d"
-msgstr ""
+msgstr "日"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Exponent (positive)"
@@ -3839,6 +3901,10 @@ msgstr "<0>Solana サポート</0><1>Botanix サポート</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "資金が GMX Account に入金されました"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr "ジュニアVaultバッファー"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "流動性不足です。流動性が確保され次第、注文が約定されます。"
@@ -3849,7 +3915,7 @@ msgstr "送金が完了しました"
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Custom %"
-msgstr ""
+msgstr "カスタム %"
 
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "and"
@@ -3865,7 +3931,7 @@ msgstr "GLV流動性が不足しています"
 
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "My Deposit"
-msgstr ""
+msgstr "私の預入"
 
 #: src/components/ClaimablePositionPriceImpactRebateModal/ClaimablePositionPriceImpactRebateModal.tsx
 #: src/components/ClaimModal/ClaimModal.tsx
@@ -3899,7 +3965,7 @@ msgstr "完全にパブリックチェーンで実行"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "Current"
-msgstr ""
+msgstr "現在"
 
 #: src/domain/synthetics/orders/utils.tsx
 msgid "May lack liquidity for parts of this order when triggered"
@@ -3908,11 +3974,11 @@ msgstr "トリガー時に注文の一部で流動性が不足する可能性が
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Withdrawing…"
-msgstr ""
+msgstr "出金中…"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Protected (30d+)"
-msgstr ""
+msgstr "保護中（30日以上）"
 
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Rebasing balance synced"
@@ -3945,6 +4011,10 @@ msgstr "最小担保係数 OI ショート"
 msgid "Failed TWAP Swap part"
 msgstr "TWAP スワップパート失敗"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr "フェーズ1 — 予防"
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "過去7日間に基づく年率換算データ"
@@ -3959,7 +4029,7 @@ msgstr "注文の更新に失敗しました"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Ready to execute"
-msgstr ""
+msgstr "実行準備完了"
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -3977,7 +4047,7 @@ msgstr "注文がキャンセルされました"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Connect wallet to deposit"
-msgstr ""
+msgstr "ウォレットを接続して入金"
 
 #: landing/src/pages/Home/FaqSection/FaqSection.tsx
 msgid "<0>Yes, we encourage you to build on top of GMX or integrate it into your DeFi app. GMX is fully composable and already integrated with hundreds of protocols across the ecosystem, including notable names like Pendle, Dolomite, Radiant, Silo Finance, Venus Protocol, Abracadabra, Compound, and Beefy. You can interact directly with GMX smart contracts or use available APIs and SDKs to plug into trading, liquidity, or data flows. Check out the <1>GMX Developer Docs</1> to get started.</0>"
@@ -4002,6 +4072,10 @@ msgstr "薄い板やスリッページを気にせず、大規模な取引を行
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr "セーフティバッファーはベースレベル（{basePct}%）です。市場は安定しており、FRスパイク調整は非アクティブです。"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4019,7 +4093,7 @@ msgstr "{fromText}から"
 
 #: src/pages/Trade/TradePage.tsx
 msgid "Select Market"
-msgstr ""
+msgstr "マーケットを選択"
 
 #: src/components/StatusNotification/OrderStatusNotification.tsx
 msgid "Decreasing..."
@@ -4059,7 +4133,7 @@ msgstr "年率パフォーマンス"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "残高が"
-msgstr ""
+msgstr "残高が"
 
 #: src/domain/vantage/trade/useVantageTrade.ts
 msgid "Closing position..."
@@ -4067,7 +4141,7 @@ msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Collecting data…"
-msgstr ""
+msgstr "データ収集中…"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Withdraw and unreserve GMX"
@@ -4085,7 +4159,7 @@ msgstr "ファンディング手数料"
 
 #: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "System Status: Normal"
-msgstr ""
+msgstr "システム状態: 正常"
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 #: src/components/OrderItem/TwapOrdersList/TwapOrdersList.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading はネットワークのネイティブトークン {0} ではご利用いただけません。代わりに {1} の使用をご検討ください。"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4126,7 +4201,7 @@ msgstr "取引エアドロップ"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Price +10%"
-msgstr ""
+msgstr "価格 +10%"
 
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Found {0} events in the past {DAYS_BACK} days"
@@ -4162,7 +4237,7 @@ msgstr "Avalanche"
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "AUM"
-msgstr ""
+msgstr "AUM"
 
 #: src/components/MarketStats/MarketGraphs.tsx
 msgid "Fee APR"
@@ -4297,8 +4372,18 @@ msgstr "GMX のフィードバックを共有する"
 msgid "Withdraw failed"
 msgstr "出金に失敗しました"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr "ヘッジADL"
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4364,7 +4449,7 @@ msgstr "許容価格"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "ADL Score"
-msgstr ""
+msgstr "ADLスコア"
 
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing from subaccount..."
@@ -4399,7 +4484,7 @@ msgstr "仮想マーケットID"
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Junior Buffer (PAYOUT Tranche)"
-msgstr ""
+msgstr "ジュニアバッファー（ペイアウトトランシュ）"
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditorAdvancedRows.tsx
@@ -4439,7 +4524,7 @@ msgstr "{daysConsidered}日間の獲得手数料"
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Expires"
-msgstr ""
+msgstr "期限"
 
 #: src/components/TokenSelector/ConnectWalletModalContent.tsx
 msgid "Wallet icon"
@@ -4458,7 +4543,7 @@ msgstr "引き出し中..."
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Phase 3 · Trade ADL"
-msgstr ""
+msgstr "フェーズ3 · トレードADL"
 
 #: src/components/Claims/ClaimsHistory.tsx
 msgid "No claims match the selected filters"
@@ -4532,6 +4617,10 @@ msgstr "ルールを読む"
 msgid "Source chain supports single token only"
 msgstr "ソースチェーンは単一トークンのみ対応しています"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr "利回りトークンのFR相殺機構により、永続的なヘッジのコストはゼロです。"
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4552,7 +4641,7 @@ msgstr "最大利益上限に達しました"
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Pending Requests"
-msgstr ""
+msgstr "保留中のリクエスト"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Virtual inventory for swaps (long / short)"
@@ -4583,7 +4672,7 @@ msgstr "UIページ"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Delta Neutral"
-msgstr ""
+msgstr "デルタニュートラル"
 
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
@@ -4635,13 +4724,21 @@ msgstr "受取パラメータが不足しています。数秒後に再試行し
 msgid "AVG. LEV."
 msgstr "平均レバレッジ"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "新しい比率または許容スリッページを入力"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr "ヘッジショートへのADL"
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
-msgstr ""
+msgstr "リスク管理"
 
 #: src/domain/synthetics/orders/createWrapOrUnwrapTxn.ts
 #: src/domain/synthetics/orders/createWrapOrUnwrapTxn.ts
@@ -4655,7 +4752,7 @@ msgstr "ボラティリティによる予想約定価格と実際の約定価格
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Expired"
-msgstr ""
+msgstr "期限切れ"
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Existing position in {0} pool but lacks liquidity for this order"
@@ -4672,7 +4769,7 @@ msgstr "清算価格はありません。担保がすべての損失をカバー
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Position closes automatically and margin is returned when ADL is triggered."
-msgstr ""
+msgstr "ADL発動時にポジションは自動的にクローズされ、証拠金が返還されます。"
 
 #: src/pages/UiPage/UiPage.tsx
 #: src/pages/UiPage/UiPage.tsx
@@ -4696,7 +4793,7 @@ msgstr "Blueberry Pulse"
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Submitting…"
-msgstr ""
+msgstr "送信中…"
 
 #: src/domain/tokens/approveTokens.tsx
 msgid "Approval cancelled"
@@ -4704,7 +4801,7 @@ msgstr "承認がキャンセルされました"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Total Protection"
-msgstr ""
+msgstr "総保護額"
 
 #: src/components/UserFeedbackModal/UserFeedbackModal.tsx
 msgid "Your feedback helps us understand what we're doing well and where we can improve"
@@ -4725,7 +4822,7 @@ msgstr "プラスファクター"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "High leverage increases ADL priority. Reduce leverage or hold longer to improve protection."
-msgstr ""
+msgstr "高レバレッジはADLの優先度を高めます。レバレッジを下げるか長期保有で保護を強化してください。"
 
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Full position close"
@@ -4737,7 +4834,7 @@ msgstr "ストップロスを作成"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "How much do you want to hedge?"
-msgstr ""
+msgstr "ヘッジしたい金額を入力してください。"
 
 #: src/components/TableMarketFilter/MarketFilterLongShort.tsx
 msgid "Direction"
@@ -4783,6 +4880,12 @@ msgstr "マーケットデータを読み込み中..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "{longOrShort} ポジションはファンディング手数料および借入手数料がかかりません"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr "フェーズ1 · 予防"
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "{0} 内"
@@ -4793,12 +4896,13 @@ msgstr "{positionName} の手数料が精算されました"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Price -20%"
-msgstr ""
+msgstr "価格 -20%"
 
 #: src/components/Claims/SettleAccruedCard.tsx
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "価格への影響リベートが発生しました。5日後に受取可能です。<0>詳細はこちら</0>。"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4841,7 +4945,7 @@ msgstr "<0><1>@GMX_IO</1> が Token Terminal とデータパートナーシッ�
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Insufficient Balance"
-msgstr ""
+msgstr "残高不足"
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 #: src/components/GmxAccountModal/AvailableToTradeAssetsView.tsx
@@ -4856,7 +4960,7 @@ msgstr "マーケット増加リクエスト"
 
 #: src/pages/Trade/components/FundingRateChart.tsx
 msgid "No funding rate data yet"
-msgstr ""
+msgstr "ファンディングレートデータがありません"
 
 #: src/pages/Actions/SyntheticsActions.tsx
 msgid "GMX {VERSION_NAME} {networkName} actions for all accounts"
@@ -4869,10 +4973,6 @@ msgstr "{0}を編集"
 #: src/components/GmxAccountModal/InsufficientWntBanner.tsx
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol}を購入</0>。"
-
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4896,7 +4996,7 @@ msgstr "最小インパクトプール量"
 
 #: src/pages/Trade/components/FundingRateChart.tsx
 msgid "Annual Funding Rate"
-msgstr ""
+msgstr "年率ファンディングレート"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Price impact too high"
@@ -4915,6 +5015,10 @@ msgstr "リベート配布履歴"
 msgid "Active orders"
 msgstr "有効な注文"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr "ジュニアBF"
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Avalanche への入金は無効です。Avalanche ウォレットから直接取引してください。"
@@ -4931,10 +5035,6 @@ msgstr "マーケットを選択"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "一致するトークンなし"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5015,7 +5115,7 @@ msgstr "{formattedNetRate} / 1H"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "No active hedge (short) position in this vault."
-msgstr ""
+msgstr "このVaultにアクティブなヘッジ（ショート）ポジションはありません。"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -5111,7 +5211,7 @@ msgstr "借入手数料"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Short Size"
-msgstr ""
+msgstr "ショートサイズ"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact"
@@ -5172,6 +5272,14 @@ msgstr "外部スワップを失敗させる"
 msgid "Withdraw"
 msgstr "出金"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr "高レバレッジ（5倍以上）の新規ヘッジがブロックされます。OI上限に達すると全新規エントリーが停止されます。"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr "フェーズ0 · 正常"
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "ストップマーケットを更新"
@@ -5213,11 +5321,16 @@ msgstr "ボーナスAPR"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "+5% Rebase"
-msgstr ""
+msgstr "+5% リベース"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "シフトリクエストが送信されました"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr "安全"
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5225,7 +5338,7 @@ msgstr "現在の影響: {0}。注文の約定精度を高めるために0.30%�
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Deposit {0} + Open Short"
-msgstr ""
+msgstr "{0} を預入＋ショートを開く"
 
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settle {totalStr}"
@@ -5313,7 +5426,7 @@ msgstr "建玉 {directionLabel}"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Amount exceeds your VLP balance"
-msgstr ""
+msgstr "VLP残高を超えています"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useTokensToApprove.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useTokensToApprove.tsx
@@ -5380,7 +5493,7 @@ msgstr "TVL (供給)"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Hedge Protection Status"
-msgstr ""
+msgstr "ヘッジ保護状態"
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
 msgid "Update Default Destination"
@@ -5404,14 +5517,20 @@ msgid "Positive funding fees"
 msgstr "正のファンディング手数料"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
-msgstr ""
+msgstr "読み込み中…"
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "まもなくGMX Accountに資金が反映されます"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr "フェーズ3 · 最終防衛"
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5474,7 +5593,7 @@ msgstr "{gmOrGlvLabel}の購入に失敗しました。"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "FR spike detected. Safety buffer has been automatically raised from {basePct}% to {curPct}% to protect LP assets. New hedge capacity is tighter until the market stabilises."
-msgstr ""
+msgstr "FRスパイクを検知しました。LP資産保護のため、セーフティバッファーが{basePct}%から{curPct}%に自動引き上げられました。市場が安定するまで新規ヘッジ容量は制限されます。"
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing limit order in WETH-USDC pool.<0>Switch to WETH-USDC pool</0>"
@@ -5483,6 +5602,11 @@ msgstr "WETH-USDCプールに既存の指値注文があります。<0>WETH-USDC
 #: src/pages/PoolsDetails/PoolsDetailsHeader.tsx
 msgid "GM: {0}"
 msgstr "GM: {0}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr "シニア利回り"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
@@ -5513,7 +5637,7 @@ msgstr "テイクプロフィット/ストップロスを作成"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Short Margin"
-msgstr ""
+msgstr "ショート証拠金"
 
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Purpose: {0} | public: {1}"
@@ -5534,7 +5658,7 @@ msgstr "リファラルコードが追加されました"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Hedge page"
-msgstr ""
+msgstr "ヘッジページ"
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX bonds on Bond Protocol at a discount with a short vesting period"
@@ -5542,15 +5666,19 @@ msgstr "Bond ProtocolでGMXボンドを短いベスティング期間で割引�
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Warning: Your position value exceeds current vault AUM. Withdrawal may be partially settled."
-msgstr ""
+msgstr "警告: ポジション価値が現在のVault AUMを超えています。出金は一部のみ精算される場合があります。"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Vault LP"
-msgstr ""
+msgstr "Vault LP"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
-msgstr ""
+msgstr "モードA — 自動終了"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
+msgstr "システムは正常に機能しています"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
@@ -5653,11 +5781,11 @@ msgstr "最大 {MAX_REFERRAL_CODE_LENGTH} 文字"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "OI Utilization"
-msgstr ""
+msgstr "OI利用率"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Convert to Paid-Short"
-msgstr ""
+msgstr "有料ショートに転換"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "Provide isolated liquidity per market"
@@ -5759,7 +5887,7 @@ msgstr "マーケット増額失敗"
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Liq. Price"
-msgstr ""
+msgstr "清算価格"
 
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "LEV."
@@ -5797,7 +5925,7 @@ msgstr "出金の最大貸出可能インパクトファクター"
 
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 msgid "Reduce Position ({closePct}%)"
-msgstr ""
+msgstr "ポジションを縮小（{closePct}%）"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
@@ -5817,7 +5945,7 @@ msgstr "無効なトランザクション"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Hedge Protection Status (Phase 4 ADL)"
-msgstr ""
+msgstr "ヘッジ保護状態（フェーズ4 ADL）"
 
 #: src/components/TradeboxPoolWarnings/TradeboxPoolWarnings.tsx
 msgid "Insufficient liquidity in {0} pool. Select a different pool."
@@ -5904,11 +6032,19 @@ msgstr "資金の請求に失敗しました"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Depositing…"
-msgstr ""
+msgstr "入金中…"
 
 #: src/components/SwitchToSettlementChain/SwitchToSettlementChainWarning.tsx
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "シフトは {chainNames} または {lastChainName} でのみ利用可能です。続行するにはネットワークを切り替えてください。"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr "プロトコル安定基金が過去の利益から積み立てた余剰を使ってFR不足を補填します。"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr "供給サイドインセンティブ"
 
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
@@ -5939,6 +6075,11 @@ msgstr "EXECUTION PRICE"
 msgid "spinner"
 msgstr "読み込み中"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr "フェーズ3 · 強制執行"
+
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
 msgstr "不明なGM売却注文"
@@ -5966,7 +6107,7 @@ msgstr "購入失敗"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD value"
-msgstr ""
+msgstr "USD評価額"
 
 #: src/pages/Dashboard/StatsCard.tsx
 msgid "Users"
@@ -5975,7 +6116,7 @@ msgstr "ユーザー"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Total AUM"
-msgstr ""
+msgstr "総AUM"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -6103,7 +6244,7 @@ msgstr ""
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Remaining capacity"
-msgstr ""
+msgstr "残余容量"
 
 #: src/pages/UiPage/UiPage.tsx
 msgid "leading-1"
@@ -6127,7 +6268,7 @@ msgstr "（スワップ額の {0}）"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "No open positions. Go to the"
-msgstr ""
+msgstr "オープンポジションがありません。"
 
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6188,7 +6329,7 @@ msgstr "GMXはTradingViewを使用してリアルタイムの暗号通貨チャ�
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Balanced ✓"
-msgstr ""
+msgstr "バランス ✓"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
@@ -6211,7 +6352,7 @@ msgstr "トークンを検索"
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Health"
-msgstr ""
+msgstr "ヘルス"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GLV (GMX Liquidity Vault) holds various GM tokens, giving you diversified exposure to GMX's markets. The vault auto-rebalances to high-demand markets, unlocking higher potential yield compared to isolated pools."
@@ -6229,7 +6370,7 @@ msgstr "借入手数料およびファンディング手数料を除く初期担
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Paused"
-msgstr ""
+msgstr "停止中"
 
 #: src/components/PositionShare/CreateReferralCode.tsx
 #: src/components/PositionShare/CreateReferralCode.tsx
@@ -6247,7 +6388,7 @@ msgstr "詳細"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Vault AUM"
-msgstr ""
+msgstr "Vault AUM"
 
 #: src/components/UserIncentiveDistribution/utils.tsx
 msgid "GLV bonus incentive"
@@ -6284,7 +6425,7 @@ msgstr "Avalancheでステーク済"
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Pending"
-msgstr ""
+msgstr "保留中"
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "s:"
@@ -6319,6 +6460,10 @@ msgstr "分割数"
 msgid "No open orders"
 msgstr "オープンの注文はありません"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr "プレミアムサージ"
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "流動性不足。利用可能: {availableLiquidityText}"
@@ -6329,11 +6474,11 @@ msgstr "アンステーク送信済み"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Zapping…"
-msgstr ""
+msgstr "Zap中…"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Trade page"
-msgstr ""
+msgstr "トレードページ"
 
 #: src/components/Earn/Discovery/EarnYieldOverview.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -6343,11 +6488,11 @@ msgstr "Botanix"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Short (hedge) positions"
-msgstr ""
+msgstr "ショート（ヘッジ）ポジション"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "FR cost / buffered yield"
-msgstr ""
+msgstr "FRコスト / バッファー利回り"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 #: src/components/TradeBox/TradeBoxRows/PriceImpactFeesRow.tsx
@@ -6372,11 +6517,15 @@ msgstr "注文失敗"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Balance (LP ↔ Short)"
-msgstr ""
+msgstr "残高（LP ↔ ショート）"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Airdrop"
 msgstr "エアドロップ"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr "ステップ7–8"
 
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
@@ -6420,10 +6569,6 @@ msgstr "{gasPaymentTokensText}を入金"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (ポルトガル語)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -6476,7 +6621,7 @@ msgstr "詳細を折りたたむ"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "DEX"
-msgstr ""
+msgstr "DEX"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Stryke"
@@ -6513,7 +6658,7 @@ msgstr "高い価格影響"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "FR停止中"
-msgstr ""
+msgstr "FR停止中"
 
 #: src/components/GmList/GmList.tsx
 #: src/components/MarketsList/NetFeeTooltip.tsx
@@ -6535,7 +6680,7 @@ msgstr "選択したフィルターに一致するトレードはありません
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "This is the price you're hedging against. A short position offsets any drop."
-msgstr ""
+msgstr "これはヘッジ対象の価格です。ショートポジションが価格下落を相殺します。"
 
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
@@ -6543,7 +6688,7 @@ msgstr "減額しました"
 
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
+msgstr "RWA資産からの利回りを得るために流動性を提供してください。"
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6561,11 +6706,11 @@ msgstr "減少"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Yield"
-msgstr ""
+msgstr "利回り"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Unrealised PnL"
-msgstr ""
+msgstr "含み損益"
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -6640,7 +6785,7 @@ msgstr "旧1CTサブアカウントに{balanceFormatted}が残っています"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Shortfall Debt"
-msgstr ""
+msgstr "ショートフォール債務"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shifting from <0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> to <3><4>GM: {toIndexName}</4><5>{toPoolName}</5></3>"
@@ -6649,7 +6794,7 @@ msgstr "<0><1>GM: {fromIndexName}</1><2>{fromPoolName}</2></0> から <3><4>GM: 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Zap In"
-msgstr ""
+msgstr "Zap In"
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/MarketStats/components/CompositionTable.tsx
@@ -6710,7 +6855,7 @@ msgstr "清算から<0/>身を守りましょう"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Auto-Close"
-msgstr ""
+msgstr "自動クローズ"
 
 #: src/components/HighPriceImpactOrFeesWarningCard/HighPriceImpactOrFeesWarningCard.tsx
 msgid "High net price impact"
@@ -6766,7 +6911,7 @@ msgstr "清算手数料"
 
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "No vaults configured. Deploy contracts first."
-msgstr ""
+msgstr "Vaultが設定されていません。まずコントラクトをデプロイしてください。"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -6859,7 +7004,7 @@ msgstr "<0>ウォレットが{0}に接続されていません</0><1/><2>{1}に�
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "My Liquidity"
-msgstr ""
+msgstr "私の流動性"
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 msgid "TVL/CAP"
@@ -6879,7 +7024,7 @@ msgstr "インパクト指数（正）"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Sync Rebasing Balance"
-msgstr ""
+msgstr "リベース残高を同期"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Can't withdraw collateral. Remaining collateral would be below minimum"
@@ -6903,7 +7048,7 @@ msgstr "このサイズでのロング増加に利用可能な流動性があり
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Keep position open as a standard short. FR payments will apply from the ADL moment onward."
-msgstr ""
+msgstr "ポジションを通常のショートとして維持します。ADL発動時点以降はFR支払いが適用されます。"
 
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/Referrals/Referrals.tsx
@@ -6938,7 +7083,7 @@ msgstr "デコードする16進エラーデータを貼り付けてください"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "Hedge Inventory"
-msgstr ""
+msgstr "ヘッジインベントリ"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Min collateral"
@@ -7030,7 +7175,7 @@ msgstr "取引"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Amount (USDC)"
-msgstr ""
+msgstr "金額（USDC）"
 
 #: src/config/uiFlagEvents.tsx
 msgid "Trading may be temporarily unavailable. Our team is working to resolve the issue."
@@ -7057,7 +7202,7 @@ msgstr "{updateOrdersCount}件のTP/SL注文を更新中..."
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Estimated {0}"
-msgstr ""
+msgstr "推定 {0}"
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price"
@@ -7068,17 +7213,15 @@ msgid "Position would be liquidatable"
 msgstr "ポジションが清算対象となります"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
-msgstr ""
+msgstr "LPブースト"
 
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "メディアキット"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7115,7 +7258,7 @@ msgstr "清算時のマーク価格"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "New ({ageDays}d)"
-msgstr ""
+msgstr "新規（{ageDays}日）"
 
 #: src/components/GmList/GmTokensTotalBalanceInfo.tsx
 msgid "Projected from last {daysConsidered} days' APY"
@@ -7131,7 +7274,7 @@ msgstr "GMXのお知らせとアップデート"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Mode A (Auto-Close) ⚠"
-msgstr ""
+msgstr "モードA（自動クローズ）⚠"
 
 #: src/components/TPSLModal/AddTPSLModal.tsx
 msgid "Edit TP/SL size"
@@ -7159,7 +7302,7 @@ msgstr "ガバナンスアラート"
 
 #: src/pages/Trade/TradePage.tsx
 msgid "LP redemption demand may reduce open positions by up to 5% per day via ADL to fund withdrawals."
-msgstr ""
+msgstr "LP償還需要により、ADLを通じて1日最大5%のポジションが削減される場合があります。"
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
@@ -7200,7 +7343,7 @@ msgstr "Yield Yak Optimizer"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Remaining Capacity"
-msgstr ""
+msgstr "残余容量"
 
 #: src/components/OldSubaccountWithdraw/OldSubaccountWithdraw.tsx
 msgid "Withdrawing {balanceFormatted} to main account..."
@@ -7208,7 +7351,7 @@ msgstr "メインアカウントに{balanceFormatted}を出金中…"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Used"
-msgstr ""
+msgstr "使用済み"
 
 #: src/domain/synthetics/orders/useOrderTxnCallbacks.tsx
 msgid "{orderText} updated"
@@ -7244,7 +7387,7 @@ msgstr "支払い"
 
 #: src/pages/Trade/components/ChartPanel.tsx
 msgid "Funding Rate"
-msgstr ""
+msgstr "ファンディングレート"
 
 #: src/pages/Earn/EarnAdditionalOpportunitiesPage.tsx
 msgid "No opportunities match your holdings"
@@ -7314,7 +7457,7 @@ msgstr "TWAPスワップをキャンセル"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Vault not found: {address}"
-msgstr ""
+msgstr "Vaultが見つかりません: {address}"
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Transaction"
@@ -7352,7 +7495,7 @@ msgstr "利用可能流動性"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Delta-neutral strategy: earn RWA yield + short funding rate with zero price exposure."
-msgstr ""
+msgstr "デルタニュートラル戦略：価格リスクゼロでRWA利回り＋ショートファンディングレートを獲得します。"
 
 #: src/components/SettingsModal/RpcDebugSettings.tsx
 msgid "Current endpoints ({0})"
@@ -7430,7 +7573,7 @@ msgstr "項目なし"
 
 #: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Protocol Defense Status"
-msgstr ""
+msgstr "プロトコル防衛状態"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade with confidence"
@@ -7447,7 +7590,7 @@ msgstr "勝率"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "What happens when funding rate is triggered?"
-msgstr ""
+msgstr "ファンディングレートが発動した場合はどうなりますか？"
 
 #: src/domain/synthetics/orders/utils.tsx
 msgid "Insufficient liquidity to execute order at trigger price"
@@ -7461,6 +7604,10 @@ msgstr "GMX trading stats"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High leverage increases liquidation risk"
 msgstr "高レバレッジは清算リスクを高めます"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr "ジュニアバッファー"
 
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
@@ -7539,7 +7686,7 @@ msgstr "V1リベート"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "Hedge FR (Shorts perspective)"
-msgstr ""
+msgstr "ヘッジFR（ショート視点）"
 
 #: src/components/GmSwap/GmSwapBox/GmSwapBoxHeader.tsx
 msgid "Sell GLV"
@@ -7662,7 +7809,7 @@ msgstr "外部スワップを有効化"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Sum of short position sizes"
-msgstr ""
+msgstr "ショートポジションサイズの合計"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "BORROWING FEES"
@@ -7711,7 +7858,7 @@ msgstr "担保スワップのための流動性不足"
 #: src/components/TVChartContainer/TVChartContainer.tsx
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Open Long"
-msgstr ""
+msgstr "ロングを開く"
 
 #: src/components/DebugSwapsSettings/DebugSwapsSettings.tsx
 msgid "Swap price impact for external swap threshold"
@@ -7736,7 +7883,7 @@ msgstr "目的"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
-msgstr ""
+msgstr "RWA利回りがFRコストを下回っているため、ヘッジのFR相殺が一時停止されています。ソルベンシー回復後に自動的に復元されます。"
 
 #: src/components/Earn/AdditionalOpportunities/OpportunityFilters.tsx
 msgid "For me"
@@ -7753,11 +7900,11 @@ msgstr "{0}の{1}への出金はサポートされていません"
 
 #: src/pages/Status/StatusPage.tsx
 msgid "Protocol Status"
-msgstr ""
+msgstr "プロトコルステータス"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Back to Hedge"
-msgstr ""
+msgstr "ヘッジ一覧に戻る"
 
 #: landing/src/pages/Home/HeaderMenu/HeaderMenu.tsx
 #: src/components/Earn/Discovery/EarnProductCard.tsx
@@ -7776,7 +7923,7 @@ msgstr "キャンセル"
 
 #: src/pages/Trade/components/ChartPanel.tsx
 msgid "Live"
-msgstr ""
+msgstr "ライブ"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group"
@@ -7835,13 +7982,19 @@ msgstr "サマリー"
 msgid "ENTRY PRICE"
 msgstr "ENTRY PRICE"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr "トレードADL"
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "手数料差引後のPnLを表示"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A ⚠"
-msgstr ""
+msgstr "モードA ⚠"
 
 #: src/components/PositionDropdown/PositionDropdown.tsx
 msgid "Share position"
@@ -7849,7 +8002,7 @@ msgstr "ポジションを共有"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "USD Value"
-msgstr ""
+msgstr "USD評価額"
 
 #: src/components/BotanixBanner/BotanixBanner.tsx
 msgid "Switch to <0><1/><2>Arbitrum</2></0> or <3><4/><5>Avalanche</5></3> for those features"
@@ -7875,10 +8028,6 @@ msgstr "ポジション手数料ファクター（マイナスPI）"
 msgid "90d"
 msgstr "90日"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
-
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
 msgstr "（{0}日前）"
@@ -7890,7 +8039,7 @@ msgstr "清算"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "My VLP"
-msgstr ""
+msgstr "保有VLP"
 
 #: src/components/TPSLModal/TPSLModal.tsx
 #: src/components/TPSLModal/TPSLModal.tsx
@@ -7917,7 +8066,7 @@ msgstr "プロジェクト"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
-msgstr ""
+msgstr "保護対象"
 
 #: src/components/TVChart/ChartHeader.tsx
 #: src/components/TVChart/ChartHeader.tsx
@@ -7926,7 +8075,7 @@ msgstr "24時間安値"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Low leverage and long tenure protect you. You are in the loyalty tier."
-msgstr ""
+msgstr "低レバレッジと長期保有があなたを守ります。ロイヤルティ層に属しています。"
 
 #: src/pages/BuyGMX/BuyGMX.tsx
 msgid "Buy GMX from TraderJoe"
@@ -7950,7 +8099,7 @@ msgstr "{0}が担保として必要です。<0/><1/>GMX内で{1}から{2}への�
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "LP-weighted net APY (annualized)"
-msgstr ""
+msgstr "LP加重平均ネットAPY（年率）"
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "27% of protocol fees are accumulating in the Treasury for GMX buybacks. Rewards will be distributed to stakers when GMX reaches $90, proportional to staking power (duration × amount staked)."
@@ -7968,6 +8117,10 @@ msgstr "最大値超過"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8016,7 +8169,7 @@ msgstr "総供給量"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Connect wallet to view positions"
-msgstr ""
+msgstr "ウォレットを接続してポジションを表示"
 
 #: src/components/Earn/Portfolio/AssetsList/AssetsList.tsx
 msgid "My assets"
@@ -8029,7 +8182,7 @@ msgstr "GMXアカウントから引き出し"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "You are being paid to hedge"
-msgstr ""
+msgstr "ヘッジで受取が発生しています"
 
 #: src/domain/synthetics/trade/utils/validation.ts
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -8051,7 +8204,7 @@ msgstr "リンクをコピーしました"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Congested"
-msgstr ""
+msgstr "混雑"
 
 #: src/components/Claims/ClaimsHistory.tsx
 #: src/components/Claims/ClaimsHistory.tsx
@@ -8094,6 +8247,10 @@ msgstr "指値増加"
 msgid "Transferring..."
 msgstr "送金中..."
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr "準備基金"
+
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
 msgstr "{gmOrGlvLabel}の売却に失敗しました。"
@@ -8127,7 +8284,7 @@ msgstr "手数料と価格への影響を含む、実現損益および含み損
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Why your assets don't decrease"
-msgstr ""
+msgstr "なぜ資産が減らないのか"
 
 #: src/components/PositionItem/PositionItem.tsx
 msgid "Position may still liquidate from fees alone (funding + borrowing), reducing collateral over time."
@@ -8159,7 +8316,7 @@ msgstr "GLP払い戻し（テスト）"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "（赤字）"
-msgstr ""
+msgstr "（赤字）"
 
 #: src/pages/PageNotFound/PageNotFound.tsx
 msgid "<0>Return to </0><1>Homepage</1> <2>or </2> <3>Trade</3>"
@@ -8200,11 +8357,11 @@ msgstr "GMXリスクモニタリング"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "Vault Yield APR"
-msgstr ""
+msgstr "Vault利回りAPR"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "High ADL risk. Reduce leverage or hold position longer to improve protection."
-msgstr ""
+msgstr "ADLリスクが高いです。レバレッジを下げるか、より長くポジションを保有して保護を強化してください。"
 
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "Minimum capital used of {0} required to qualify for rankings"
@@ -8310,7 +8467,7 @@ msgstr "強制エラー"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "1× = delta-neutral. Higher = partial hedge."
-msgstr ""
+msgstr "1× = デルタニュートラル。高いほど = 部分ヘッジ。"
 
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
@@ -8336,7 +8493,7 @@ msgstr "利用可能なスワップ経路がありません"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Mode B (Convert)"
-msgstr ""
+msgstr "モードB（転換）"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Stop-Loss"
@@ -8361,7 +8518,7 @@ msgstr "検索に一致する機会はありません"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Estimated VLP"
-msgstr ""
+msgstr "推定VLP"
 
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 msgid "Leaderboard for traders on GMX V2"
@@ -8390,7 +8547,7 @@ msgstr "GMX Accountへの入金および出金中..."
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Loading yield data…"
-msgstr ""
+msgstr "利回りデータを読み込み中…"
 
 #: src/config/uiFlagEvents.tsx
 msgid "Service disruption"
@@ -8403,7 +8560,7 @@ msgstr "ストップ成行価格がマーク価格を上回っています"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Deposited to the LP Vault. You receive VLP shares in return."
-msgstr ""
+msgstr "LP Vaultに預け入れます。代わりにVLPシェアを受け取ります。"
 
 #: src/components/PoolSelector2/PoolSelector2.tsx
 msgid "SHORT LIQ."
@@ -8450,7 +8607,7 @@ msgstr "ウォレットまたはGMX Accountから取引"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "← Back to Vaults"
-msgstr ""
+msgstr "← ボールトに戻る"
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Min position size: {0}"
@@ -8483,11 +8640,11 @@ msgstr "建玉リザーブファクター（ショート）"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Transaction submitted:"
-msgstr ""
+msgstr "トランザクションを送信しました:"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Managed Net APY = Vault APY + Short Funding Rate. Past rates are not indicative of future returns."
-msgstr ""
+msgstr "管理型ネットAPY = Vault APY ＋ ショートファンディングレート。過去の実績は将来のリターンを保証しません。"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient pool liquidity"
@@ -8499,7 +8656,7 @@ msgstr "Botanixにはまだ機会がありません"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low ADL risk. Your position has low leverage or minimal unrealized profit."
-msgstr ""
+msgstr "ADLリスクが低いです。レバレッジが低いか含み益が少ないポジションです。"
 
 #: landing/src/pages/Home/SocialSection/SocialSlider.tsx
 msgid "<0><1>#GMX V2</1>'s OI looks great</0><2>GMX V2 > GMX V1 + Kwenta + Polynomial</2><3>Check more: <4>https://tradao.xyz/#/open-interest</4></3>"
@@ -8516,7 +8673,7 @@ msgstr "手数料"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "m"
-msgstr ""
+msgstr "分"
 
 #: src/domain/synthetics/userFeedback/utils.ts
 msgid "What could we improve?"
@@ -8567,7 +8724,7 @@ msgstr "{fromText}から{toExecutionText}へ"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Net APY"
-msgstr ""
+msgstr "ネットAPY"
 
 #: src/components/TradeHistory/keys.ts
 msgid "Execute Limit Swap"
@@ -8610,7 +8767,7 @@ msgstr "受け取り完了"
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Connect wallet to trade"
-msgstr ""
+msgstr "ウォレットを接続してトレード"
 
 #: src/components/TwapRows/TwapRows.tsx
 msgid "less than a minute"
@@ -8622,7 +8779,7 @@ msgstr "エコシステム"
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "3. Mode (Auto-Close first)"
-msgstr ""
+msgstr "3. モード（自動クローズを優先）"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "Next"
@@ -8679,7 +8836,7 @@ msgstr "金額"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Mint 1,000 {0} to wallet"
-msgstr ""
+msgstr "ウォレットに1,000 {0} をミント"
 
 #: src/components/TVChart/ChartHeader.tsx
 msgid "Open interest (<0>{longOIPercentage}</0>/<1>{shortOIPercentage}</1>)"
@@ -8715,10 +8872,6 @@ msgstr "未ステーキング"
 #: src/pages/RpcDebug/parts.tsx
 msgid "{0}ms"
 msgstr "{0}ms"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
 
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
@@ -8761,10 +8914,6 @@ msgstr "x"
 msgid "Notifications"
 msgstr "通知"
 
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
-
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
 msgstr "トレーディングモード"
@@ -8772,7 +8921,7 @@ msgstr "トレーディングモード"
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 #: src/pages/Trade/TradePage.tsx
 msgid "Back"
-msgstr ""
+msgstr "戻る"
 
 #: landing/src/pages/Home/RoadmapSection/Quareters.tsx
 msgid "<0>Cross-margin</0><1>Cross-collateral</1>"
@@ -8820,7 +8969,7 @@ msgstr "{comment}"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "My Deposit (USD)"
-msgstr ""
+msgstr "預入額（USD）"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 #: src/components/Referrals/AffiliatesStats.tsx
@@ -8970,7 +9119,7 @@ msgstr "トップポジション"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Buffer"
-msgstr ""
+msgstr "バッファー"
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "V2 rebates apply automatically as fee discounts and aren't shown here"
@@ -8986,7 +9135,7 @@ msgstr "V2取引"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "（健全）"
-msgstr ""
+msgstr "（健全）"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Protocol analytics"
@@ -8997,10 +9146,15 @@ msgid "Show positions on chart"
 msgstr "チャートにポジションを表示"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Hedge"
-msgstr ""
+msgstr "ヘッジ"
 
 #: src/components/MetricsDebugSettings/MetricsDebugSettings.tsx
 msgid "Metrics debug"
@@ -9101,7 +9255,7 @@ msgstr "言語を選択"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Open New Hedge"
-msgstr ""
+msgstr "新規ヘッジを開く"
 
 #: src/pages/ParseTransaction/ParseTransaction.tsx
 msgid "Unknown value"
@@ -9157,7 +9311,7 @@ msgstr "価格への影響"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Estimated USDC received"
-msgstr ""
+msgstr "受取予定USDC"
 
 #: src/components/Referrals/AddAffiliateCode.tsx
 msgid "You don't have a referral code to share. <0/> Create one now and start earning rebates!"
@@ -9185,11 +9339,11 @@ msgstr "価格への影響はありません。このサイズでの<0/>ロン�
 
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Confirming…"
-msgstr ""
+msgstr "確認中…"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Slippage guard"
-msgstr ""
+msgstr "スリッページガード"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Telegram group (Chinese)"
@@ -9246,7 +9400,7 @@ msgstr "リファラルコードを編集"
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Acceptable Price"
-msgstr ""
+msgstr "許容価格"
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Sell request sent"
@@ -9272,7 +9426,7 @@ msgstr "TOTAL VOLUME"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Live (15s poll)"
-msgstr ""
+msgstr "ライブ（15秒更新）"
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Enable One-Click Trading"
@@ -9334,7 +9488,11 @@ msgstr "受取"
 #: src/pages/Trade/components/ClosePositionPanel.tsx
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Execution Fee"
-msgstr ""
+msgstr "実行手数料"
+
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr "このプロトコルはファンディングレートを遡って引き上げることはしません。システムがヘッジ費用を賄えなくなった場合、既存ユーザーのコストを増加させる代わりにステップ7（契約終了）を実行します。上記の8段階防衛シーケンスが公開コミットされた完全なフレームワークであり、この順序の外で何かが起こることはありません。"
 
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
@@ -9384,6 +9542,10 @@ msgstr "リファラルコードを使用しているトレーダーの数"
 msgid "Max reserved {directionLabel}"
 msgstr "最大予約済み {directionLabel}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr "ロング利益へのADL"
+
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
 msgstr "手数料および価格への影響（ネット）控除後の確定損益"
@@ -9404,7 +9566,7 @@ msgstr ""
 #: src/pages/Trade/components/PositionListPanel.tsx
 #: src/pages/Trade/components/UnifiedPositionList.tsx
 msgid "Side"
-msgstr ""
+msgstr "サイド"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "LIQUIDITY SHORT"
@@ -9463,7 +9625,7 @@ msgstr "請求可能なリベート"
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Slippage Tolerance"
-msgstr ""
+msgstr "スリッページ許容値"
 
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
@@ -9485,7 +9647,7 @@ msgstr "入金するアセットを選択"
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Phase 2-5"
-msgstr ""
+msgstr "フェーズ2-5"
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Max GM buyable amount reached"
@@ -9510,7 +9672,7 @@ msgstr "コピーエラー"
 
 #: src/pages/Trade/components/PriceChart.tsx
 msgid "Loading chart data…"
-msgstr ""
+msgstr "チャートデータを読み込み中…"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Saulius GMX analytics"
@@ -9542,7 +9704,7 @@ msgstr "エンドポイントを追加"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "This transaction sends:"
-msgstr ""
+msgstr "このトランザクションで送信されるもの:"
 
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/Referrals/ClaimAffiliatesModal/ClaimAffiliatesModal.tsx
@@ -9599,7 +9761,7 @@ msgstr "アカウントのイベント："
 
 #: src/pages/Trade/components/PositionListPanel.tsx
 msgid "閉じる"
-msgstr ""
+msgstr "閉じる"
 
 #: src/pages/UiPage/UiPage.tsx
 #: src/pages/UiPage/UiPage.tsx
@@ -9648,7 +9810,7 @@ msgstr "日付"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Total Net Worth"
-msgstr ""
+msgstr "総資産"
 
 #: src/components/TradeBox/TradeBoxRows/AvailableLiquidityRow.tsx
 msgid "Executes when liquidity and price conditions are met"
@@ -9683,6 +9845,10 @@ msgstr "GMX報酬："
 msgid "Wallet trading only on these networks"
 msgstr "これらのネットワークではウォレット取引のみ利用可能です"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr "新規ユーザーのみエントリープレミアムが上昇します。既存のヘッジポジションは一切影響を受けません。"
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "トリガー価格"
@@ -9697,7 +9863,7 @@ msgstr "売却可能"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "FR相殺停止中"
-msgstr ""
+msgstr "FR相殺停止中"
 
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Select positions where accrued funding fee exceeds the {0} gas cost to settle"
@@ -9705,7 +9871,7 @@ msgstr "発生したファンディング手数料が決済のGasコスト{0}を
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 msgid "Provide liquidity to earn yield from trades and RWA assets."
-msgstr ""
+msgstr "トレードとRWA資産からの利回りを得るために流動性を提供してください。"
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "No from token address"
@@ -9714,6 +9880,10 @@ msgstr "送信元トークンアドレスがありません"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "大口アカウント"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr "フェーズ3 — 最終手段"
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9729,7 +9899,7 @@ msgstr "ダウンロード"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "ADL Mode"
-msgstr ""
+msgstr "ADLモード"
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "Up"
@@ -9832,7 +10002,7 @@ msgstr "ファンディングレート低減の閾値"
 
 #: src/pages/Trade/components/PriceChart.tsx
 msgid "Low"
-msgstr ""
+msgstr "安値"
 
 #: src/domain/synthetics/fees/utils/index.ts
 msgid "Network fees are very high due to increased {chainName} network activity"
@@ -9861,7 +10031,7 @@ msgstr "{operationTokenSymbol}を売却"
 
 #: src/pages/Status/StatusPage.tsx
 msgid "Trade ADL in progress for {elapsed}. Long positions with high leverage × profit are being force-closed."
-msgstr ""
+msgstr "{elapsed} 間ADLが実行中です。高レバレッジかつ含み益の大きいロングポジションが強制クローズされています。"
 
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "When on, leverage is set manually and determines margin and position size. When off, margin and size are set freely, and leverage is derived."
@@ -9907,6 +10077,10 @@ msgstr "ベスティング用に予約されたトークン：{0}"
 msgid "Something went wrong"
 msgstr "エラーが発生しました"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr "FR相殺"
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
 msgstr "凍結"
@@ -9917,7 +10091,7 @@ msgstr "CONFIG"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "The current funding rate"
-msgstr ""
+msgstr "現在のファンディングレート"
 
 #: src/components/ChartTokenSelector/ChartTokenSelector.tsx
 #: src/components/MarketSelector/MarketSelector.tsx
@@ -9982,7 +10156,7 @@ msgstr "裏付けトークンへのエクスポージャー"
 
 #: src/pages/Status/components/FrDefenseExplainer.tsx
 msgid "Defense escalates only when the previous phase is insufficient. Phase 0 covers the vast majority of market conditions."
-msgstr ""
+msgstr "防衛は前のフェーズが不十分な場合にのみエスカレートします。フェーズ0は大多数の市場環境をカバーします。"
 
 #: src/domain/vantage/trade/usePositionRouterTrade.ts
 msgid "Request submitted — waiting for Keeper execution"
@@ -9990,7 +10164,7 @@ msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "No pending requests"
-msgstr ""
+msgstr "保留中のリクエストはありません"
 
 #: src/components/OrderList/filters/OrderTypeFilter.tsx
 msgid "Search type"
@@ -10019,7 +10193,7 @@ msgstr "シフト"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
-msgstr ""
+msgstr "プロトコルのソルベンシー比率が低下したため、このポジションのファンディングレート相殺が一時的に停止されました。ソルベンシーが回復次第、自動的に復元されます。コラテラルおよびポジションは安全に保持されています。"
 
 #: src/components/NotifyModal/NotifyModal.tsx
 msgid "Liquidation risk alerts"
@@ -10051,7 +10225,7 @@ msgstr "エクスプレス + ワンクリック"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "ADL Mode:"
-msgstr ""
+msgstr "ADLモード:"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "GM tokens represent shares in a liquidity pool for a single GMX market. Buy GM to provide liquidity and earn fees from leverage trading, swaps, and market-making activity on that specific market. All rewards are auto-compounded."
@@ -10152,7 +10326,7 @@ msgstr "{marketName}をエクスプローラーで開く"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Position"
-msgstr ""
+msgstr "ポジション"
 
 #: src/components/Earn/Discovery/EarnProductCard.tsx
 msgid "What is GMX?"
@@ -10161,7 +10335,7 @@ msgstr "GMXとは？"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share price"
-msgstr ""
+msgstr "シェア価格"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "Deposit submitted"
@@ -10247,7 +10421,7 @@ msgstr "リンクがクリップボードにコピーされました"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "My Position"
-msgstr ""
+msgstr "私のポジション"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max pool capacity reached. Current: {poolAmountText}, max: {maxPoolAmountText}"
@@ -10263,7 +10437,7 @@ msgstr "オプションベースのボールト"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "No hedge positions. Open a hedge on the"
-msgstr ""
+msgstr "ヘッジポジションがありません。"
 
 #: src/components/OneClickAdvancedSettings/OneClickAdvancedSettings.tsx
 msgid "Time limit"
@@ -10301,7 +10475,7 @@ msgstr "トップPnL ($)"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "LP"
-msgstr ""
+msgstr "LP"
 
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Leverage trading terminal"
@@ -10376,10 +10550,6 @@ msgstr "手数料（ファンディング＋借入）だけでポジションが
 msgid "Claim price impact rebates"
 msgstr "価格への影響リベートを受け取る"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "シフトリクエストを実行中…"
@@ -10424,7 +10594,7 @@ msgstr "約定済みまたはキャンセル済みのトランザクションは
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Spot (LP)"
-msgstr ""
+msgstr "スポット（LP）"
 
 #: landing/src/pages/Home/SolanaRedirectModal/SolanaRedirectModal.tsx
 #: src/components/NetworkDropdown/SolanaNetworkItem.tsx
@@ -10493,7 +10663,7 @@ msgstr "指値価格"
 
 #: src/pages/Trade/TradePage.tsx
 msgid "ADL is active — profitable positions may be force-closed to restore Hub solvency. Cover ratio: {0}%"
-msgstr ""
+msgstr "ADLが発動中 — Hubのソルベンシー回復のため、含み益ポジションが強制クローズされる場合があります。カバー比率: {0}%"
 
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Select at least one distribution to claim"
@@ -10662,13 +10832,13 @@ msgstr "TP/SLボタンを使用してTP/SL注文を設定してください。"
 #: src/components/TVChartContainer/TVChartContainer.tsx
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Close Long"
-msgstr ""
+msgstr "ロングをクローズ"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "APY"
-msgstr ""
+msgstr "APY"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Traders referred on Arbitrum"
@@ -10680,7 +10850,7 @@ msgstr "GMとは？"
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Route"
-msgstr ""
+msgstr "ルート"
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/TPSLModal/TPSLOrdersList.tsx
@@ -10712,6 +10882,10 @@ msgstr "GMXからのアラートとお知らせを受け取り、取引や清算
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel}の購入は完了しましたが、Baseへのブリッジに失敗しました。資金はGMX Accountに安全に保管されています。ブリッジを再試行するか、{indexName}プールに移動してGMトークンを出金してください。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr "ステップ4–5"
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) はGMX V2におけるGLPの改良版です。利回りを最適化する暗号資産インデックストークンであり:"
@@ -10724,10 +10898,6 @@ msgstr "ベスティング用に預け入れた{1} esGMXのうち、{0}トーク
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "トリガー価格が清算価格を上回っています"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10874,7 +11044,7 @@ msgstr "<0>毎</0> {minutes} 分{0}"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Entry Price"
-msgstr ""
+msgstr "エントリー価格"
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "r:"
@@ -10974,6 +11144,10 @@ msgstr "ページを再読み込み"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "注文は実行されません: トリガー価格が清算価格を超えています"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr "フェーズ2 — 内部防衛"
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "決済中..."
@@ -11015,7 +11189,7 @@ msgstr "流動性は{chainNames}または{lastChainName}でのみ利用可能で
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Balance"
-msgstr ""
+msgstr "VLP残高"
 
 #: src/components/Referrals/AffiliatesStats.tsx
 msgid "Total trading volume from your referrals"
@@ -11041,6 +11215,10 @@ msgstr "ファンディング手数料を受け取る"
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Token permit testing"
 msgstr "トークンパーミットテスト"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr "レバレッジロック"
 
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
@@ -11087,7 +11265,7 @@ msgstr "選択期間におけるベンチマークとの比較パフォーマン
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "ソルベンシーは回復しています。ポジションの復元を待っています。"
-msgstr ""
+msgstr "ソルベンシーは回復しています。ポジションの復元を待っています。"
 
 #: src/components/Referrals/JoinReferralCode.tsx
 msgid "Referral code updated"
@@ -11096,10 +11274,6 @@ msgstr "リファラルコードが更新されました"
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "をクリックしてフィルタリングを切り替えます。このデバッグツールをスワップで使用するには、MARKET GRAPH タブのまま、スワップに切り替えてください。設定はローカルストレージに保存されます。完了後はクリアすることを忘れないでください。"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
 
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
@@ -11113,7 +11287,7 @@ msgstr "取引失敗"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Δ"
-msgstr ""
+msgstr "Δ"
 
 #: src/components/MarketStats/components/CompositionTable.tsx
 #: src/components/PositionList/PositionList.tsx
@@ -11134,6 +11308,7 @@ msgstr "Arbitrum で APE を <0>Camelot</0> で購入"
 msgid "Depositing..."
 msgstr "入金中…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11147,7 +11322,7 @@ msgstr "やや重要度の低いテキストですが、読み取り可能です
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Consider reducing leverage to improve your ADL protection ranking."
-msgstr ""
+msgstr "ADL保護ランキングを改善するため、レバレッジの引き下げを検討してください。"
 
 #: src/components/GmxAccountModal/DepositView.tsx
 msgid "30s"
@@ -11155,7 +11330,7 @@ msgstr "30秒"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "ソルベンシー比率"
-msgstr ""
+msgstr "ソルベンシー比率"
 
 #: src/components/GmList/PerformanceLabel.tsx
 msgid "Annualized performance"
@@ -11192,6 +11367,10 @@ msgstr "アドレスがコピーされました"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>請求前に未委任の{0} GMX DAO</0>投票権を委任。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr "新規エントリープレミアム急騰"
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "資金を請求"
@@ -11208,19 +11387,20 @@ msgstr "リファラルコードを生成"
 msgid "NET VALUE"
 msgstr "純価値"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
-msgstr ""
+msgstr "ボールト"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Leverage & Margin"
-msgstr ""
+msgstr "レバレッジ＆証拠金"
 
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Share Price"
-msgstr ""
+msgstr "シェア価格"
 
 #: src/components/OrderList/OrderList.tsx
 #: src/components/PositionList/PositionList.tsx
@@ -11259,7 +11439,7 @@ msgstr "最大値に合わせて出金額を減らしてください。<0>詳細
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "ADL Priority Factors (Hedge Mode):"
-msgstr ""
+msgstr "ADL優先度要因（ヘッジモード）:"
 
 #: src/components/GmList/GmList.tsx
 #: src/components/GmList/GmList.tsx
@@ -11375,6 +11555,7 @@ msgstr "イベント"
 msgid "Distribution"
 msgstr "分配"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}秒"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 アクション"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr "含み益の大きい投機的ロングポジションが強制クローズされ、未払いのFR債務が直接削減されます。"
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11403,7 +11588,7 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Connect wallet to hedge"
-msgstr ""
+msgstr "ウォレットを接続してヘッジ"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Benefit from up to 100x leverage and guaranteed on-chain liquidity that's not dependent on order book depth"
@@ -11427,7 +11612,7 @@ msgstr "新しいサイズまたは価格を入力"
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Position size exceeds OI cap. Available: ${availableUsd} (LP liquidity is ${0} × {1}%)"
-msgstr ""
+msgstr "ポジションサイズがOI上限を超えています。利用可能: ${availableUsd}（LP流動性 ${0} × {1}%）"
 
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/useGmSwapSubmitState.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -11442,7 +11627,7 @@ msgstr "不明な注文"
 #: src/pages/VantageLP/VantageLPPage.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "VLP Amount"
-msgstr ""
+msgstr "VLP量"
 
 #: src/components/PositionItem/PositionItem.tsx
 #: src/components/PositionShare/PositionShareCard.tsx
@@ -11494,10 +11679,6 @@ msgstr "ダッシュボード"
 msgid "Leftover collateral below {0} USD"
 msgstr "残余担保が{0} USD未満"
 
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
-
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
 msgstr "トリガー"
@@ -11533,7 +11714,7 @@ msgstr "{0} 件の注文が更新されませんでした。上限に達しま�
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Phase 2-4"
-msgstr ""
+msgstr "フェーズ2-4"
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "Proportional stored impact"
@@ -11549,11 +11730,11 @@ msgstr "EIP-4844、3月20-27日"
 
 #: src/pages/Hedge/HedgePage.tsx
 msgid "Vault APY"
-msgstr ""
+msgstr "Vault APY"
 
 #: src/pages/Status/components/OIStats.tsx
 msgid "+ve = shorts receive payment"
-msgstr ""
+msgstr "正 = ショートが受取"
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Save on costs"
@@ -11579,11 +11760,11 @@ msgstr "マーケットが見つかりません"
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "利回り"
-msgstr ""
+msgstr "利回り"
 
 #: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Step {defenseStep}:"
-msgstr ""
+msgstr "ステップ {defenseStep}:"
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient collateral. Need more"
@@ -11603,7 +11784,7 @@ msgstr "{chainName} ネットワークの活動増加により、ネットワー
 
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Trading Positions"
-msgstr ""
+msgstr "トレードポジション"
 
 #: src/components/Claims/ClaimsHistory.tsx
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
@@ -11716,11 +11897,11 @@ msgstr "ティアを保存"
 
 #: src/pages/Trade/components/PositionListPanel.tsx
 msgid "詳細"
-msgstr ""
+msgstr "詳細"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "New Hedges Temporarily Paused"
-msgstr ""
+msgstr "新規ヘッジを一時停止中"
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{count, plural, one {Order} other {# Orders}}"
@@ -11816,7 +11997,7 @@ msgstr "リファラルコードが作成されました"
 
 #: src/pages/Status/components/BufferGauges.tsx
 msgid "Internal Buffers"
-msgstr ""
+msgstr "内部バッファー"
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
@@ -11838,10 +12019,6 @@ msgstr "ブリッジ送金中..."
 msgid "Network fee"
 msgstr "ネットワーク手数料"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "非活性化"
@@ -11857,7 +12034,7 @@ msgstr "匿名の1対1チャットに参加して体験を共有しましょう"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Healthy"
-msgstr ""
+msgstr "健全"
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GMX staked rewards:"
@@ -11916,7 +12093,7 @@ msgstr "{1}でのガスに必要な{0}が不足しています<0/><1/><2>{2}を�
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "System Status"
-msgstr ""
+msgstr "システム状態"
 
 #: src/pages/PriceImpactRebatesStats/PriceImpactRebatesStats.tsx
 msgid "TIMEKEY"
@@ -12006,7 +12183,7 @@ msgstr "デリバティブポートフォリオトラッカー"
 
 #: src/pages/Trade/components/PriceChart.tsx
 msgid "High"
-msgstr ""
+msgstr "高値"
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Execution price didn't meet acceptable price. Order will fill when the condition is met."
@@ -12052,11 +12229,7 @@ msgstr "リファラルコードを入力して手数料の割引を受けまし
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
-msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
+msgstr "証拠金トークン"
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -316,10 +316,6 @@ msgstr "포지션에 대한 가상 재고"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "가장 활발한 시장에 유동성을 동적으로 배분하여 자본 효율성과 수익률을 극대화합니다"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "포지션과 담보에서 {indexSymbol}에 대한 이중 노출이 발�
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "GMX Account 잔액"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "포지션"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "인센티브, 에어드롭 및 상금이 여기에 표시됩니다"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "중앙화 거래소에서 GMX 구매"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "후속 질문을 위해 공유합니다"
@@ -906,6 +914,10 @@ msgstr "이 웹사이트는 오픈소스 <0>GMX 프론트엔드</0>의 커뮤니
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "수수료 및 가격 영향 차감 후 총 PnL(실현 + 미실현)"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "펀딩 감소 계수"
@@ -921,6 +933,10 @@ msgstr "유동성 내"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "수수료 값은 수익 발생 시점에 계산됩니다. 인센티브�
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "금고 및 풀의 TVL"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "마켓"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "활성 추천 코드"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "원클릭 트레이딩 비활성화. 시간 제한 만료."
 msgid "Session generation failed"
 msgstr "세션 생성 실패"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "온체인 퀘스트 및 보상"
@@ -1858,10 +1891,6 @@ msgstr "실패"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "주문 트리거 시 스왑 유동성이 부족할 수 있습니다"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "키"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "분배"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (중국어)"
 msgid "Search"
 msgstr "검색"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "WETH-USDC 풀에 기존 포지션이 있으나 이 주문에 대한 유동성이 부족합니다"
@@ -2409,6 +2447,10 @@ msgstr "과거 수수료"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "최대 미결제약정 {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "롱 미결제약정 준비금 비율"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "레이어 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade(이전 GMX Solana)는 다른 웹사이트에서 호스팅되며 
 msgid "Token categories"
 msgstr "토큰 카테고리"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "선택한 기간 동안 거래 내역이 없습니다"
@@ -3169,6 +3223,10 @@ msgstr "유효하지 않은 감소 규모"
 msgid "It's just a wrap"
 msgstr "단순 래핑입니다"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "구독"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "GMX를 위한 Dune 분석"
 msgid "Pending borrowing fees from all open positions"
 msgstr "모든 미결 포지션의 미지급 차입 수수료"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "마켓 그래프"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "영문자, 숫자, 밑줄만 허용됩니다"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Solana 지원</0><1>Botanix 지원</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "자금이 GMX Account에 입금되었습니다"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "유동성 부족. 유동성이 확보되면 주문이 체결됩니다."
@@ -3945,6 +4011,10 @@ msgstr "최소 담보 계수 OI 숏"
 msgid "Failed TWAP Swap part"
 msgstr "TWAP 스왑 부분 실패"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "최근 7일 데이터 기반 연환산"
@@ -4002,6 +4072,10 @@ msgstr "얇은 호가창이나 슬리피지 걱정 없이 대규모로 거래하
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "네트워크 기본 토큰 {0}에서는 Express Trading을 사용할 수 없습니다. 대신 {1} 사용을 고려하십시오."
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "GMX 피드백 공유"
 msgid "Withdraw failed"
 msgstr "출금에 실패했습니다"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "규칙 읽기"
 msgid "Source chain supports single token only"
 msgstr "소스 체인은 단일 토큰만 지원합니다"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "수령 매개변수가 누락되었습니다. 몇 초 후에 다시 시�
 msgid "AVG. LEV."
 msgstr "평균 레버리지"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "새 비율 또는 허용 슬리피지 입력"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "마켓 데이터 로딩 중..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "{longOrShort} 포지션은 펀딩 수수료 또는 차입 수수료를 지불하지 않습니다"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "{0} 내"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "가격 영향 리베이트가 누적되었습니다. 5일 후 수령 가능합니다. <0>자세히 보기</0>."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "{0} 편집"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>{wrappedNativeTokenSymbol} 구매</0>."
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "리베이트 배분 내역"
 msgid "Active orders"
 msgstr "활성 주문"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Avalanche 입금이 비활성화되어 있습니다. Avalanche 지갑에서 직접 거래하십시오."
@@ -4931,10 +5035,6 @@ msgstr "시장 선택"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "일치하는 토큰 없음"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "외부 스왑 실패 처리"
 msgid "Withdraw"
 msgstr "인출"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "스탑 마켓 업데이트"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "전환 요청이 전송되었습니다"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "양의 펀딩 수수료"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "자금이 곧 GMX Account에 입금됩니다"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "WETH-USDC 풀에 기존 지정가 주문이 있습니다.<0>WETH-USDC �
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "풀 최대 롱 USD 입금 한도"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "시프팅은 {chainNames} 또는 {lastChainName}에서만 가능합니다. 계속하려면 네트워크를 전환하십시오."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "스왑 경로 없음. <0>{0}을 {swapToTokenSymbol}로 스왑</0>, 그 다음 {1}로."
@@ -5938,6 +6074,11 @@ msgstr "체결가"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "로딩 중"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "분할 수"
 msgid "No open orders"
 msgstr "열려있는 주문이 없습니다"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "유동성 부족. 가용: {availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "에어드랍"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "앱 실행"
@@ -6420,10 +6569,6 @@ msgstr "{gasPaymentTokensText} 입금"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (포르투갈어)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "포지션이 청산 대상이 됩니다"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "미디어 키트"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "높은 레버리지는 청산 위험을 증가시킵니다"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "유효하지 않은 서명입니다.<0/><1/>다른 지갑 공급자를 시도하거나 <2>설정</2>에서 Classic 또는 One-Click Trading으로 전환하십시오"
@@ -7835,6 +7982,12 @@ msgstr "요약"
 msgid "ENTRY PRICE"
 msgstr "ENTRY PRICE"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "수수료 차감 후 PnL 표시"
@@ -7874,10 +8027,6 @@ msgstr "포지션 수수료 계수 (음수 PI)"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90일"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "최대 수량 초과"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "지정가 증가"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "전송 중..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "미스테이킹"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "알림"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "프로토콜 분석"
 msgid "Show positions on chart"
 msgstr "차트에 포지션 표시"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "수령"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "추천 코드를 사용 중인 트레이더 수"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "최대 예약 {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "GMX 보상:"
 msgid "Wallet trading only on these networks"
 msgstr "해당 네트워크에서는 지갑 거래만 가능합니다"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "조건가"
@@ -9714,6 +9880,10 @@ msgstr "출발 토큰 주소 없음"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "대형 계정"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "베스팅을 위해 {0} 토큰이 예약되어 있습니다"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "수수료(펀딩 + 차입)만으로도 포지션이 청산될 수 있으
 msgid "Claim price impact rebates"
 msgstr "가격 영향 리베이트 수령"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "시프트 요청을 실행하는 중…"
@@ -10712,6 +10882,10 @@ msgstr "GMX에서 알림 및 공지를 받아 거래, 청산 위험 등을 관�
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} 구매에 성공했으나 Base로의 브릿지가 실패했습니다. 자금은 GMX Account에 안전하게 보관되어 있습니다. 브릿지를 재시도하거나 {indexName} 풀로 이동하여 GM 토큰을 출금하십시오."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults)는 GMX V2의 개선된 GLP 버전입니다. 수익률을 최적화하는 암호화폐 인덱스 토큰으로:"
@@ -10724,10 +10898,6 @@ msgstr "베스팅을 위해 예치된 {1} esGMX 중 {0} 토큰이 GMX로 전환�
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "조건가가 청산가보다 높습니다"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "페이지 새로고침"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "주문이 실행되지 않습니다: 조건가가 청산가를 초과합니다"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "정산 중..."
@@ -11042,6 +11216,10 @@ msgstr "펀딩 수수료 수령"
 msgid "Token permit testing"
 msgstr "토큰 허용 테스트"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "GMX 직접 구매"
@@ -11097,10 +11275,6 @@ msgstr "추천 코드가 업데이트되었습니다"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "을 클릭하여 필터링을 전환합니다. 스왑에서 이 디버그 도구를 사용하려면 MARKET GRAPH 탭에서 스왑으로 전환하십시오. 설정은 로컬 스토리지에 저장되므로, 완료 후 반드시 삭제하십시오."
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "<0>Camelot</0>을 통해 Arbitrum에서 APE를 구매하십시오"
 msgid "Depositing..."
 msgstr "입금 중…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "주소가 복사되었습니다"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>청구 전 위임되지 않은 {0} GMX DAO</0> 투표권 위임."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "자금 청구"
@@ -11208,6 +11387,7 @@ msgstr "추천 코드 생성"
 msgid "NET VALUE"
 msgstr "순가치"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "EVENT"
 msgid "Distribution"
 msgstr "분배"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}초"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 액션"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "대시보드"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "잔여 담보 {0} USD 미만"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "자금 브릿징 중..."
 msgid "Network fee"
 msgstr "네트워크 수수료"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "비활성화됨"
@@ -12053,10 +12230,6 @@ msgstr "추천 코드를 입력하면 수수료 할인을 받으실 수 있습�
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -316,10 +316,6 @@ msgstr ""
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr ""
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -459,6 +455,10 @@ msgstr ""
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
 msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
@@ -661,6 +661,10 @@ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
 msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
@@ -887,6 +891,10 @@ msgstr ""
 msgid "Buy GMX on centralized exchanges"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr ""
@@ -906,6 +914,10 @@ msgstr ""
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr ""
@@ -921,6 +933,10 @@ msgstr ""
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1015,6 +1031,14 @@ msgstr ""
 
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
 msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
@@ -1165,6 +1189,10 @@ msgstr ""
 
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
 msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
@@ -1634,6 +1662,11 @@ msgstr ""
 msgid "Session generation failed"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr ""
@@ -1858,10 +1891,6 @@ msgstr ""
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr ""
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1996,6 +2026,10 @@ msgstr ""
 
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
 msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
@@ -2398,6 +2432,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr ""
@@ -2408,6 +2446,10 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
 msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2645,6 +2691,10 @@ msgstr ""
 
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
 msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
@@ -2939,6 +2989,10 @@ msgstr ""
 msgid "Token categories"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr ""
@@ -3169,6 +3223,10 @@ msgstr ""
 msgid "It's just a wrap"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr ""
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr ""
 msgid "Pending borrowing fees from all open positions"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3643,6 +3701,10 @@ msgstr ""
 
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
+msgstr ""
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
@@ -3839,6 +3901,10 @@ msgstr ""
 msgid "Funds are now in your GMX Account"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr ""
@@ -3945,6 +4011,10 @@ msgstr ""
 msgid "Failed TWAP Swap part"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr ""
@@ -4002,6 +4072,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr ""
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr ""
 msgid "Withdraw failed"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr ""
 msgid "Source chain supports single token only"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,8 +4724,16 @@ msgstr ""
 msgid "AVG. LEV."
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -4783,6 +4880,12 @@ msgstr ""
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr ""
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr ""
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr ""
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr ""
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr ""
 msgid "Active orders"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr ""
@@ -4931,10 +5035,6 @@ msgstr ""
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr ""
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr ""
 msgid "Withdraw"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr ""
@@ -5217,6 +5325,11 @@ msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
 msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5411,6 +5525,11 @@ msgstr ""
 
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
 msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
@@ -5484,6 +5603,11 @@ msgstr ""
 msgid "GM: {0}"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr ""
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr ""
@@ -5937,6 +6073,11 @@ msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
 msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
@@ -6319,6 +6460,10 @@ msgstr ""
 msgid "No open orders"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr ""
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr ""
@@ -6420,10 +6569,6 @@ msgstr ""
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr ""
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr ""
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr ""
 msgid "High leverage increases liquidation risk"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr ""
@@ -7835,6 +7982,12 @@ msgstr ""
 msgid "ENTRY PRICE"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr ""
@@ -7874,10 +8027,6 @@ msgstr ""
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr ""
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8092,6 +8245,10 @@ msgstr ""
 
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
 msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
@@ -8716,10 +8873,6 @@ msgstr ""
 msgid "{0}ms"
 msgstr ""
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr ""
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr ""
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr ""
 msgid "Show positions on chart"
 msgstr ""
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr ""
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9382,6 +9540,10 @@ msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
 msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
@@ -9683,6 +9845,10 @@ msgstr ""
 msgid "Wallet trading only on these networks"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr ""
@@ -9713,6 +9879,10 @@ msgstr ""
 
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
 msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
@@ -9905,6 +10075,10 @@ msgstr ""
 
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
 msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
@@ -10376,10 +10550,6 @@ msgstr ""
 msgid "Claim price impact rebates"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr ""
@@ -10712,6 +10882,10 @@ msgstr ""
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr ""
@@ -10724,10 +10898,6 @@ msgstr ""
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr ""
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr ""
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr ""
@@ -11042,6 +11216,10 @@ msgstr ""
 msgid "Token permit testing"
 msgstr ""
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr ""
@@ -11097,10 +11275,6 @@ msgstr ""
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr ""
 msgid "Depositing..."
 msgstr ""
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr ""
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr ""
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr ""
@@ -11208,6 +11387,7 @@ msgstr ""
 msgid "NET VALUE"
 msgstr ""
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr ""
 msgid "Distribution"
 msgstr ""
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11387,6 +11568,10 @@ msgstr ""
 
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
 msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
@@ -11492,10 +11677,6 @@ msgstr ""
 
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
-msgstr ""
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
 msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
@@ -11838,10 +12019,6 @@ msgstr ""
 msgid "Network fee"
 msgstr ""
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr ""
@@ -12053,10 +12230,6 @@ msgstr ""
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -316,10 +316,6 @@ msgstr "Виртуальный инвентарь для позиций"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "Динамически распределяет ликвидность на наиболее востребованные рынки, максимизируя эффективность капитала и доходность"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "Двойная экспозиция {indexSymbol} от позиции и
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "Баланс GMX Account"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "Позиции"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "Поощрения, аирдропы и призы будут отображаться здесь"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "Купить GMX на централизованных биржах"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "Для дальнейших вопросов"
@@ -906,6 +914,10 @@ msgstr "Этот сайт является экземпляром с откры�
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "Общий PnL (реализованный + нереализованный) за вычетом комиссий и влияния на цену"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "Фактор снижения фондирования"
@@ -921,6 +933,10 @@ msgstr "используется для обеспечения ликвидно�
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "Значения комиссий рассчитываются на мо
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "TVL в хранилищах и пулах"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "РЫНОК"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "Активный реферальный код"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "Торговля в один клик отключена. Истекло
 msgid "Session generation failed"
 msgstr "Не удалось сгенерировать сессию"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "Ончейн-задания и вознаграждения"
@@ -1858,10 +1891,6 @@ msgstr "Ошибка"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "Ликвидности для обмена может быть недостаточно при срабатывании ордера"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "Ключ"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "Распределения"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (Китайский)"
 msgid "Search"
 msgstr "Поиск"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "Существующая позиция в пуле WETH-USDC, но недостаточная ликвидность для данного ордера"
@@ -2409,6 +2447,10 @@ msgstr "Комиссии за прошлое"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "Макс. открытый интерес {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "Резервный фактор открытого интереса дл
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Layer 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade (ранее GMX Solana) размещён на другом са�
 msgid "Token categories"
 msgstr "Категории токенов"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "Вы не совершали сделок за выбранный период"
@@ -3169,6 +3223,10 @@ msgstr "Недопустимый размер уменьшения"
 msgid "It's just a wrap"
 msgstr "Это просто wrap"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "Подписаться"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "Dune Analytics для GMX"
 msgid "Pending borrowing fees from all open positions"
 msgstr "Незафиксированные комиссии за заимствование по всем открытым позициям"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "График рынка"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "Допускаются только буквы, цифры и символы подчёркивания"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Поддержка Solana</0><1>Поддержка Botanix</1><2>GMX 
 msgid "Funds are now in your GMX Account"
 msgstr "Средства поступили на ваш GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "Недостаточная ликвидность. Ордер будет исполнен, когда появится ликвидность."
@@ -3945,6 +4011,10 @@ msgstr "Мин. фактор обеспечения OI шорт"
 msgid "Failed TWAP Swap part"
 msgstr "Ошибка части TWAP Swap"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "Годовые данные на основе последних 7 дней"
@@ -4002,6 +4072,10 @@ msgstr "Торгуйте крупными объёмами, не беспоко�
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading недоступен с нативным токеном сети {0}. Рассмотрите использование {1} вместо него."
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "Поделиться отзывом о GMX"
 msgid "Withdraw failed"
 msgstr "Вывод не удался"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "Прочитайте правила"
 msgid "Source chain supports single token only"
 msgstr "Исходная сеть поддерживает только один токен"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "Отсутствуют параметры для получения. П�
 msgid "AVG. LEV."
 msgstr "СРЕД. ПЛЕЧО"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "Введите новое соотношение или допустимое скольжение"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "Загрузка данных рынков..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "Позиции {longOrShort} не платят комиссию за финансирование или комиссию за заимствование"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "в {0}"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "Возвраты за влияние на цену начислены. Доступны для получения через 5 дней. <0>Подробнее</0>."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "Редактировать {0}"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>Купить</0> {wrappedNativeTokenSymbol}."
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "История распределения возвратов"
 msgid "Active orders"
 msgstr "Активные ордера"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "Депозит на Avalanche отключён. Торгуйте напрямую с вашего кошелька Avalanche."
@@ -4931,10 +5035,6 @@ msgstr "Выбрать рынок"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "Нет совпадающих токенов"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "Принудительный сбой внешних свопов"
 msgid "Withdraw"
 msgstr "Вывод"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "Обновить Стоп-Маркет"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "Запрос на перераспределение отправлен"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "Положительные комиссии за финансирование"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "Средства скоро поступят на ваш GMX Account"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "Существующий лимитный ордер в пуле WETH-US
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "Макс. лонг USD пула для депозита"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Перемещение доступно только на {chainNames} или {lastChainName}. Переключите сеть для продолжения."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "Нет доступного пути обмена. <0>Обмен {0} на {swapToTokenSymbol}</0>, затем на {1}."
@@ -5938,6 +6074,11 @@ msgstr "ЦЕНА ИСПОЛНЕНИЯ"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "загрузка"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "Количество частей"
 msgid "No open orders"
 msgstr "Нет открытых ордеров"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "Недостаточная ликвидность. Доступно: {availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "Аирдроп"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "Запустить приложение"
@@ -6420,10 +6569,6 @@ msgstr "Внести {gasPaymentTokensText}"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (Португальский)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "Позиция будет подлежать ликвидации"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "Медиакит"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "Высокое кредитное плечо увеличивает риск ликвидации"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "Недействительная подпись.<0/><1/>Попробуйте другого провайдера кошелька или переключитесь на Classic Trading или One-Click Trading в <2>настройках</2>"
@@ -7835,6 +7982,12 @@ msgstr "Сводка"
 msgid "ENTRY PRICE"
 msgstr "ЦЕНА ВХОДА"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "Отображать PnL после комиссий"
@@ -7874,10 +8027,6 @@ msgstr "Фактор комиссии позиции (отрицательное
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90д"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "Максимальная сумма превышена"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "Увеличение лимита"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "Перевод..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "Не в стейкинге"
 msgid "{0}ms"
 msgstr "{0}мс"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "Уведомления"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "Аналитика протокола"
 msgid "Show positions on chart"
 msgstr "Показать позиции на графике"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "Получение"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "Количество трейдеров, использующих ваш
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "Макс. зарезервировано {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "Награды GMX:"
 msgid "Wallet trading only on these networks"
 msgstr "Торговля только через кошелёк в этих сетях"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "Цена активации"
@@ -9714,6 +9880,10 @@ msgstr "Нет адреса исходного токена"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "Крупный аккаунт"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "Токенов зарезервировано для вестинга: {
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "Что-то пошло не так"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "Позиция может быть ликвидирована тольк
 msgid "Claim price impact rebates"
 msgstr "Получить компенсации за влияние на цену"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "Выполнение запроса на перемещение…"
@@ -10712,6 +10882,10 @@ msgstr "Получайте оповещения и уведомления от G
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} успешно куплены, но мост на Base не удался. Ваши средства в безопасности в вашем GMX Account. Повторите мост или перейдите в пул {indexName}, чтобы вывести свои GM токены."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) — это улучшенная версия GLP в GMX V2. Это крипто-индексный токен с оптимизацией доходности, который:"
@@ -10724,10 +10898,6 @@ msgstr "{0} токенов конвертировано в GMX из {1} esGMX, �
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "Цена активации выше цены ликвидации"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "Перезагрузить страницу"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "Ордер не будет исполнен: цена активации за пределами цены ликвидации"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "Расчёт..."
@@ -11042,6 +11216,10 @@ msgstr "Получить комиссии финансирования"
 msgid "Token permit testing"
 msgstr "Тестирование разрешений токенов"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "Купить GMX напрямую"
@@ -11097,10 +11275,6 @@ msgstr "Реферальный код обновлён"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "для переключения фильтрации. Чтобы использовать этот инструмент отладки для свопов, оставайтесь на вкладке MARKET GRAPH и переключитесь на свопы. Настройки сохраняются в локальном хранилище; не забудьте очистить его по завершении."
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "Купить APE на Arbitrum через <0>Camelot</0>"
 msgid "Depositing..."
 msgstr "Внесение средств…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "Адрес скопирован"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>Делегируйте вашу не делегированную {0} GMX DAO</0> голосовую силу перед заявкой."
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "Клейм средств"
@@ -11208,6 +11387,7 @@ msgstr "Создать реферальный код"
 msgid "NET VALUE"
 msgstr "НЕТТО-СТОИМОСТЬ"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "СОБЫТИЕ"
 msgid "Distribution"
 msgstr "Распределение"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}с"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 действия"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "Панели"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "Оставшийся залог ниже {0} USD"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "Перевод средств в..."
 msgid "Network fee"
 msgstr "Комиссия сети"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "Деактивировано"
@@ -12053,10 +12230,6 @@ msgstr "Введите реферальный код для получения �
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -316,10 +316,6 @@ msgstr "倉位虛擬庫存"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "動態將流動性分配至使用率最高的市場，最大化資金效率與收益"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "倉位和抵押品帶來雙重 {indexSymbol} 曝險。清算價格高於
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "GMX Account 餘額"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "倉位"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "獎勵、空投和獎品將顯示在這裡"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "在中心化交易所購買 GMX"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "分享以便後續問題聯繫"
@@ -906,6 +914,10 @@ msgstr "本網站是開源 <0>GMX 前端</0>的社群部署實例，託管於分
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "扣除費用及價格影響後的總 PnL（已實現 + 未實現）"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "資金遞減因子"
@@ -921,6 +933,10 @@ msgstr "流動性"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "費用數值在賺取時計算。不包含獎勵。"
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "金庫與池中的 TVL"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "市場"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "使用中的推薦碼"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "One-Click Trading 已停用。時間限制已到期。"
 msgid "Session generation failed"
 msgstr "工作階段產生失敗"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "鏈上任務與獎勵"
@@ -1858,10 +1891,6 @@ msgstr "失敗"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "訂單觸發時兌換流動性可能不足"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "金鑰"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "分配"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX（中文）"
 msgid "Search"
 msgstr "搜尋"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "WETH-USDC 池中有現有倉位，但此訂單的流動性不足"
@@ -2409,6 +2447,10 @@ msgstr "過去的費用"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "最大未平倉量 {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "做多未平倉量儲備因子"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Layer 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade（前身為 GMX Solana）託管在另一個網站上，由不同
 msgid "Token categories"
 msgstr "代幣類別"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "您在所選期間內未進行任何交易"
@@ -3169,6 +3223,10 @@ msgstr "無效的減少規模"
 msgid "It's just a wrap"
 msgstr "這只是一個包裝操作"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "訂閱"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "Dune Analytics for GMX"
 msgid "Pending borrowing fees from all open positions"
 msgstr "所有未平倉倉位的待結算借貸費用"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "市場圖表"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "僅允許字母、數字和底線"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Solana 支援</0><1>Botanix 支援</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "資金已存入您的 GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "流動性不足。當流動性可用時將執行訂單。"
@@ -3945,6 +4011,10 @@ msgstr "做空未平倉量最低抵押品因子"
 msgid "Failed TWAP Swap part"
 msgstr "TWAP 兌換部分失敗"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "年化數據基於過去 7 天"
@@ -4002,6 +4072,10 @@ msgstr "大規模交易，無需擔憂薄弱的訂單簿或滑點"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading 不支援網路原生代幣 {0}。請考慮改用 {1}。"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "分享 GMX 意見回饋"
 msgid "Withdraw failed"
 msgstr "提取失敗"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "閱讀規則"
 msgid "Source chain supports single token only"
 msgstr "來源鏈僅支援單一代幣"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "缺少領取參數，請稍後重試"
 msgid "AVG. LEV."
 msgstr "平均槓桿"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "請輸入新比例或允許的滑點"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "正在載入市場資料..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "{longOrShort} 倉位不需支付資金費率或借貸費用"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "於 {0}"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "價格影響回饋已累積，5 天後可領取。<0>閱讀更多</0>。"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "編輯 {0}"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>買入</0> {wrappedNativeTokenSymbol}。"
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "回饋分配歷史"
 msgid "Active orders"
 msgstr "進行中的訂單"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "已停用存入 Avalanche 功能。請直接從您的 Avalanche 錢包進行交易。"
@@ -4931,10 +5035,6 @@ msgstr "選擇市場"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "沒有符合的代幣"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "強制外部兌換失敗"
 msgid "Withdraw"
 msgstr "提取"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "更新止損市價單"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "轉移請求已發送"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "正向資金費用"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "資金將很快顯示在您的 GMX Account 中"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "WETH-USDC 池中有現有限價單。<0>切換至 WETH-USDC 池</0>"
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "池做多 USD 存入上限"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "Shifting 僅適用於 {chainNames} 或 {lastChainName}。請切換網路以繼續。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "無可用兌換路徑。<0>將 {0} 兌換為 {swapToTokenSymbol}</0>，再兌換為 {1}。"
@@ -5938,6 +6074,11 @@ msgstr "成交價格"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "載入中"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "分割數量"
 msgid "No open orders"
 msgstr "沒有未結訂單"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "流動性不足。可用：{availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "空投"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "啟動應用程式"
@@ -6420,10 +6569,6 @@ msgstr "存入 {gasPaymentTokensText}"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX（葡萄牙語）"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "倉位將面臨清算"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "媒體素材包"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX 交易統計"
 msgid "High leverage increases liquidation risk"
 msgstr "高槓桿會增加清算風險"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "無效簽名。<0/><1/>請嘗試其他錢包供應商，或在<2>設定</2>中切換至 Classic 或 One-Click Trading"
@@ -7835,6 +7982,12 @@ msgstr "摘要"
 msgid "ENTRY PRICE"
 msgstr "入場價格"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "顯示扣除費用後的 PnL"
@@ -7874,10 +8027,6 @@ msgstr "倉位手續費因子（負向 PI）"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90天"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "超過最大數量"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "Limit Increase"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "轉帳中..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "未質押"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "通知"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "協議分析"
 msgid "Show positions on chart"
 msgstr "在圖表上顯示倉位"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "收到"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "使用您推薦碼的交易者數量"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "最大保留 {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "GMX 獎勵："
 msgid "Wallet trading only on these networks"
 msgstr "僅在這些網路上使用錢包交易"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "觸發價格"
@@ -9714,6 +9880,10 @@ msgstr "無來源代幣地址"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "大型帳戶"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "{0} 代幣已保留用於歸屬"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "發生錯誤"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "倉位可能僅因費用（資金費用 + 借貸費用）而被清算，
 msgid "Claim price impact rebates"
 msgstr "領取價格影響回饋"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "正在處理轉換請求..."
@@ -10712,6 +10882,10 @@ msgstr "獲取 GMX 的提醒和公告，隨時掌握您的交易、清算風險�
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} 買入成功，但橋接至 Base 失敗。您的資金安全存放在您的 GMX Account 中。請重試橋接，或前往 {indexName} 池提取您的 GM 代幣。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV（GMX Liquidity Vaults）是 GMX V2 對 GLP 的改良版本。這是一種收益優化的加密指數代幣，能夠："
@@ -10724,10 +10898,6 @@ msgstr "{0} 個代幣已從存入歸屬期的 {1} esGMX 轉換為 GMX。"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "觸發價格高於清算價格"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "重新載入頁面"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "訂單將不會執行：觸發價格超過清算價格"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "結算中..."
@@ -11042,6 +11216,10 @@ msgstr "領取資金費用"
 msgid "Token permit testing"
 msgstr "代幣許可測試"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "直接購買 GMX"
@@ -11097,10 +11275,6 @@ msgstr "推薦碼已更新"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "以切換其篩選。若要在兌換上使用此除錯工具，請停留在 MARKET GRAPH 分頁並切換至兌換。設定儲存於本機儲存空間中，完成後請記得清除。"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "透過 <0>Camelot</0> 在 Arbitrum 上購買 APE"
 msgid "Depositing..."
 msgstr "存入中..."
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "地址已複製"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>在領取前，請將您未委託的 {0} GMX DAO</0>投票權進行委託。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "領取資金"
@@ -11208,6 +11387,7 @@ msgstr "產生推薦碼"
 msgid "NET VALUE"
 msgstr "淨值"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "事件"
 msgid "Distribution"
 msgstr "分配"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}s"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 操作"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "儀表板"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "剩餘抵押品低於 {0} USD"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "資金正在跨鏈至..."
 msgid "Network fee"
 msgstr "網路費用"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "已停用"
@@ -12053,10 +12230,6 @@ msgstr "輸入推薦碼以獲得手續費折扣"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -316,10 +316,6 @@ msgstr "仓位虚拟库存"
 msgid "Dynamically allocates liquidity to highest-utilized markets, maximizing capital efficiency and yield"
 msgstr "动态分配流动性至使用率最高的市场，最大化资本效率和收益"
 
-#: src/pages/Status/components/FrDefenseExplainer.tsx
-#~ msgid "FR Risk Defense — How it works"
-#~ msgstr ""
-
 #: src/components/ExpressTradingOutOfGasBanner/ExpressTradingOutOfGasBanner.tsx
 #: src/components/TradeBox/ExpressTradingWarningCard.tsx
 msgid "Buy {gasPaymentTokensText}"
@@ -460,6 +456,10 @@ msgstr "仓位和抵押品带来双重 {indexSymbol} 敞口。清算价格高于
 #: src/components/MultichainBalanceTooltip/MultichainBalanceTooltip.tsx
 msgid "GMX Account balance"
 msgstr "GMX Account 余额"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-yield junior LP (USDC) profits absorb the deficit, shielding senior LPs (RWA) and maintaining hedge user costs."
+msgstr ""
 
 #: src/components/DebugMarketGraph/DebugMarketGraph.tsx
 msgid "Best swap path"
@@ -662,6 +662,10 @@ msgstr "仓位"
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "Incentives, airdrops, and prizes will appear here"
 msgstr "激励、空投和奖励将在此处显示"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve Fund Utilization"
+msgstr ""
 
 #: src/components/NetworkFeeRow/NetworkFeeRow.tsx
 msgid "Max network fee includes fees for additional orders. Refunded in full if they don't trigger and are canceled. <0>Read more</0>."
@@ -887,6 +891,10 @@ msgstr "Lorem ipsum dolor"
 msgid "Buy GMX on centralized exchanges"
 msgstr "在中心化交易所买入 GMX"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Restriction"
+msgstr ""
+
 #: src/components/NpsModal/NpsModal.tsx
 msgid "Share for follow-up questions"
 msgstr "用于后续问题的跟进联系"
@@ -906,6 +914,10 @@ msgstr "该网站是开源 <0>GMX 前端</0>的社区部署实例，托管在分
 msgid "Total PnL (realized + unrealized) after fees and price impact"
 msgstr "扣除费用和价格影响后的总 PnL（已实现 + 未实现）"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield-Bearing"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Funding decrease factor"
 msgstr "资金递减因子"
@@ -921,6 +933,10 @@ msgstr "流动性中"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "システム収益保護のため、現在一時的にFR相殺が停止されています"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Last line of defense. Some hedge shorts are force-closed (or converted to paid-shorts) to prevent LP insolvency and protocol halt — rather than raising costs retroactively."
 msgstr ""
 
 #: src/pages/VaultDetail/VaultDetailPage.tsx
@@ -1016,6 +1032,14 @@ msgstr "费用值在获得时计算。不包含激励。"
 #: src/pages/Pools/Pools.tsx
 msgid "TVL in vaults and pools"
 msgstr "金库和池中的 TVL"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Stablecoin"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Reserve fund temporarily boosts LP rewards to attract new RWA deposits and expand pool capacity."
+msgstr ""
 
 #: src/pages/Trade/components/PendingRequestsPanel.tsx
 msgid "Clear completed"
@@ -1166,6 +1190,10 @@ msgstr "市场"
 #: src/components/Referrals/TradersStats.tsx
 msgid "Active referral code"
 msgstr "当前推荐码"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 1–3"
+msgstr ""
 
 #: src/components/UserIncentiveDistribution/ClaimableDistribution.tsx
 msgid "View breakdown"
@@ -1634,6 +1662,11 @@ msgstr "一键交易已禁用。时间限制已过期。"
 msgid "Session generation failed"
 msgstr "会话生成失败"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 2 · Internal Buffer"
+msgstr ""
+
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "Onchain quests and rewards"
 msgstr "链上任务和奖励"
@@ -1858,10 +1891,6 @@ msgstr "失败"
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr ""
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Restricted (weekend)"
-#~ msgstr ""
-
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
 msgid "No fee"
@@ -1872,6 +1901,7 @@ msgid "Swap liquidity may be insufficient when order triggers"
 msgstr "订单触发时兑换流动性可能不足"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "Reserve Fund"
 msgstr ""
 
@@ -1997,6 +2027,10 @@ msgstr "密钥"
 #: src/pages/Earn/EarnPageLayout.tsx
 msgid "Distributions"
 msgstr "分配"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Senior LP yield will be used to make FR payments"
+msgstr ""
 
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Max profit limit reached. Current: {pnlToPoolFactorText}, max: {maxPnlFactorText}"
@@ -2398,6 +2432,10 @@ msgstr "GMX (中文)"
 msgid "Search"
 msgstr "搜索"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode B — Premium Only"
+msgstr ""
+
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Existing position in WETH-USDC pool but lacks liquidity for this order"
 msgstr "WETH-USDC 池中存在现有仓位，但该池流动性不足以执行此订单"
@@ -2409,6 +2447,10 @@ msgstr "过去的费用"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max open interest {directionLabel}"
 msgstr "最大未平仓量 {directionLabel}"
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "No yield earned. Hedge cost = funding rate only."
+msgstr ""
 
 #: src/domain/synthetics/orders/cancelOrdersTxn.ts
 msgid "{ordersText} cancellation failed"
@@ -2506,6 +2548,10 @@ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Consider reducing leverage to lower your ADL priority."
+msgstr ""
+
+#: src/components/SettingsModal/LanguageSettings.tsx
+msgid "Select your preferred language"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -2646,6 +2692,10 @@ msgstr "做多未平仓量储备因子"
 #: src/context/TokensFavoritesContext/TokensFavoritesContextProvider.tsx
 msgid "Layer 2"
 msgstr "Layer 2"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Normal Operation"
+msgstr ""
 
 #: src/pages/Trade/components/OpenPositionPanel.tsx
 #: src/pages/VantageLP/VantageLPPage.tsx
@@ -2939,6 +2989,10 @@ msgstr "GMTrade（前身为 GMX Solana）托管在另一个网站上，由另一
 msgid "Token categories"
 msgstr "代币类别"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Normal"
+msgstr ""
+
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
 msgid "You have not traded during the selected period"
 msgstr "您在所选时间段内没有交易记录"
@@ -3169,6 +3223,10 @@ msgstr "无效的减仓规模"
 msgid "It's just a wrap"
 msgstr "这只是一笔包装操作"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "High-Lev Lock"
+msgstr ""
+
 #: landing/src/pages/Home/SocialSection/SocialSection.tsx
 msgid "Subscribe"
 msgstr "订阅"
@@ -3348,10 +3406,6 @@ msgstr ""
 #: src/pages/Trade/components/SpreadBadge.tsx
 msgid "Ask"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is kept as a normal short. Funding rate payments apply from ADL moment."
-#~ msgstr ""
 
 #: src/pages/Status/components/AdlLeaderboard.tsx
 msgid "Low leverage and long tenure protect you from ADL. You are in the loyalty tier."
@@ -3569,6 +3623,10 @@ msgstr "GMX 的 Dune Analytics"
 msgid "Pending borrowing fees from all open positions"
 msgstr "所有未平仓仓位的待结算借贷费用"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Surge"
+msgstr ""
+
 #: src/components/TVChartContainer/useChartContextMenu.ts
 msgid "Set Long Take Profit @ {0}"
 msgstr ""
@@ -3644,6 +3702,10 @@ msgstr "市场图表"
 #: src/components/Referrals/referralsHelper.ts
 msgid "Only letters, numbers, and underscores allowed"
 msgstr "仅允许字母、数字和下划线"
+
+#: src/pages/Status/StatusPage.tsx
+msgid "Real-time solvency dashboard. 8-step defense sequence transparency."
+msgstr ""
 
 #: landing/src/pages/Home/HeroSection/Features.tsx
 msgid "Trade from your wallet"
@@ -3839,6 +3901,10 @@ msgstr "<0>Solana 支持</0><1>Botanix 支持</1><2>GMX Express</2>"
 msgid "Funds are now in your GMX Account"
 msgstr "资金已存入您的 GMX Account"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Junior Vault Buffer"
+msgstr ""
+
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Insufficient liquidity. Order will fill when liquidity is available."
 msgstr "流动性不足。订单将在流动性可用时成交。"
@@ -3945,6 +4011,10 @@ msgstr "最小抵押品因子 OI 做空"
 msgid "Failed TWAP Swap part"
 msgstr "TWAP 兑换子单失败"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 1 — Prevention"
+msgstr ""
+
 #: src/pages/Dashboard/OverviewCard.tsx
 msgid "Annualized data based on the past 7 days"
 msgstr "基于过去 7 天数据的年化计算"
@@ -4002,6 +4072,10 @@ msgstr "大规模交易无需担忧订单簿深度不足或滑点问题"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Safety buffer is at its base level ({basePct}%). Market conditions are stable — no FR spike adjustment active."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Your staking yield offsets the hedge premium. Net cost may be positive."
 msgstr ""
 
 #: src/components/Claims/SettleAccruedCard.tsx
@@ -4111,6 +4185,7 @@ msgid "Express Trading is unavailable with the network's native token {0}. Consi
 msgstr "Express Trading 不支持网络原生代币 {0}。请考虑使用 {1} 替代。"
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
+#: src/components/AppNav/AppNav.tsx
 #: src/components/SideNav/SideNav.tsx
 #: src/pages/SyntheticsPage/SyntheticsPage.tsx
 msgid "Trade"
@@ -4297,8 +4372,18 @@ msgstr "分享 GMX 反馈"
 msgid "Withdraw failed"
 msgstr "提取失败"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Hedge ADL"
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "This token earns no yield. Hedge cost = funding rate only."
 msgstr ""
 
 #. chainname balance
@@ -4532,6 +4617,10 @@ msgstr "阅读规则"
 msgid "Source chain supports single token only"
 msgstr "来源链仅支持单一代币"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Users pay zero fees for perpetual hedging, thanks to the Yield Token FR Offset mechanism."
+msgstr ""
+
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 #: src/components/TVChart/ChartHeader.tsx
 #: src/pages/Dashboard/OverviewCard.tsx
@@ -4635,9 +4724,17 @@ msgstr "缺少领取参数。请稍后重试"
 msgid "AVG. LEV."
 msgstr "AVG. LEV."
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting mode…"
+msgstr ""
+
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a new ratio or allowed slippage"
 msgstr "输入新比率或允许滑点"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Hedge-Shorts"
+msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Risk Management"
@@ -4783,6 +4880,12 @@ msgstr "正在加载市场数据..."
 msgid "{longOrShort} positions do not pay a funding fee or a borrow fee"
 msgstr "{longOrShort} 仓位无需支付资金费用或借贷费用"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 1 · Prevention"
+msgstr ""
+
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "in {0}"
 msgstr "在 {0} 中"
@@ -4799,6 +4902,7 @@ msgstr ""
 msgid "Price impact rebates accrued. Claimable after 5 days. <0>Read more</0>."
 msgstr "价格影响返利已累计。5 天后可领取。<0>了解更多</0>。"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Earn/EarnPageLayout.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
 msgid "Portfolio"
@@ -4870,10 +4974,6 @@ msgstr "编辑 {0}"
 msgid "<0>Buy</0> {wrappedNativeTokenSymbol}."
 msgstr "<0>购买</0> {wrappedNativeTokenSymbol}。"
 
-#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
-msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 7-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
-msgstr ""
-
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
 #: src/pages/Admin/AdminPage.tsx
@@ -4915,6 +5015,10 @@ msgstr "返利分配历史记录"
 msgid "Active orders"
 msgstr "活跃订单"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Jr Buffer"
+msgstr ""
+
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Depositing to Avalanche is disabled. Trade directly from your Avalanche wallet."
 msgstr "向 Avalanche 存款已禁用。请直接从您的 Avalanche 钱包进行交易。"
@@ -4931,10 +5035,6 @@ msgstr "选择市场"
 #: src/components/TokenSelector/TokenSelector.tsx
 msgid "No tokens matched"
 msgstr "没有匹配的代币"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Est. USDC received"
-#~ msgstr ""
 
 #: src/pages/TestPermits/TestPermits.tsx
 msgid "Error sending permit for {0}: {1}"
@@ -5172,6 +5272,14 @@ msgstr "强制外部兑换失败"
 msgid "Withdraw"
 msgstr "提取"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "High-leverage (5×+) new hedges are locked. Once the OI cap is reached, all new entries are frozen."
+msgstr ""
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 0 · Normal"
+msgstr ""
+
 #: src/components/TradeHistory/keys.ts
 msgid "Update Stop Market"
 msgstr "更新止损市价"
@@ -5218,6 +5326,11 @@ msgstr ""
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Shift request sent"
 msgstr "Shift 请求已发送"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Safe"
+msgstr ""
 
 #: src/components/AcceptablePriceImpactInputRow/AcceptablePriceImpactInputRow.tsx
 msgid "Current impact: {0}. Add 0.30% buffer for better order execution."
@@ -5404,6 +5517,7 @@ msgid "Positive funding fees"
 msgstr "正向资金费率"
 
 #: src/pages/Admin/AdminPage.tsx
+#: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Trade/components/FundingRateChart.tsx
 #: src/pages/Trade/components/OIChart.tsx
 msgid "Loading…"
@@ -5412,6 +5526,11 @@ msgstr ""
 #: src/components/GmxAccountModal/DepositStatusView.tsx
 msgid "Funds will appear in your GMX Account soon"
 msgstr "资金将很快显示在您的 GMX Account 中"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Final Defense"
+msgstr ""
 
 #: src/components/InterviewToast/InterviewToast.tsx
 msgid "Join an anonymous one-on-one chat to share your GMX liquidity provider experience"
@@ -5484,6 +5603,11 @@ msgstr "WETH-USDC 池中存在现有限价单。<0>切换至 WETH-USDC 池</0>"
 msgid "GM: {0}"
 msgstr "GM: {0}"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Senior Yield"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pool max long USD for deposit"
 msgstr "池最大做多 USD 存入上限"
@@ -5550,6 +5674,10 @@ msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Auto-Terminate"
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "System working as intended"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/GmxAssetCard.tsx
@@ -5910,6 +6038,14 @@ msgstr ""
 msgid "Shifting only available on {chainNames} or {lastChainName}. Switch networks to continue."
 msgstr "转换仅在 {chainNames} 或 {lastChainName} 上可用。请切换网络以继续。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "The protocol stability fund covers FR shortfalls using surplus accumulated from past profits."
+msgstr ""
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Supply-Side Incentive"
+msgstr ""
+
 #: src/components/TradeBox/hooks/useTradeButtonState.tsx
 msgid "No swap path available. <0>Swap {0} to {swapToTokenSymbol}</0>, then to {1}."
 msgstr "无可用交换路径。<0>将 {0} 交换到 {swapToTokenSymbol}</0>，然后到 {1}。"
@@ -5938,6 +6074,11 @@ msgstr "成交价格"
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "spinner"
 msgstr "加载中"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Phase 3 · Enforcement"
+msgstr ""
 
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Unknown sell GM order"
@@ -6319,6 +6460,10 @@ msgstr "分割份数"
 msgid "No open orders"
 msgstr "无开订单"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Premium Surge"
+msgstr ""
+
 #: src/components/Errors/getContractErrorToastContent.tsx
 msgid "Insufficient liquidity. Available: {availableLiquidityText}"
 msgstr "流动性不足。可用：{availableLiquidityText}"
@@ -6378,6 +6523,10 @@ msgstr ""
 msgid "Airdrop"
 msgstr "空投"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 7–8"
+msgstr ""
+
 #: src/components/ModalViews/RedirectModal.tsx
 msgid "Launch app"
 msgstr "启动应用"
@@ -6420,10 +6569,6 @@ msgstr "存入 {gasPaymentTokensText}"
 #: src/pages/Ecosystem/ecosystemConstants.tsx
 msgid "GMX (Portuguese)"
 msgstr "GMX (葡萄牙语)"
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Oracle Price"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 #: src/pages/LeaderboardPage/components/LeaderboardPositionsTable.tsx
@@ -7068,6 +7213,8 @@ msgid "Position would be liquidatable"
 msgstr "仓位将面临清算"
 
 #: src/pages/Status/components/BufferGauges.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
 msgid "LP Boost"
 msgstr ""
 
@@ -7075,10 +7222,6 @@ msgstr ""
 #: src/components/Footer/constants.tsx
 msgid "Media kit"
 msgstr "媒体资料包"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Exceeds your VLP balance"
-#~ msgstr ""
 
 #: src/pages/LeaderboardPage/components/LeaderboardAccountsTable.tsx
 msgid "$ 0.00"
@@ -7462,6 +7605,10 @@ msgstr "GMX trading stats"
 msgid "High leverage increases liquidation risk"
 msgstr "高杠杆会增加清算风险"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Junior Buffer"
+msgstr ""
+
 #: src/components/Errors/errorToasts.tsx
 msgid "Invalid signature.<0/><1/>Try a different wallet provider or switch to Classic or One-Click Trading in <2>settings</2>"
 msgstr "签名无效。<0/><1/>请尝试使用其他钱包提供者，或在<2>设置</2>中切换至 Classic 或 One-Click Trading"
@@ -7835,6 +7982,12 @@ msgstr "摘要"
 msgid "ENTRY PRICE"
 msgstr "ENTRY PRICE"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Trade ADL"
+msgstr ""
+
 #: src/components/SettingsModal/DisplaySettings.tsx
 msgid "Display PnL after fees"
 msgstr "显示扣除费用后的 PnL"
@@ -7874,10 +8027,6 @@ msgstr "仓位费用因子（负 PI）"
 #: src/components/DateRangeSelect/DateRangeSelect.tsx
 msgid "90d"
 msgstr "90 天"
-
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "LP Withdrawal"
-#~ msgstr ""
 
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 msgid "({0} days ago)"
@@ -7968,6 +8117,10 @@ msgstr "超出最大金额"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Mode A — Yield + Premium Offset"
 msgstr ""
 
 #: src/components/PositionSeller/CollateralDestinationDialog.tsx
@@ -8093,6 +8246,10 @@ msgstr "限价增加"
 #: src/pages/AccountTransfer/BeginAccountTransfer/BeginAccountTransfer.tsx
 msgid "Transferring..."
 msgstr "转账中..."
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Reserve"
+msgstr ""
 
 #: src/domain/multichain/progress/MultichainTransferProgressView.tsx
 msgid "Sell {gmOrGlvLabel} failed."
@@ -8716,10 +8873,6 @@ msgstr "未质押"
 msgid "{0}ms"
 msgstr "{0}ms"
 
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Position is closed and margin is returned when ADL is triggered."
-#~ msgstr ""
-
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/BridgeModal/BridgeInModal.tsx
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
@@ -8760,10 +8913,6 @@ msgstr "x"
 #: src/components/GmxAccountModal/MainView.tsx
 msgid "Notifications"
 msgstr "通知"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Managed Net APY"
-#~ msgstr ""
 
 #: src/components/SettingsModal/TradingSettings.tsx
 msgid "Trading mode"
@@ -8996,6 +9145,11 @@ msgstr "协议分析"
 msgid "Show positions on chart"
 msgstr "在图表上显示仓位"
 
+#: src/pages/Hedge/HedgeDetailPage.tsx
+msgid "Detecting collateral mode…"
+msgstr ""
+
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Hedge/HedgePage.tsx
@@ -9336,6 +9490,10 @@ msgstr "接收"
 msgid "Execution Fee"
 msgstr ""
 
+#: src/pages/Status/components/ProtocolCommitmentBanner.tsx
+msgid "This protocol does not raise funding rates retroactively. If the system can no longer sustain hedge payments, it executes Step 7 (contract termination) rather than increasing costs for existing users. The 8-step defense sequence above is the complete, publicly committed framework — nothing will happen outside this order."
+msgstr ""
+
 #: src/domain/vantage/lp/useVantageLPActions.ts
 #: src/domain/vantage/vaults/useVaultActions.ts
 msgid "Liquidity removed"
@@ -9383,6 +9541,10 @@ msgstr "使用您推荐码的交易者数量"
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Max reserved {directionLabel}"
 msgstr "最大预留 {directionLabel}"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "ADL for Long Profits"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistory.tsx
 msgid "Realized PnL after fees and net price impact"
@@ -9683,6 +9845,10 @@ msgstr "GMX 奖励："
 msgid "Wallet trading only on these networks"
 msgstr "这些网络仅支持钱包交易"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Entry premiums rise only for incoming users. All existing hedge positions are unaffected."
+msgstr ""
+
 #: src/components/TPSLModal/TPSLOrdersList.tsx
 msgid "Trigger Price"
 msgstr "触发价格"
@@ -9714,6 +9880,10 @@ msgstr "无来源代币地址"
 #: src/pages/RpcDebug/parts.tsx
 msgid "Large account"
 msgstr "大额账户"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 3 — Last Resort"
+msgstr ""
 
 #: src/components/GmSwap/GmFees/GmFees.tsx
 msgid "Shift fee"
@@ -9906,6 +10076,10 @@ msgstr "{0} 代币已预留用于归属期"
 #: src/components/Errors/ErrorBoundary.tsx
 msgid "Something went wrong"
 msgstr "出现错误"
+
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "FR Offset"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/shared.ts
 msgid "Freeze"
@@ -10376,10 +10550,6 @@ msgstr "仓位可能仅因费用（资金费用 + 借款费用）而被清算，
 msgid "Claim price impact rebates"
 msgstr "领取价格影响返还"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Next redemption:"
-#~ msgstr ""
-
 #: src/components/StatusNotification/GmStatusNotification.tsx
 msgid "Fulfilling shift request..."
 msgstr "正在执行转移请求…"
@@ -10712,6 +10882,10 @@ msgstr "获取 GMX 的提醒和公告，随时掌握您的交易、清算风险�
 msgid "{gmOrGlvLabel} bought successfully, but bridge to Base failed. Your funds are safe in your GMX Account. Retry the bridge or go to the {indexName} pool to withdraw your GM tokens."
 msgstr "{gmOrGlvLabel} 买入成功，但跨链桥至 Base 失败。您的资金安全保存在您的 GMX Account 中。请重试跨链桥或前往 {indexName} 池提取您的 GM 代币。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Steps 4–5"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a yield-optimizing crypto-index token that:"
 msgstr "GLV (GMX Liquidity Vaults) 是 GMX V2 对 GLP 的改进版本。它是一种收益优化的加密指数代币，具有以下特点："
@@ -10724,10 +10898,6 @@ msgstr "已从存入归属期的 {1} esGMX 中转换 {0} 个代币为 GMX。"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Trigger price above liquidation price"
 msgstr "触发价格高于清算价格"
-
-#: src/pages/Hedge/HedgePage.tsx
-#~ msgid "Self-Custody APY"
-#~ msgstr ""
 
 #: src/components/GmxAccountModal/TransferDetailsView.tsx
 msgid "Repeat transaction"
@@ -10974,6 +11144,10 @@ msgstr "重新加载页面"
 msgid "Order won't execute: trigger price beyond liquidation price"
 msgstr "订单将不会执行：触发价格超过清算价格"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Phase 2 — Internal Defense"
+msgstr ""
+
 #: src/components/SettleAccruedFundingFeeModal/SettleAccruedFundingFeeModal.tsx
 msgid "Settling..."
 msgstr "结算中..."
@@ -11042,6 +11216,10 @@ msgstr "领取资金费用"
 msgid "Token permit testing"
 msgstr "代币许可测试"
 
+#: src/pages/Status/components/SolvencySpeedometer.tsx
+msgid "Lev Lock"
+msgstr ""
+
 #: src/pages/BuyGMX/BuyGmxModal.tsx
 msgid "Buy GMX directly"
 msgstr "直接买入 GMX"
@@ -11097,10 +11275,6 @@ msgstr "推荐码已更新"
 msgid "to toggle its filtering. To use this debug tool on swap, stay on MARKET GRAPH tab and switch to swap. Settings are saved in local storage; don't forget to clear it when done."
 msgstr "来切换其过滤。要在兑换中使用此调试工具，请停留在 MARKET GRAPH 标签并切换到兑换。设置保存在本地存储中，使用完毕后请记得清除。"
 
-#: src/pages/Portfolio/PortfolioPage.tsx
-#~ msgid "Withdraw VLP"
-#~ msgstr ""
-
 #: src/pages/AccountEvents/AccountEvents.tsx
 #: src/pages/AccountEvents/AccountEvents.tsx
 msgid "Account events"
@@ -11134,6 +11308,7 @@ msgstr "在 Arbitrum 上通过 <0>Camelot</0> 买入 APE"
 msgid "Depositing..."
 msgstr "正在存入…"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/components/UserIncentiveDistribution/UserIncentiveDistribution.tsx
 #: src/pages/Hedge/HedgeDetailPage.tsx
 #: src/pages/Portfolio/PortfolioPage.tsx
@@ -11192,6 +11367,10 @@ msgstr "地址已复制"
 msgid "<0>Delegate your undelegated {0} GMX DAO</0>voting power before claiming."
 msgstr "<0>在领取前委托您未委托的 {0} GMX DAO</0> 投票权。"
 
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "New Entry Premium Surge"
+msgstr ""
+
 #: src/components/UserIncentiveDistribution/ClaimableAmounts.tsx
 msgid "Claim funds"
 msgstr "申领资金"
@@ -11208,6 +11387,7 @@ msgstr "生成推荐码"
 msgid "NET VALUE"
 msgstr "净值"
 
+#: src/components/AppNav/AppNav.tsx
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 #: src/pages/Vaults/VaultsPage.tsx
 msgid "Vaults"
@@ -11375,6 +11555,7 @@ msgstr "EVENT"
 msgid "Distribution"
 msgstr "分配"
 
+#: src/components/SettingsModal/SettingsModal.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/BottomMenuSection.tsx
 #: src/components/SideNav/LanguageNavItem.tsx
@@ -11388,6 +11569,10 @@ msgstr "{idleSeconds}s"
 #: src/pages/Actions/ActionsRouter.tsx
 msgid "GMX V1 actions"
 msgstr "GMX V1 操作"
+
+#: src/pages/Status/components/FrDefenseExplainer.tsx
+msgid "Highly profitable speculative long positions are force-closed, directly reducing the outstanding FR obligation."
+msgstr ""
 
 #: src/components/Earn/Portfolio/RewardsBar.tsx
 msgid "GLV vaults:"
@@ -11493,10 +11678,6 @@ msgstr "仪表板"
 #: src/domain/synthetics/trade/utils/validation.ts
 msgid "Leftover collateral below {0} USD"
 msgstr "剩余抵押品低于 {0} USD"
-
-#: src/components/AppNav/AppNav.tsx
-msgid "{label}"
-msgstr ""
 
 #: src/domain/synthetics/positions/utils.ts
 msgid "trigger"
@@ -11838,10 +12019,6 @@ msgstr "资金正在跨链转移至..."
 msgid "Network fee"
 msgstr "网络费用"
 
-#: src/pages/Status/StatusPage.tsx
-msgid "Real-time solvency dashboard. 7-step defense sequence transparency."
-msgstr ""
-
 #: src/context/SubaccountContext/SubaccountContextProvider.tsx
 msgid "Deactivated"
 msgstr "已停用"
@@ -12053,10 +12230,6 @@ msgstr "输入推荐码以获得费用折扣"
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Margin Token"
 msgstr ""
-
-#: src/pages/Hedge/HedgeDetailPage.tsx
-#~ msgid "Emergency Behavior (ADL)"
-#~ msgstr ""
 
 #: src/pages/AccountDashboard/GeneralPerformanceDetails.tsx
 msgid "General performance details"

--- a/src/pages/Hedge/HedgeDetailPage.tsx
+++ b/src/pages/Hedge/HedgeDetailPage.tsx
@@ -731,7 +731,10 @@ export default function HedgeDetailPage() {
   const totalShortfallUsd = rwaShortfallUsd + marginShortfallUsd;
   const hasInsufficientBalance = !!account && rwaAmount > 0 && totalShortfallUsd > 0.001;
 
-  const canExecute = account && !isSubmitting && rwaAmount > 0 && !pageData.isHedgeDisabled && !hasInsufficientBalance;
+  // Also block submit while assetType is loading (Issue #201: prevents mode-ambiguous tx)
+  const isModeLoading = pageData.isYieldBearing === undefined;
+  const canExecute =
+    account && !isSubmitting && rwaAmount > 0 && !pageData.isHedgeDisabled && !hasInsufficientBalance && !isModeLoading;
 
   // Compute display values for Safety Buffer warning banner
   const frPct = pageData.fundingRateBps !== null ? (Math.abs(pageData.fundingRateBps) / 100).toFixed(2) : null;
@@ -814,12 +817,34 @@ export default function HedgeDetailPage() {
 
               {/* Status: Yield vs Funding */}
               <div className="mb-20 border-b border-b-vantage-border pb-20">
-                <div className="mb-12 text-12 font-medium text-slate-400">{t`Status`}</div>
+                <div className="mb-12 flex items-center justify-between">
+                  <div className="text-12 font-medium text-slate-400">{t`Status`}</div>
+                  {/* Mode badge (Issue #201) — derived from AssetRegistry.assetType */}
+                  {pageData.isYieldBearing === undefined ? (
+                    <span className="animate-pulse rounded-full bg-slate-700 px-10 py-3 text-11 text-slate-500">
+                      {t`Loading…`}
+                    </span>
+                  ) : pageData.isYieldBearing ? (
+                    <span className="rounded-full bg-green-900/40 px-10 py-3 text-11 font-medium text-green-400">
+                      {t`Mode A — Yield + Premium Offset`}
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-slate-700/60 px-10 py-3 text-11 font-medium text-slate-400">
+                      {t`Mode B — Premium Only`}
+                    </span>
+                  )}
+                </div>
                 <YieldMeter
-                  yieldAprBps={pageData.yieldAprBps}
+                  yieldAprBps={pageData.isYieldBearing ? pageData.yieldAprBps : 0}
                   fundingRateBps={pageData.fundingRateBps}
-                  netApyBps={pageData.netApyBps}
+                  netApyBps={pageData.isYieldBearing ? pageData.netApyBps : pageData.fundingRateBps}
                 />
+                {/* Mode B explanation */}
+                {pageData.isYieldBearing === false && (
+                  <p className="mt-10 text-11 text-slate-500">
+                    {t`This token earns no yield. Hedge cost = funding rate only.`}
+                  </p>
+                )}
               </div>
 
               {/* Soft-lock warning (Issue #180) */}
@@ -908,6 +933,27 @@ export default function HedgeDetailPage() {
               <p className="mt-6 text-11 text-slate-500">
                 {t`Deposited to the LP Vault. You receive VLP shares in return.`}
               </p>
+
+              {/* Mode indicator (Issue #201) — auto-detected from AssetRegistry */}
+              <div className="mt-10">
+                {pageData.isYieldBearing === undefined ? (
+                  <div className="animate-pulse rounded-4 bg-slate-800/40 px-12 py-8 text-11 text-slate-500">
+                    {t`Detecting collateral mode…`}
+                  </div>
+                ) : pageData.isYieldBearing ? (
+                  <div className="rounded-4 bg-green-900/20 px-12 py-8 text-11 text-green-400">
+                    ✦ {t`Mode A — Yield-Bearing`}
+                    <span className="ml-6 text-green-600">
+                      {t`Your staking yield offsets the hedge premium. Net cost may be positive.`}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="rounded-4 bg-slate-800/40 px-12 py-8 text-11 text-slate-400">
+                    ○ {t`Mode B — Stablecoin`}
+                    <span className="ml-6 text-slate-500">{t`No yield earned. Hedge cost = funding rate only.`}</span>
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Divider */}
@@ -1128,9 +1174,11 @@ export default function HedgeDetailPage() {
               >
                 {isSubmitting
                   ? t`Submitting…`
-                  : hasInsufficientBalance
-                    ? t`Insufficient Balance`
-                    : t`Deposit ${cfg.symbol} + Open Short`}
+                  : isModeLoading
+                    ? t`Detecting mode…`
+                    : hasInsufficientBalance
+                      ? t`Insufficient Balance`
+                      : t`Deposit ${cfg.symbol} + Open Short`}
               </button>
             )}
           </div>


### PR DESCRIPTION
## 概要

Issue #201 のフロントエンド対応。`AssetRegistry.assets(token).assetType` を読み取り、Mode A（利回りあり）/ Mode B（プレミアムのみ）を自動判定・表示。

## 変更内容

### `useHedgePageData.ts`
- `isYieldBearing: boolean | undefined` を `HedgePageData` に追加
- `assetReg.assets(tokenAddr)` の `assetType` フィールドから自動判定（既存 fetch を活用、追加 RPC 呼び出しなし）
- `undefined` = ローディング中（取得完了を型で判別可能）

### `HedgeDetailPage.tsx`
- **Status セクション**に Mode バッジを追加
  - `Mode A — Yield + Premium Offset`（緑）
  - `Mode B — Premium Only`（スレート）
  - ローディング中はスケルトン表示
- **YieldMeter**: Mode B 時は Yield 行を 0 表示、Net APY = fundingRateBps のみ
- **フォーム Step 1** 下に Mode インジケーターチップ（ローディング中はアニメーション）
- **Deposit ボタン無効化**: `isYieldBearing === undefined` の間は "Detecting mode…" を表示し誤操作防止

### `getDefenseStep.ts` (bugfix)
- `DefenseStep` 型を `0|1|2|3|4|5|6|7` → `0|1|2|3|4|5|6|7|8|9` に拡張
- `STEP_META` に step 8/9 エントリを追加（pre-existing TS エラーを解消）

## 完了条件の確認
- [x] トークン選択時、`AssetRegistry` 設定に応じた Mode A/B が自動表示
- [x] Mode B では Yield 行を非表示（プレミアムコストのみ強調）
- [x] ローディング中のスケルトン表示と Deposit ボタン無効化
- [x] TypeScript エラーゼロ（tsc --noEmit 通過）

## 関連 PR
- Smart Contract: itchii-06/bcellar-monorepo#202

🤖 Generated with [Claude Code](https://claude.com/claude-code)