### PR TITLE
feat(issue-203): Tranche-based Vault Listing (Senior & Junior)

### DIFF
--- a/src/domain/vantage/vaults/vaultConfig.ts
+++ b/src/domain/vantage/vaults/vaultConfig.ts
@@ -16,6 +16,39 @@ import localhostDeployment from "vantage/deployments/frontend-localhost.json";
 
 export type AssetTypeId = 0 | 1 | 2 | "stable";
 
+// ---------------------------------------------------------------------------
+// Tranche types
+// ---------------------------------------------------------------------------
+
+export type TrancheType = "senior" | "junior";
+
+export interface TrancheMeta {
+  label: string;
+  shortLabel: string;
+  riskLabel: string;
+  badgeClass: string;
+  description: string;
+}
+
+export const TRANCHE_META: Record<TrancheType, TrancheMeta> = {
+  senior: {
+    label: "Senior Vault",
+    shortLabel: "Senior",
+    riskLabel: "Low Risk",
+    badgeClass: "bg-indigo-900/60 text-indigo-300 border border-indigo-700",
+    description:
+      "Receives priority yield distribution from protocol revenue. In the event of a loss, Junior capital absorbs the deficit first, providing a higher safety cushion.",
+  },
+  junior: {
+    label: "Junior Vault",
+    shortLabel: "Junior",
+    riskLabel: "High Reward",
+    badgeClass: "bg-amber-900/60 text-amber-300 border border-amber-700",
+    description:
+      "Captures all residual yield after Senior allocations, enabling higher APY potential. Acts as the first-loss layer — absorbs FR deficits before Senior LPs are affected.",
+  },
+};
+
 export interface VaultConfig {
   /** Unique key used in URLs and as React key */
   key: string;
@@ -25,6 +58,12 @@ export interface VaultConfig {
   symbol: string;
   /** Asset type: 1=Rebasing, 2=PriceShare, 0=Direct, "stable"=USDC */
   assetType: AssetTypeId;
+  /**
+   * Tranche classification:
+   *   senior — RWA vaults receiving priority yield distribution.
+   *   junior — USDC vault acting as first-loss layer for FR deficit.
+   */
+  trancheType: TrancheType;
   /** Vault contract address */
   vaultAddress: string;
   /** Underlying token address */
@@ -57,12 +96,13 @@ const d = localhostDeployment.addresses as {
 };
 
 export const VAULT_CONFIGS: VaultConfig[] = [
-  // ── USDC (stable) ────────────────────────────────────────────────────────
+  // ── USDC (stable / Junior) ───────────────────────────────────────────────
   {
     key: "usdc",
     name: "USDC Vault",
     symbol: "USDC",
     assetType: "stable",
+    trancheType: "junior",
     vaultAddress: d.Vault ?? "",
     tokenAddress: d.tokens?.USDC ?? "",
     lpManagerAddress: d.LPManager ?? "",
@@ -71,12 +111,13 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     isMock: false,
     tvSymbol: "BINANCE:BTCUSDT",
   },
-  // ── mBUIDL (Rebasing) ────────────────────────────────────────────────────
+  // ── mBUIDL (Rebasing / Senior) ───────────────────────────────────────────
   {
     key: "mBUIDL",
     name: "mBUIDL Vault",
     symbol: "mBUIDL",
     assetType: 1,
+    trancheType: "senior",
     vaultAddress: d.mockRWAVaults?.Rebasing ?? "",
     tokenAddress: d.mockRWA?.Rebasing ?? "",
     lpManagerAddress: d.mockRWALPManagers?.Rebasing ?? "",
@@ -85,12 +126,13 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     isMock: true,
     tvSymbol: "BINANCE:BTCUSDT",
   },
-  // ── mUSDY (PriceShare) ───────────────────────────────────────────────────
+  // ── mUSDY (PriceShare / Senior) ──────────────────────────────────────────
   {
     key: "mUSDY",
     name: "mUSDY Vault",
     symbol: "mUSDY",
     assetType: 2,
+    trancheType: "senior",
     vaultAddress: d.mockRWAVaults?.PriceShare ?? "",
     tokenAddress: d.mockRWA?.PriceShare ?? "",
     lpManagerAddress: d.mockRWALPManagers?.PriceShare ?? "",
@@ -99,12 +141,13 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     isMock: true,
     tvSymbol: "BINANCE:ETHUSD",
   },
-  // ── mRWA (Direct) ────────────────────────────────────────────────────────
+  // ── mRWA (Direct / Senior) ───────────────────────────────────────────────
   {
     key: "mRWA",
     name: "mRWA Vault",
     symbol: "mRWA",
     assetType: 0,
+    trancheType: "senior",
     vaultAddress: d.mockRWAVaults?.Direct ?? "",
     tokenAddress: d.mockRWA?.Direct ?? "",
     lpManagerAddress: d.mockRWALPManagers?.Direct ?? "",

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "Details anzeigen"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "Liquidität nur auf {chainNames} verfügbar. Wechseln Sie das Netzwerk, 
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "Fehlgeschlagen"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "Preisänderung bis zur Liquidation"
 msgid "possibilities in total"
 msgstr "Möglichkeiten insgesamt"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "Der Preiseinfluss wird beim Vergrößern einer Position gespeichert und beim Verkleinern angewendet. <0>Mehr erfahren</0>."
@@ -5927,6 +5943,10 @@ msgstr "Maximaler verleihbarer Einflussfaktor für Abhebungen"
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "Beanspruchung abgeschlossen"
@@ -6651,6 +6671,10 @@ msgstr "Pools, die Liquidität für bestimmte GMX-Märkte bereitstellen. Unterst
 msgid "Max funding factor"
 msgstr "Maximaler Finanzierungsfaktor"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "Verringert"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "Short Liq."
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Liquidationsgebühr"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "Lädt..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "Jetzt handeln"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>Marktgruppen</0><1>Netto Open Interest</1>"
 msgid "Transfer submitted"
 msgstr "Übertragung eingereicht"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "Transaktion anzeigen"
 msgid "Project"
 msgstr "Projekt"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "DEX-Aggregator"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Handeln Sie über GMX Account mit Arbitrum-Liquidität. Wallet-Handel ist ebenfalls auf Arbitrum verfügbar."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Herunterladen der Handelsverlauf-CSV fehlgeschlagen"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "Min. Margin pro Teil: {0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "Verteilungsverlauf für beanspruchte Rückerstattungen und Airdrops"
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "Neuen Betrag oder Preis eingeben"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) ist die verbesserte Version von GLP in GMX V2
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "{0} Token wurden aus den {1} für das Vesting eingezahlten esGMX in GMX umgewandelt."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "Keine dezentralen Börsen verfügbar"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "Aktivieren Sie <0>Express Trading</0> in den Einstellungen für bessere Zuverlässigkeit.<1/><2/>Oder erhöhen Sie den maximalen Netzwerkgebührenpuffer {bufferText} in {settingsLink}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -856,6 +856,10 @@ msgstr "Loading positions…"
 msgid "View details"
 msgstr "View details"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr "Hedge OI"
@@ -1424,6 +1428,10 @@ msgstr "Liquidity only available on {chainNames}. Switch networks to continue."
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr "No vaults in this category."
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr "Transactions"
@@ -1890,6 +1898,10 @@ msgstr "Failed"
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr "Protocol Commitment — No Surprise Rate Hikes"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
+msgstr "RWA yield + Trading fees"
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
@@ -5052,6 +5064,10 @@ msgstr "Price change to liquidation"
 msgid "possibilities in total"
 msgstr "possibilities in total"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr "{0}s"
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
@@ -5927,6 +5943,10 @@ msgstr "Max lendable impact factor for withdrawals"
 msgid "Reduce Position ({closePct}%)"
 msgstr "Reduce Position ({closePct}%)"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr "Lower risk · Stable yield"
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "Claim completed"
@@ -6651,6 +6671,10 @@ msgstr "Pools that provide liquidity to specific GMX markets. Supports single-as
 msgid "Max funding factor"
 msgstr "Max funding factor"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr "Receives yield first. Junior capital cushions any losses."
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr "This is the price you're hedging against. A short position offsets any d
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "Decreased"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr "Provide liquidity to earn yield from RWA assets."
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "Short liq."
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Liquidation fee"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr "No vaults configured. Deploy contracts first."
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "Loading..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "Trade now"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr "Priority Layer"
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>Market groups</0><1>Net open interest</1>"
 msgid "Transfer submitted"
 msgstr "Transfer submitted"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr "Junior Vault"
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "View transaction"
 msgid "Project"
 msgstr "Project"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr "Protection Target"
@@ -8273,6 +8301,10 @@ msgstr "DEX aggregator"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr "Protocol Revenue"
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Failed to download trade history CSV"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr "Senior Vaults"
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "Min margin per part: {0}"
 msgid "Hedge Cap"
 msgstr "Hedge Cap"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr "Captures residual yield after Senior. Absorbs FR deficits first."
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "Distribution history for claimed rebates and airdrops"
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "Enter a new amount or price"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr "Higher APY · First-loss layer"
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) is GMX V2's improved version of GLP. It's a y
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr "Performance Layer"
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "No decentralized exchanges available"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr "Tranche Structure"
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "Ver detalles"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "Liquidez disponible únicamente en {chainNames}. Cambie de red para cont
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "Fallida"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "Cambio de precio hasta la liquidación"
 msgid "possibilities in total"
 msgstr "posibilidades en total"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "El impacto en el precio se almacena cuando aumenta una posición y se aplica cuando la reduce. <0>Más información</0>."
@@ -5927,6 +5943,10 @@ msgstr "Factor de impacto prestable máximo para retiradas"
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "Reclamación completada"
@@ -6651,6 +6671,10 @@ msgstr "Pools que proporcionan liquidez a mercados específicos de GMX. Admite o
 msgid "Max funding factor"
 msgstr "Factor máximo de financiación"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "Reducido"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "Liq. corto"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Comisión de liquidación"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "Cargando..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "Operar ahora"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>Grupos de mercado</0><1>Interés abierto neto</1>"
 msgid "Transfer submitted"
 msgstr "Transferencia enviada"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "Ver transacción"
 msgid "Project"
 msgstr "Proyecto"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "Agregador DEX"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Opere mediante GMX Account utilizando la liquidez de Arbitrum. También puede operar desde su monedero en Arbitrum."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Error al descargar el CSV del historial de operaciones"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "Margen mín. por parte: {0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "Historial de distribuciones de reembolsos reclamados y airdrops"
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "Introduzca un nuevo importe o precio"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) es la versión mejorada de GLP en GMX V2. Es 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "{0} tokens convertidos a GMX de los {1} esGMX depositados para el periodo de consolidación."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "No hay exchanges descentralizados disponibles"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "Active <0>Express Trading</0> en configuración para una mayor fiabilidad.<1/><2/>O aumente el búfer máximo de comisión de red {bufferText} en {settingsLink}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "Voir les détails"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "Liquidité disponible uniquement sur {chainNames}. Changez de réseau po
 msgid "Stop-Loss"
 msgstr "Stop-Loss"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "Échec"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "Variation de prix jusqu'à la liquidation"
 msgid "possibilities in total"
 msgstr "possibilités au total"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "L'impact sur le prix est enregistré lorsque vous augmentez une position et appliqué lorsque vous la réduisez. <0>En savoir plus</0>."
@@ -5927,6 +5943,10 @@ msgstr "Facteur d'impact prêtable max pour les retraits"
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "Récupération terminée"
@@ -6651,6 +6671,10 @@ msgstr "Pools fournissant de la liquidité à des marchés GMX spécifiques. Pre
 msgid "Max funding factor"
 msgstr "Facteur de financement maximum"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "Diminué"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "Liq. short"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Frais de liquidation"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "Chargement..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "Négocier maintenant"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>Groupes de marchés</0><1>Positions ouvertes nettes</1>"
 msgid "Transfer submitted"
 msgstr "Transfert soumis"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "Voir la transaction"
 msgid "Project"
 msgstr "Projet"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "Agrégateur DEX"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Négociez via GMX Account en utilisant la liquidité d'Arbitrum. Le trading depuis le portefeuille est également disponible sur Arbitrum."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Échec du téléchargement du CSV de l'historique des transactions"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "Marge min. par part : {0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "Historique des distributions pour les remises récupérées et les airdr
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "Saisissez un nouveau montant ou prix"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) est la version améliorée de GLP dans GMX V2
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "{0} jetons convertis en GMX à partir des {1} esGMX déposés pour l'acquisition progressive."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "Aucun échange décentralisé disponible"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "Activez <0>Express Trading</0> dans les paramètres pour une meilleure fiabilité.<1/><2/>Ou augmentez le tampon maximal des frais de réseau {bufferText} dans {settingsLink}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -856,6 +856,10 @@ msgstr "ポジションを読み込み中…"
 msgid "View details"
 msgstr "詳細を表示"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "流動性は {chainNames} でのみ利用可能です。続行するに�
 msgid "Stop-Loss"
 msgstr "ストップロス"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr "トランザクション"
@@ -1890,6 +1898,10 @@ msgstr "失敗"
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
 msgstr "プロトコルの約束 — 予告なき金利引き上げはしない"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
+msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
 #: src/components/GmxAccountModal/WithdrawalView.tsx
@@ -5052,6 +5064,10 @@ msgstr "清算までの価格変動"
 msgid "possibilities in total"
 msgstr "パターン（合計）"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "価格への影響はポジションを増加する際に蓄積され、減少する際に適用されます。<0>詳細はこちら</0>。"
@@ -5927,6 +5943,10 @@ msgstr "出金の最大貸出可能インパクトファクター"
 msgid "Reduce Position ({closePct}%)"
 msgstr "ポジションを縮小（{closePct}%）"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "受け取りが完了しました"
@@ -6651,6 +6671,10 @@ msgstr "特定のGMX市場に流動性を提供するプールです。単一ア
 msgid "Max funding factor"
 msgstr "最大ファンディングファクター"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr "これはヘッジ対象の価格です。ショートポジションが
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "減額しました"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr "RWA資産からの利回りを得るために流動性を提供してください。"
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "ショート流動性"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "清算手数料"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr "Vaultが設定されていません。まずコントラクトをデプロイしてください。"
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "ロード中..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "今すぐ取引"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>マーケットグループ</0><1>ネット建玉</1>"
 msgid "Transfer submitted"
 msgstr "送金が送信されました"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "トランザクションを表示"
 msgid "Project"
 msgstr "プロジェクト"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr "保護対象"
@@ -8273,6 +8301,10 @@ msgstr "DEXアグリゲーター"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Arbitrumの流動性を利用し、GMX Account経由で取引できます。Arbitrumではウォレットからの直接取引も可能です。"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "取引履歴CSVのダウンロードに失敗しました"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "パートあたりの最小証拠金：{0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "受け取り済みリベートおよびエアドロップの配布履歴
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "新しい金額または価格を入力してください"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) はGMX V2におけるGLPの改良版です。
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "ベスティング用に預け入れた{1} esGMXのうち、{0}トークンがGMXに変換されました。"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "利用可能な分散型取引所はありません"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "信頼性を向上させるには設定で<0>Express Trading</0>を有効にしてください。<1/><2/>または{settingsLink}で最大ネットワーク手数料バッファ{bufferText}を引き上げてください"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "상세 보기"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "유동성은 {chainNames}에서만 이용 가능합니다. 계속하려�
 msgid "Stop-Loss"
 msgstr "손절매"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "실패"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "청산까지 가격 변동"
 msgid "possibilities in total"
 msgstr "총 경우의 수"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "포지션을 증가시킬 때 가격 영향이 저장되며, 감소시킬 때 적용됩니다. <0>자세히 보기</0>."
@@ -5927,6 +5943,10 @@ msgstr "출금 시 최대 대출 가능 영향 계수"
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "수령이 완료되었습니다"
@@ -6651,6 +6671,10 @@ msgstr "특정 GMX 마켓에 유동성을 제공하는 풀입니다. 단일 자�
 msgid "Max funding factor"
 msgstr "최대 펀딩 계수"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "감소 완료"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "숏 유동성"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "청산 수수료"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "로딩 중..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "지금 거래하기"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>마켓 그룹</0><1>순 미결제약정</1>"
 msgid "Transfer submitted"
 msgstr "전송 제출됨"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "거래 보기"
 msgid "Project"
 msgstr "프로젝트"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "DEX 애그리게이터"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Arbitrum 유동성을 활용하여 GMX Account를 통해 거래합니다. Arbitrum에서 지갑 거래도 가능합니다."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "거래 내역 CSV 다운로드에 실패했습니다"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "파트당 최소 증거금: {0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "수령된 리베이트 및 에어드롭 배분 내역"
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "새로운 금액 또는 가격을 입력하십시오"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults)는 GMX V2의 개선된 GLP 버전입니다. �
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "베스팅을 위해 예치된 {1} esGMX 중 {0} 토큰이 GMX로 전환되었습니다."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "이용 가능한 탈중앙화 거래소가 없습니다"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "안정성 향상을 위해 설정에서 <0>Express Trading</0>을 활성화하십시오.<1/><2/>또는 {settingsLink}에서 최대 네트워크 수수료 버퍼 {bufferText}을(를) 늘리십시오"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr ""
 msgid "Stop-Loss"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr ""
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr ""
 msgid "possibilities in total"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr ""
@@ -5927,6 +5943,10 @@ msgstr ""
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr ""
@@ -6651,6 +6671,10 @@ msgstr ""
 msgid "Max funding factor"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6684,10 +6708,6 @@ msgstr ""
 
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
-msgstr ""
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
 msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
@@ -6907,10 +6927,6 @@ msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
-msgstr ""
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
 msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
@@ -7138,6 +7154,10 @@ msgstr ""
 #: landing/src/pages/Home/HeroSection/Features.tsx
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
 msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
@@ -7760,6 +7780,10 @@ msgstr ""
 msgid "Transfer submitted"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr ""
 msgid "Project"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8272,6 +8300,10 @@ msgstr ""
 
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
 msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
@@ -9096,6 +9128,10 @@ msgstr ""
 
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
 msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr ""
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10409,6 +10449,10 @@ msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
 msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
@@ -10892,6 +10936,10 @@ msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
 msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
@@ -12287,6 +12335,10 @@ msgstr ""
 
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
 msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "Подробнее"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "Ликвидность доступна только в сети {chainN
 msgid "Stop-Loss"
 msgstr "Стоп-лосс"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "Ошибка"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "Изменение цены до ликвидации"
 msgid "possibilities in total"
 msgstr "вариантов всего"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "Влияние на цену сохраняется при увеличении позиции и применяется при её уменьшении. <0>Подробнее</0>."
@@ -5927,6 +5943,10 @@ msgstr "Макс. фактор влияния заёмных средств дл
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "Получение завершено"
@@ -6651,6 +6671,10 @@ msgstr "Пулы, обеспечивающие ликвидность для о�
 msgid "Max funding factor"
 msgstr "Макс. фактор финансирования"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "Уменьшено"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "Шорт ликв."
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "Комиссия за ликвидацию"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "Загрузка..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "Торговать"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>Группы рынков</0><1>Чистый открытый инт�
 msgid "Transfer submitted"
 msgstr "Перевод отправлен"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "Просмотреть транзакцию"
 msgid "Project"
 msgstr "Проект"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "DEX-агрегатор"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "Торговля через GMX Account с использованием ликвидности Arbitrum. Торговля с кошелька также доступна на Arbitrum."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "Не удалось скачать CSV истории сделок"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "Мин. маржа на часть: {0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "История распределений полученных комп�
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "Введите новую сумму или цену"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) — это улучшенная версия 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "{0} токенов конвертировано в GMX из {1} esGMX, депонированных для вестинга."
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "Нет доступных децентрализованных бирж"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "Включите <0>Express Trading</0> в настройках для повышения надёжности.<1/><2/>Или увеличьте макс. буфер комиссии сети {bufferText} в {settingsLink}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "查看詳情"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "流動性僅在 {chainNames} 上可用。請切換網路以繼續。"
 msgid "Stop-Loss"
 msgstr "止損"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "失敗"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "距清算價格變動"
 msgid "possibilities in total"
 msgstr "種可能路徑"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "價格影響在您增加倉位時儲存，並在您減少倉位時套用。<0>閱讀更多</0>。"
@@ -5927,6 +5943,10 @@ msgstr "提取最大可借出影響因子"
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "領取完成"
@@ -6651,6 +6671,10 @@ msgstr "為特定 GMX 市場提供流動性的池。支援單一資產和原生�
 msgid "Max funding factor"
 msgstr "最大資金費率因子"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "已減倉"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "做空流動性"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "清算費用"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "載入中..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "立即交易"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>市場群組</0><1>淨未平倉量</1>"
 msgid "Transfer submitted"
 msgstr "轉帳已提交"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "查看交易"
 msgid "Project"
 msgstr "專案"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "DEX 聚合器"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "透過 GMX Account 使用 Arbitrum 流動性進行交易。也可在 Arbitrum 上使用錢包交易。"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "交易歷史 CSV 下載失敗"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "每份最低保證金：{0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "已領取回饋和空投的分發歷史記錄"
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "輸入新的金額或價格"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV（GMX Liquidity Vaults）是 GMX V2 對 GLP 的改良版本。這是
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "{0} 個代幣已從存入歸屬期的 {1} esGMX 轉換為 GMX。"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "無可用的去中心化交易所"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "在設定中啟用 <0>Express Trading</0> 以提升可靠性。<1/><2/>或在 {settingsLink} 中增加最大網路費用緩衝 {bufferText}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -856,6 +856,10 @@ msgstr ""
 msgid "View details"
 msgstr "查看详情"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior: \"Always gets served first at the buffet.\" Junior: \"Gets whatever is left — but more of it, faster.\""
+msgstr ""
+
 #: src/pages/Admin/AdminPage.tsx
 msgid "Hedge OI"
 msgstr ""
@@ -1424,6 +1428,10 @@ msgstr "流动性仅在 {chainNames} 上可用。请切换网络以继续。"
 msgid "Stop-Loss"
 msgstr "止损"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "No vaults in this category."
+msgstr ""
+
 #: src/pages/VaultDetail/VaultDetailPage.tsx
 msgid "Transactions"
 msgstr ""
@@ -1889,6 +1897,10 @@ msgstr "失败"
 
 #: src/pages/Status/components/ProtocolCommitmentBanner.tsx
 msgid "Protocol Commitment — No Surprise Rate Hikes"
+msgstr ""
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "RWA yield + Trading fees"
 msgstr ""
 
 #: src/components/GmxAccountModal/DepositView.tsx
@@ -5052,6 +5064,10 @@ msgstr "距清算价格变动"
 msgid "possibilities in total"
 msgstr "种可能的路径"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "{0}s"
+msgstr ""
+
 #: src/components/TradeBox/TradeBoxRows/NextStoredImpactRows.tsx
 msgid "Price impact is stored when you increase a position and applied when you decrease. <0>Read more</0>."
 msgstr "价格影响在您增加仓位时存储，并在您减少仓位时应用。<0>了解更多</0>。"
@@ -5927,6 +5943,10 @@ msgstr "提取最大可借出影响因子"
 msgid "Reduce Position ({closePct}%)"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Lower risk · Stable yield"
+msgstr ""
+
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/ClaimModal.tsx
 msgid "Claim completed"
 msgstr "领取完成"
@@ -6651,6 +6671,10 @@ msgstr "为特定 GMX 市场提供流动性的池。支持单资产和原生资�
 msgid "Max funding factor"
 msgstr "最大资金费率因子"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Receives yield first. Junior capital cushions any losses."
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmSwapWarningsRow.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "High price impact"
@@ -6685,10 +6709,6 @@ msgstr ""
 #: src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
 msgid "Decreased"
 msgstr "已减少"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "Provide liquidity to earn yield from RWA assets."
-msgstr ""
 
 #: src/components/UserIncentiveDistribution/AboutGlpIncident.tsx
 msgid "Earns fees from liquidity provision across GMX V2 markets"
@@ -6908,10 +6928,6 @@ msgstr "做空流动性"
 #: src/components/TradeHistory/TradeHistoryRow/utils/position.ts
 msgid "Liquidation fee"
 msgstr "清算费用"
-
-#: src/pages/Vaults/VaultsPage.tsx
-msgid "No vaults configured. Deploy contracts first."
-msgstr ""
 
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Swap impact exponent"
@@ -7139,6 +7155,10 @@ msgstr "正在加载..."
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "Trade now"
 msgstr "立即交易"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Priority Layer"
+msgstr ""
 
 #: src/components/TradeHistory/TradeHistoryRow/TradeHistoryRow.tsx
 msgid "Share"
@@ -7760,6 +7780,10 @@ msgstr "<0>市场分组</0><1>净未平仓量</1>"
 msgid "Transfer submitted"
 msgstr "转账已提交"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Junior Vault"
+msgstr ""
+
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useDepositTransactions.tsx
 #: src/components/GmSwap/GmSwapBox/GmDepositWithdrawalBox/lpTxn/useWithdrawalTransactions.tsx
@@ -8064,6 +8088,10 @@ msgstr "查看交易"
 msgid "Project"
 msgstr "项目"
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield."
+msgstr ""
+
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Protection Target"
 msgstr ""
@@ -8273,6 +8301,10 @@ msgstr "DEX 聚合器"
 #: src/components/NetworkDropdown/NetworkDropdown.tsx
 msgid "Trade via GMX Account using Arbitrum liquidity. Wallet trading also available on Arbitrum."
 msgstr "通过 GMX Account 使用 Arbitrum 流动性进行交易。也可在 Arbitrum 上使用钱包交易。"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Protocol Revenue"
+msgstr ""
 
 #: src/components/TradeFeesRow/TradeFeesRow.tsx
 msgid "({0} of {1})"
@@ -9097,6 +9129,10 @@ msgstr "Jones DAO"
 #: src/components/TradeHistory/useDownloadAsCsv.tsx
 msgid "Failed to download trade history CSV"
 msgstr "交易历史 CSV 下载失败"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Senior Vaults"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 #: src/components/PositionEditor/PositionEditor.tsx
@@ -10114,6 +10150,10 @@ msgstr "每份最低保证金：{0}"
 msgid "Hedge Cap"
 msgstr ""
 
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Captures residual yield after Senior. Absorbs FR deficits first."
+msgstr ""
+
 #: src/pages/DebugOracleKeeper/parts.tsx
 #: src/pages/RpcDebug/parts.tsx
 msgid "FAILURES"
@@ -10410,6 +10450,10 @@ msgstr "已领取返还和空投的分发历史记录"
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 msgid "Enter a new amount or price"
 msgstr "输入新的金额或价格"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Higher APY · First-loss layer"
+msgstr ""
 
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/StakeModal.tsx
 msgid "Stake {tokenSymbol}"
@@ -10893,6 +10937,10 @@ msgstr "GLV (GMX Liquidity Vaults) 是 GMX V2 对 GLP 的改进版本。它是�
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 msgid "{0} tokens converted to GMX from the {1} esGMX deposited for vesting."
 msgstr "已从存入归属期的 {1} esGMX 中转换 {0} 个代币为 GMX。"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Performance Layer"
+msgstr ""
 
 #: src/domain/synthetics/orders/getPositionOrderError.tsx
 #: src/domain/synthetics/trade/utils/validation.ts
@@ -12288,6 +12336,10 @@ msgstr "无可用的去中心化交易所"
 #: src/components/Errors/errorToasts.tsx
 msgid "Enable <0>Express Trading</0> in settings for better reliability.<1/><2/>Or increase the max network fee buffer {bufferText} in {settingsLink}"
 msgstr "在设置中启用 <0>Express Trading</0> 以获得更高可靠性。<1/><2/>或在 {settingsLink} 中增加最大网络费用缓冲 {bufferText}"
+
+#: src/pages/Vaults/VaultsPage.tsx
+msgid "Tranche Structure"
+msgstr ""
 
 #: src/components/OrderEditor/OrderEditor.tsx
 msgid "Enter a ratio"

--- a/src/pages/VaultDetail/VaultDetailPage.tsx
+++ b/src/pages/VaultDetail/VaultDetailPage.tsx
@@ -17,7 +17,12 @@ import { useVaultApy } from "domain/vantage/vaults/useVaultApy";
 import { useVaultDetail } from "domain/vantage/vaults/useVaultDetail";
 import { useVaultTxHistory } from "domain/vantage/vaults/useVaultTxHistory";
 import { useZapInActions } from "domain/vantage/vaults/useZapInActions";
-import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, getVaultConfigByAddress } from "domain/vantage/vaults/vaultConfig";
+import {
+  ASSET_TYPE_COLOR,
+  ASSET_TYPE_LABEL,
+  TRANCHE_META,
+  getVaultConfigByAddress,
+} from "domain/vantage/vaults/vaultConfig";
 import { useChainId } from "lib/chains";
 import useWallet from "lib/wallets/useWallet";
 import { ZAP_TOKENS, ZapTokenConfig, resolvePoolFee } from "vantage/config/zapTokens";
@@ -299,8 +304,13 @@ export default function VaultDetailPage() {
                 {cfg.symbol.slice(0, 2)}
               </div>
               <div>
-                <div className="flex items-center gap-8">
+                <div className="flex flex-wrap items-center gap-8">
                   <h1 className="text-h1">{cfg.symbol}</h1>
+                  <span
+                    className={`rounded-full px-8 py-2 text-11 font-medium ${TRANCHE_META[cfg.trancheType].badgeClass}`}
+                  >
+                    {TRANCHE_META[cfg.trancheType].shortLabel} · {TRANCHE_META[cfg.trancheType].riskLabel}
+                  </span>
                   <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[cfg.assetType]}`}>
                     {ASSET_TYPE_LABEL[cfg.assetType]}
                   </span>
@@ -310,7 +320,7 @@ export default function VaultDetailPage() {
                     </span>
                   )}
                 </div>
-                <p className="text-13 text-slate-400">{cfg.name}</p>
+                <p className="mt-4 text-13 text-slate-400">{TRANCHE_META[cfg.trancheType].description}</p>
               </div>
             </div>
 

--- a/src/pages/Vaults/VaultsPage.tsx
+++ b/src/pages/Vaults/VaultsPage.tsx
@@ -1,7 +1,7 @@
 /**
  * VaultsPage.tsx
  *
- * Kamino Lend-style table view of all 4 Vaults.
+ * Vault list page split into Senior (Priority Layer) and Junior (Performance Layer) sections.
  * Route: /vaults
  *
  * Columns: Asset | Type | AUM | APY | My Deposit
@@ -10,12 +10,19 @@
 
 import { t } from "@lingui/macro";
 import { formatEther } from "ethers";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { useVaultApy } from "domain/vantage/vaults/useVaultApy";
 import { useVaultList } from "domain/vantage/vaults/useVaultList";
-import { ASSET_TYPE_COLOR, ASSET_TYPE_LABEL, VAULT_CONFIGS } from "domain/vantage/vaults/vaultConfig";
+import { type VaultListItem } from "domain/vantage/vaults/useVaultList";
+import {
+  ASSET_TYPE_COLOR,
+  ASSET_TYPE_LABEL,
+  TRANCHE_META,
+  VAULT_CONFIGS,
+  type TrancheType,
+} from "domain/vantage/vaults/vaultConfig";
 import useWallet from "lib/wallets/useWallet";
 import { COLORS } from "styles/vantageTheme";
 
@@ -42,7 +49,257 @@ type SortKey = "aum" | "apy" | "none";
 type SortDir = "asc" | "desc";
 
 // ---------------------------------------------------------------------------
-// Component
+// Waterfall diagram — shows yield/risk flow between tranches
+// ---------------------------------------------------------------------------
+
+function WaterfallDiagram() {
+  return (
+    <div className="mb-28 rounded-4 border border-vantage-border bg-vantage-base p-20">
+      <h2 className="mb-16 text-13 font-semibold text-slate-400">{t`Tranche Structure`}</h2>
+      <div className="flex flex-col gap-0 sm:flex-row sm:items-stretch sm:gap-0">
+        {/* Protocol Revenue box */}
+        <div className="flex flex-1 flex-col items-center justify-center rounded-4 border border-slate-700 bg-slate-800/60 px-16 py-14 text-center">
+          <div className="text-slate-300 mb-4 text-16">⬇</div>
+          <div className="text-slate-200 text-13 font-semibold">{t`Protocol Revenue`}</div>
+          <div className="mt-4 text-12 text-slate-500">{t`RWA yield + Trading fees`}</div>
+        </div>
+
+        {/* Arrow right */}
+        <div className="flex items-center justify-center px-8 text-slate-600 sm:px-12">→</div>
+
+        {/* Senior box */}
+        <div className="border-indigo-700/50 bg-indigo-900/20 flex flex-1 flex-col justify-between rounded-4 border px-16 py-14">
+          <div className="mb-8 flex items-center gap-8">
+            <span className="text-16">🛡️</span>
+            <span className="text-indigo-300 text-14 font-semibold">{t`Senior Vaults`}</span>
+            <span className="border-indigo-700 bg-indigo-900/60 text-indigo-300 rounded-full border px-8 py-1 text-11">
+              {t`Priority Layer`}
+            </span>
+          </div>
+          <div className="leading-relaxed text-12 text-slate-400">
+            {t`Receives yield first. Junior capital cushions any losses.`}
+          </div>
+          <div className="mt-8 flex items-center gap-6 text-12 text-green-400">
+            <span className="h-8 w-8 rounded-full bg-green-500" />
+            {t`Lower risk · Stable yield`}
+          </div>
+        </div>
+
+        {/* Arrow right */}
+        <div className="flex items-center justify-center px-8 text-slate-600 sm:px-12">→</div>
+
+        {/* Junior box */}
+        <div className="border-amber-700/50 bg-amber-900/20 flex flex-1 flex-col justify-between rounded-4 border px-16 py-14">
+          <div className="mb-8 flex items-center gap-8">
+            <span className="text-16">🚀</span>
+            <span className="text-amber-300 text-14 font-semibold">{t`Junior Vault`}</span>
+            <span className="border-amber-700 bg-amber-900/60 text-amber-300 rounded-full border px-8 py-1 text-11">
+              {t`Performance Layer`}
+            </span>
+          </div>
+          <div className="leading-relaxed text-12 text-slate-400">
+            {t`Captures residual yield after Senior. Absorbs FR deficits first.`}
+          </div>
+          <div className="text-amber-400 mt-8 flex items-center gap-6 text-12">
+            <span className="bg-amber-500 h-8 w-8 rounded-full" />
+            {t`Higher APY · First-loss layer`}
+          </div>
+        </div>
+      </div>
+
+      {/* Tooltip hint */}
+      <p className="mt-12 text-12 text-slate-600">
+        💡{" "}
+        {t`Senior: "Always gets served first at the buffet." Junior: "Gets whatever is left — but more of it, faster."`}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// VaultTable — shared table component used by each tranche section
+// ---------------------------------------------------------------------------
+
+type VaultTableProps = {
+  items: VaultListItem[];
+  apyByKey: Record<string, number | null>;
+  account: string | null | undefined;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+  onRowClick: (vaultAddress: string) => void;
+};
+
+function VaultTable({ items, apyByKey, account, sortKey, sortDir, onSort, onRowClick }: VaultTableProps) {
+  const sorted = [...items].sort((a, b) => {
+    if (sortKey === "aum") return sortDir === "desc" ? Number(b.aum - a.aum) : Number(a.aum - b.aum);
+    if (sortKey === "apy") {
+      const apyA = apyByKey[a.key] ?? -Infinity;
+      const apyB = apyByKey[b.key] ?? -Infinity;
+      return sortDir === "desc" ? apyB - apyA : apyA - apyB;
+    }
+    return 0;
+  });
+
+  return (
+    <div className="overflow-hidden rounded-4 border-b border-b-vantage-border bg-vantage-base">
+      {/* Table header */}
+      <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-0 border-b border-b-vantage-border px-20 py-12 text-12 text-vantage-text-secondary">
+        <div>{t`Asset`}</div>
+        <div
+          className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "aum" ? "text-white" : ""}`}
+          onClick={() => onSort("aum")}
+        >
+          {t`AUM`} {sortKey === "aum" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
+        </div>
+        <div
+          className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "apy" ? "text-white" : ""}`}
+          onClick={() => onSort("apy")}
+        >
+          {t`APY`} {sortKey === "apy" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
+        </div>
+        <div className="text-right">{t`Type`}</div>
+        <div className="text-right">{account ? t`My Deposit` : ""}</div>
+      </div>
+
+      {/* Rows */}
+      {sorted.map((item) => {
+        const apy = apyByKey[item.key];
+        return (
+          <div
+            key={item.key}
+            onClick={() => item.vaultAddress && onRowClick(item.vaultAddress)}
+            className="grid cursor-pointer grid-cols-[2fr_1fr_1fr_1fr_1fr] items-center gap-0 border-b border-b-vantage-border px-20 py-16 transition-colors last:border-0 hover:bg-slate-800/40"
+            onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.background = COLORS.baseHover)}
+            onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.background = "transparent")}
+          >
+            {/* Asset */}
+            <div className="flex items-center gap-12">
+              <div className="flex h-56 w-56 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
+                {item.symbol.slice(0, 2)}
+              </div>
+              <div>
+                <div className="flex items-center gap-8">
+                  <div className="text-16 font-semibold text-white">{item.symbol}</div>
+                  <span
+                    className={`rounded-full px-8 py-1 text-11 font-medium ${TRANCHE_META[item.trancheType].badgeClass}`}
+                  >
+                    {TRANCHE_META[item.trancheType].shortLabel} · {TRANCHE_META[item.trancheType].riskLabel}
+                  </span>
+                </div>
+                <div className="text-14 text-vantage-text-secondary">{item.name}</div>
+              </div>
+            </div>
+
+            {/* AUM */}
+            <div className="text-right">
+              {item.isLoading ? (
+                <span className="text-slate-500">—</span>
+              ) : (
+                <span className="text-15 font-medium text-white">{formatUsd(item.aum)}</span>
+              )}
+            </div>
+
+            {/* APY */}
+            <div className="text-right">
+              {apy === null ? (
+                <span className="text-14 text-slate-500">—</span>
+              ) : (
+                <span className="text-15 font-medium text-green-400">{(apy * 100).toFixed(2)}%</span>
+              )}
+            </div>
+
+            {/* Asset Type badge */}
+            <div className="flex justify-end">
+              <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[item.assetType]}`}>
+                {ASSET_TYPE_LABEL[item.assetType]}
+              </span>
+            </div>
+
+            {/* My Deposit */}
+            <div className="text-right">
+              {!account ? (
+                <span className="text-14 text-slate-500">—</span>
+              ) : item.isLoading ? (
+                <span className="text-14 text-slate-500">…</span>
+              ) : item.usdValue > 0n ? (
+                <span className="text-15 font-medium text-white">{formatUsd(item.usdValue)}</span>
+              ) : (
+                <span className="text-14 text-slate-500">—</span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TrancheSection — heading + description + table for one tranche
+// ---------------------------------------------------------------------------
+
+type TrancheSectionProps = {
+  tranche: TrancheType;
+  items: VaultListItem[];
+  apyByKey: Record<string, number | null>;
+  account: string | null | undefined;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+  onRowClick: (vaultAddress: string) => void;
+};
+
+function TrancheSection({
+  tranche,
+  items,
+  apyByKey,
+  account,
+  sortKey,
+  sortDir,
+  onSort,
+  onRowClick,
+}: TrancheSectionProps) {
+  const meta = TRANCHE_META[tranche];
+  const icon = tranche === "senior" ? "🛡️" : "🚀";
+  const borderClass = tranche === "senior" ? "border-l-indigo-500" : "border-l-amber-500";
+
+  return (
+    <div className="mb-28">
+      {/* Section header */}
+      <div className={`mb-12 border-l-4 pl-12 ${borderClass}`}>
+        <div className="flex items-center gap-10">
+          <span className="text-20">{icon}</span>
+          <div>
+            <h2 className="text-16 font-bold text-white">
+              {t`${meta.label}s`} <span className="ml-4 text-14 font-normal text-slate-400">({meta.riskLabel})</span>
+            </h2>
+            <p className="leading-relaxed mt-2 text-13 text-slate-400">{meta.description}</p>
+          </div>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-4 border border-vantage-border bg-vantage-base py-32 text-center text-14 text-slate-500">
+          {t`No vaults in this category.`}
+        </div>
+      ) : (
+        <VaultTable
+          items={items}
+          apyByKey={apyByKey}
+          account={account}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          onRowClick={onRowClick}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page component
 // ---------------------------------------------------------------------------
 
 export default function VaultsPage() {
@@ -55,12 +312,15 @@ export default function VaultsPage() {
   const apy1 = useVaultApy(VAULT_CONFIGS[1]);
   const apy2 = useVaultApy(VAULT_CONFIGS[2]);
   const apy3 = useVaultApy(VAULT_CONFIGS[3]);
-  const apyByKey: Record<string, number | null> = {
-    [VAULT_CONFIGS[0].key]: apy0,
-    [VAULT_CONFIGS[1].key]: apy1,
-    [VAULT_CONFIGS[2].key]: apy2,
-    [VAULT_CONFIGS[3].key]: apy3,
-  };
+  const apyByKey: Record<string, number | null> = useMemo(
+    () => ({
+      [VAULT_CONFIGS[0].key]: apy0,
+      [VAULT_CONFIGS[1].key]: apy1,
+      [VAULT_CONFIGS[2].key]: apy2,
+      [VAULT_CONFIGS[3].key]: apy3,
+    }),
+    [apy0, apy1, apy2, apy3]
+  );
 
   const [sortKey, setSortKey] = useState<SortKey>("none");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -74,17 +334,8 @@ export default function VaultsPage() {
     }
   }
 
-  const sorted = [...items].sort((a, b) => {
-    if (sortKey === "aum") {
-      return sortDir === "desc" ? Number(b.aum - a.aum) : Number(a.aum - b.aum);
-    }
-    if (sortKey === "apy") {
-      const apyA = apyByKey[a.key] ?? -Infinity;
-      const apyB = apyByKey[b.key] ?? -Infinity;
-      return sortDir === "desc" ? apyB - apyA : apyA - apyB;
-    }
-    return 0;
-  });
+  const seniorItems = items.filter((v) => v.trancheType === "senior");
+  const juniorItems = items.filter((v) => v.trancheType === "junior");
 
   return (
     <div className="w-full">
@@ -93,102 +344,40 @@ export default function VaultsPage() {
         <AppHeader leftContent={<AppNav />} />
       </div>
 
-      <VantagePageContainer title={t`Vaults`} description={t`Provide liquidity to earn yield from RWA assets.`}>
-        {/* Table */}
-        <div className="overflow-hidden rounded-4 border-b border-b-vantage-border bg-vantage-base">
-          {/* Table header */}
-          <div className="grid grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-0 border-b border-b-vantage-border px-20 py-12 text-12 text-vantage-text-secondary">
-            <div>{t`Asset`}</div>
-            <div
-              className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "aum" ? "text-white" : ""}`}
-              onClick={() => handleSort("aum")}
-            >
-              {t`AUM`} {sortKey === "aum" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
-            </div>
-            <div
-              className={`cursor-pointer select-none text-right transition-colors hover:text-white ${sortKey === "apy" ? "text-white" : ""}`}
-              onClick={() => handleSort("apy")}
-            >
-              {t`APY`} {sortKey === "apy" ? (sortDir === "desc" ? "↓" : "↑") : "↕"}
-            </div>
-            <div className="text-right">{t`Type`}</div>
-            <div className="text-right">{account ? t`My Deposit` : ""}</div>
-          </div>
+      <VantagePageContainer
+        title={t`Vaults`}
+        description={t`Choose your risk-return profile: Senior vaults offer stability, Junior captures higher yield.`}
+      >
+        {/* Waterfall structure diagram */}
+        <WaterfallDiagram />
 
-          {/* Rows */}
-          {sorted.map((item) => {
-            const apy = apyByKey[item.key];
-            return (
-              <div
-                key={item.key}
-                onClick={() => item.vaultAddress && history.push(`/vaults/${item.vaultAddress}`)}
-                className="grid cursor-pointer grid-cols-[2fr_1fr_1fr_1fr_1fr] items-center gap-0 border-b border-b-vantage-border px-20 py-16 transition-colors last:border-0 hover:bg-slate-800/40"
-                onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.background = COLORS.baseHover)}
-                onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.background = "transparent")}
-              >
-                {/* Asset */}
-                <div className="flex items-center gap-12">
-                  <div className="flex h-56 w-56 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
-                    {item.symbol.slice(0, 2)}
-                  </div>
-                  <div>
-                    <div className="text-16 font-semibold text-white">{item.symbol}</div>
-                    <div className="text-14 text-vantage-text-secondary">{item.name}</div>
-                  </div>
-                </div>
+        {/* Senior Vaults section */}
+        <TrancheSection
+          tranche="senior"
+          items={seniorItems}
+          apyByKey={apyByKey}
+          account={account}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+          onRowClick={(addr) => history.push(`/vaults/${addr}`)}
+        />
 
-                {/* AUM */}
-                <div className="text-right">
-                  {item.isLoading ? (
-                    <span className="text-slate-500">—</span>
-                  ) : (
-                    <span className="text-15 font-medium text-white">{formatUsd(item.aum)}</span>
-                  )}
-                </div>
-
-                {/* APY */}
-                <div className="text-right">
-                  {apy === null ? (
-                    <span className="text-14 text-slate-500">—</span>
-                  ) : (
-                    <span className="text-15 font-medium text-green-400">{(apy * 100).toFixed(2)}%</span>
-                  )}
-                </div>
-
-                {/* Type badge */}
-                <div className="flex justify-end">
-                  <span className={`rounded-full px-8 py-2 text-11 font-medium ${ASSET_TYPE_COLOR[item.assetType]}`}>
-                    {ASSET_TYPE_LABEL[item.assetType]}
-                  </span>
-                </div>
-
-                {/* My Deposit */}
-                <div className="text-right">
-                  {!account ? (
-                    <span className="text-14 text-slate-500">—</span>
-                  ) : item.isLoading ? (
-                    <span className="text-14 text-slate-500">…</span>
-                  ) : item.usdValue > 0n ? (
-                    <span className="text-15 font-medium text-white">{formatUsd(item.usdValue)}</span>
-                  ) : (
-                    <span className="text-14 text-slate-500">—</span>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-
-          {/* Empty state */}
-          {items.length === 0 && (
-            <div className="py-40 text-center text-14 text-vantage-text-secondary">
-              {t`No vaults configured. Deploy contracts first.`}
-            </div>
-          )}
-        </div>
+        {/* Junior Vault section */}
+        <TrancheSection
+          tranche="junior"
+          items={juniorItems}
+          apyByKey={apyByKey}
+          account={account}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+          onRowClick={(addr) => history.push(`/vaults/${addr}`)}
+        />
 
         {/* Footer hint */}
         {!account && (
-          <p className="mt-16 text-center text-13 text-slate-500">{t`Connect your wallet to see your deposits.`}</p>
+          <p className="mt-8 text-center text-13 text-slate-500">{t`Connect your wallet to see your deposits.`}</p>
         )}
       </VantagePageContainer>
     </div>


### PR DESCRIPTION
## 概要

Issue #203 対応。Vault 一覧ページ（`/vaults`）に Senior / Junior トランチの概念を導入し、ユーザーがリスク・リターン特性を直感的に理解できるよう UI を再構成した。

## 変更内容

### `vaultConfig.ts`
- `TrancheType = 'senior' | 'junior'` 型を追加
- `TRANCHE_META` — バッジスタイル・ラベル・説明文の静的マップを追加
- `VaultConfig.trancheType` フィールドを追加し、各 Vault に分類を設定
  - USDC Vault → `junior`（FR 赤字のファースト・ロス・レイヤー）
  - mBUIDL / mUSDY / mRWA → `senior`（優先利回り受取）

### `VaultsPage.tsx`
- **WaterfallDiagram** コンポーネントを追加：プロトコル収益 → Senior → Junior の流れを図解
- **TrancheSection** コンポーネントでセクション分割（タイトル・説明文・テーブル）
- 各 Vault 行に `Senior / Low Risk` or `Junior / High Reward` バッジを表示
- `apyByKey` を `useMemo` でメモ化（ESLint `react-perf` 対応）

### `VaultDetailPage.tsx`
- 詳細ページのヘッダーにトランチバッジと説明文を追加

## 影響範囲

- `src/domain/vantage/vaults/vaultConfig.ts`
- `src/pages/Vaults/VaultsPage.tsx`
- `src/pages/VaultDetail/VaultDetailPage.tsx`
- `src/locales/**` — Lingui による文字列抽出

## 完了条件の確認

- [x] Vault 一覧が Senior と Junior で視覚的に分離されている
- [x] 各トランチの役割説明文が記載されている
- [x] Waterfall 構造図でリスク・収益フローを説明
- [x] レスポンシブ対応（`flex-col` → `sm:flex-row`）
- [x] `pnpm tscheck` がクリーン
- [x] 532 tests passed

## 動作確認

- [x] `pnpm tscheck` がグリーン
- [x] `pnpm test:ci` — 532 passed
- [x] ESLint `--max-warnings=0` クリーン（pre-commit フック通過）

## 関連情報

- Closes #203