### PR TITLE
feat(issue-227): Index Selector + Skew Fee Display (Frontend)

### DIFF
--- a/src/domain/vantage/positions/types.ts
+++ b/src/domain/vantage/positions/types.ts
@@ -28,6 +28,12 @@ export type VantagePosition = {
   currentPrice: bigint;
   /** Maintenance margin in basis points from AssetRegistry (e.g. 100 = 1%). 0 if registry unavailable. */
   maintenanceMarginBps: bigint;
+  /**
+   * Price adapter bound to this position via Vault.positionAdapter(key).
+   * address(0) when opened through the standard increasePosition path.
+   * Set for Interest Prism positions opened via increasePositionWithAdapter (Issue #225).
+   */
+  priceAdapter: string;
 };
 
 export type VantageAccountSummary = {

--- a/src/domain/vantage/positions/useVantagePositions.ts
+++ b/src/domain/vantage/positions/useVantagePositions.ts
@@ -142,6 +142,16 @@ export function useVantagePositions(
                 }
               }
 
+              // Fetch per-index adapter binding (Issue #225).
+              // Cast to any: positionAdapter is not yet in the generated Vault typechain.
+              let priceAdapter = ZERO;
+              try {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                priceAdapter = await (vault as any).positionAdapter(key);
+              } catch {
+                // positionAdapter not available on older deployments — default to zero address
+              }
+
               openPositions.push({
                 key: key as string,
                 account: account!,
@@ -156,6 +166,7 @@ export function useVantagePositions(
                 pendingPnl,
                 currentPrice,
                 maintenanceMarginBps,
+                priceAdapter,
               });
             }
           }

--- a/src/domain/vantage/trade/usePositionRouterTrade.ts
+++ b/src/domain/vantage/trade/usePositionRouterTrade.ts
@@ -33,6 +33,8 @@ export type IncreaseRequest = {
   markPrice: bigint;
   slippageBps?: number;
   useNativeEth?: boolean;
+  /** Price adapter address for per-index skew tracking (Issue #225). Omit for standard path. */
+  priceAdapter?: string;
 };
 
 export type DecreaseRequest = {
@@ -110,6 +112,20 @@ export function usePositionRouterTrade(): PositionRouterTradeResult {
             acceptablePrice,
             minExecutionFee,
             { value: totalValue }
+          );
+        } else if (req.priceAdapter) {
+          // Per-index adapter path: routes through Vault.increasePositionWithAdapter.
+          // Cast to any: createIncreasePositionWithAdapter is not yet in the generated PositionRouter typechain.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          tx = await (positionRouterWrite as any).createIncreasePositionWithAdapter(
+            req.collateralToken,
+            req.indexToken,
+            req.amountIn,
+            req.sizeDelta,
+            req.isLong,
+            acceptablePrice,
+            req.priceAdapter,
+            { value: minExecutionFee }
           );
         } else {
           tx = await positionRouterWrite.createIncreasePosition(

--- a/src/domain/vantage/vaults/vaultConfig.ts
+++ b/src/domain/vantage/vaults/vaultConfig.ts
@@ -4,6 +4,9 @@
  * Static configuration for the 4 supported Vaults:
  *   USDC (stable), mBUIDL (Rebasing), mUSDY (PriceShare), mRWA (Direct)
  *
+ * Also includes 3 Interest Prism display configs (no real vault — chart-only):
+ *   sUSDe_Price (raw market price), sUSDe_Yield (rate→price), sUSDe_Total (return index)
+ *
  * Addresses are resolved from the deployment JSON at runtime so this file
  * remains network-agnostic. For localhost these come from frontend-localhost.json.
  */
@@ -84,6 +87,14 @@ export interface VaultConfig {
   isMock: boolean;
   /** TradingView symbol used for the price chart (e.g. "BINANCE:BTCUSDT") */
   tvSymbol: string;
+  /**
+   * Interest Prism axis (display-only configs; no real vault or LPManager).
+   *   "price" — raw market price via MockPriceFeed / price oracle
+   *   "yield" — interest rate → price via InterestRateAdapter
+   *   "total" — cumulative total return index via TotalReturnAccumulatorAdapter
+   * When set, vaultAddress / lpManagerAddress / lpTokenAddress are empty strings.
+   */
+  prismAxis?: "price" | "yield" | "total";
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +110,14 @@ const d = localhostDeployment.addresses as {
   mockRWAVaults?: Record<string, string>;
   mockRWALPManagers?: Record<string, string>;
   mockRWALPTokens?: Record<string, string>;
+  /** Interest Prism virtual index token addresses (localhost only) */
+  prismTokens?: { Price?: string; Yield?: string; Total?: string };
+  /** Interest Prism adapter addresses (localhost only) */
+  prismAdapters?: {
+    benchmarkOracle?: string;
+    interestRateAdapter?: string;
+    totalReturnAdapter?: string;
+  };
 };
 
 export const VAULT_CONFIGS: VaultConfig[] = [
@@ -161,6 +180,63 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     tokenDecimals: 18,
     isMock: true,
     tvSymbol: "BINANCE:BTCUSDT",
+  },
+
+  // ── Interest Prism (display-only; no real vault or LPManager) ────────────
+  //
+  // Three views of the same sUSDe asset across different axes:
+  //   Price — raw oracle market price
+  //   Yield — InterestRateAdapter: (benchmarkRate + margin) × scalingFactor
+  //   Total — TotalReturnAccumulatorAdapter: compounding return index
+  //
+  // These configs are only meaningful on localhost where the Prism adapters are
+  // deployed. On other networks prismTokens is absent and tokenAddress will be
+  // an empty string, causing the chart to skip data loading gracefully.
+
+  {
+    key: "sUSDe_Price",
+    name: "sUSDe Market Price",
+    symbol: "sUSDe_P",
+    assetType: 2,
+    trancheType: "senior",
+    vaultAddress: "",
+    tokenAddress: d.prismTokens?.Price ?? "",
+    lpManagerAddress: "",
+    lpTokenAddress: "",
+    tokenDecimals: 18,
+    isMock: true,
+    tvSymbol: "BINANCE:BTCUSDT",
+    prismAxis: "price",
+  },
+  {
+    key: "sUSDe_Yield",
+    name: "sUSDe Yield Rate → Price",
+    symbol: "sUSDe_Y",
+    assetType: 2,
+    trancheType: "senior",
+    vaultAddress: "",
+    tokenAddress: d.prismTokens?.Yield ?? "",
+    lpManagerAddress: "",
+    lpTokenAddress: "",
+    tokenDecimals: 18,
+    isMock: true,
+    tvSymbol: "BINANCE:BTCUSDT",
+    prismAxis: "yield",
+  },
+  {
+    key: "sUSDe_Total",
+    name: "sUSDe Total Return Index",
+    symbol: "sUSDe_T",
+    assetType: 2,
+    trancheType: "senior",
+    vaultAddress: "",
+    tokenAddress: d.prismTokens?.Total ?? "",
+    lpManagerAddress: "",
+    lpTokenAddress: "",
+    tokenDecimals: 18,
+    isMock: true,
+    tvSymbol: "BINANCE:BTCUSDT",
+    prismAxis: "total",
   },
 ];
 

--- a/src/domain/vantage/vaults/vaultConfig.ts
+++ b/src/domain/vantage/vaults/vaultConfig.ts
@@ -95,6 +95,12 @@ export interface VaultConfig {
    * When set, vaultAddress / lpManagerAddress / lpTokenAddress are empty strings.
    */
   prismAxis?: "price" | "yield" | "total";
+  /**
+   * Price adapter address for per-index skew tracking (Issue #225/#227).
+   * Set on Prism axis configs to route increasePositionWithAdapter calls.
+   * Undefined on standard configs (no adapter binding).
+   */
+  adapterAddress?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -199,7 +205,7 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     symbol: "sUSDe_P",
     assetType: 2,
     trancheType: "senior",
-    vaultAddress: "",
+    vaultAddress: d.JuniorTrancheVault ?? "",
     tokenAddress: d.prismTokens?.Price ?? "",
     lpManagerAddress: "",
     lpTokenAddress: "",
@@ -207,6 +213,7 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     isMock: true,
     tvSymbol: "BINANCE:BTCUSDT",
     prismAxis: "price",
+    adapterAddress: d.prismAdapters?.benchmarkOracle ?? "",
   },
   {
     key: "sUSDe_Yield",
@@ -214,7 +221,7 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     symbol: "sUSDe_Y",
     assetType: 2,
     trancheType: "senior",
-    vaultAddress: "",
+    vaultAddress: d.JuniorTrancheVault ?? "",
     tokenAddress: d.prismTokens?.Yield ?? "",
     lpManagerAddress: "",
     lpTokenAddress: "",
@@ -222,6 +229,7 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     isMock: true,
     tvSymbol: "BINANCE:BTCUSDT",
     prismAxis: "yield",
+    adapterAddress: d.prismAdapters?.interestRateAdapter ?? "",
   },
   {
     key: "sUSDe_Total",
@@ -229,7 +237,7 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     symbol: "sUSDe_T",
     assetType: 2,
     trancheType: "senior",
-    vaultAddress: "",
+    vaultAddress: d.JuniorTrancheVault ?? "",
     tokenAddress: d.prismTokens?.Total ?? "",
     lpManagerAddress: "",
     lpTokenAddress: "",
@@ -237,6 +245,7 @@ export const VAULT_CONFIGS: VaultConfig[] = [
     isMock: true,
     tvSymbol: "BINANCE:BTCUSDT",
     prismAxis: "total",
+    adapterAddress: d.prismAdapters?.totalReturnAdapter ?? "",
   },
 ];
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1891,6 +1891,7 @@ msgstr "Affiliate-Adresse:"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "Insgesamt"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "Dashboard für dezentrale Finanzen"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "Ausstehender PnL aus allen offenen Positionen"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "Einklappen"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "Nahtloser Handel"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "aus Ihrer Wallet"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "Maximalbetrag überschritten"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "Parameter zum Beanspruchen nicht verfügbar. Versuchen Sie es in einigen
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "Details lesen"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1891,6 +1891,7 @@ msgstr "Affiliate address:"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "Total"
 
@@ -3307,6 +3308,10 @@ msgstr "Next redemption execution:"
 msgid "Decentralized finance dashboard"
 msgstr "Decentralized finance dashboard"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr "Index"
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "Pending PnL from all open positions"
@@ -3891,6 +3896,10 @@ msgstr "Withdrawals are restricted on weekends due to RWA liquidity protection. 
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "Collapse"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr "Index Capacity"
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "Seamless trading"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "from your wallet"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr "Base Fee"
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8263,6 +8276,10 @@ msgstr "Max amount exceeded"
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
 msgstr "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
+msgstr "Skew Adjustment"
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
 msgid "Mode A — Yield + Premium Offset"
@@ -11716,6 +11733,10 @@ msgstr "Claim parameters unavailable. Retry in a few seconds"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "Read details"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr "Estimated Fee"
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1891,6 +1891,7 @@ msgstr "Dirección del afiliado:"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "Total"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "Panel de finanzas descentralizadas"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "PnL pendiente de todas las posiciones abiertas"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "Contraer"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "Trading sin interrupciones"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "desde tu billetera"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "Superado el importe máximo"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "Parámetros de reclamación no disponibles. Reintente en unos segundos"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "Leer detalles"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1891,6 +1891,7 @@ msgstr "Adresse de l'affilié :"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "Total"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "Tableau de bord de la finance décentralisée"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "PnL en attente de toutes les positions ouvertes"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "Réduire"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "Trading fluide"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "depuis votre portefeuille"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "Montant maximal dépassé"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "Paramètres de récupération indisponibles. Réessayez dans quelques se
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "Lire les détails"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1891,6 +1891,7 @@ msgstr "アフィリエイトアドレス:"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "総計"
 
@@ -3307,6 +3308,10 @@ msgstr "次の償還実行予定:"
 msgid "Decentralized finance dashboard"
 msgstr "分散型金融ダッシュボード"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "すべてのオープンポジションからの未確定PnL"
@@ -3891,6 +3896,10 @@ msgstr "RWA流動性保護のため、週末は出金が制限されています
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "折りたたむ"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "シームレスな取引"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "ウォレットから"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8258,6 +8271,10 @@ msgstr "最大値超過"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11708,6 +11725,10 @@ msgstr "受け取りパラメータが利用できません。数秒後に再試
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "詳細を読む"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1891,6 +1891,7 @@ msgstr "추천인 주소:"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "총계"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "탈중앙화 금융 대시보드"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "모든 미결 포지션의 미실현 PnL"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "접기"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "원활한 거래"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "지갑에서"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "최대 수량 초과"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "수령 매개변수를 사용할 수 없습니다. 몇 초 후 다시 �
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "상세 내용 보기"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/pseudo/messages.po
+++ b/src/locales/pseudo/messages.po
@@ -1891,6 +1891,7 @@ msgstr ""
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr ""
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr ""
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr ""
@@ -3890,6 +3895,10 @@ msgstr ""
 
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
 msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
@@ -5898,6 +5907,10 @@ msgstr ""
 
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
 msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
@@ -8262,6 +8275,10 @@ msgstr ""
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11715,6 +11732,10 @@ msgstr ""
 #: src/components/Earn/Portfolio/AssetsList/GmxAssetCard/VestModal.tsx
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
 msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1891,6 +1891,7 @@ msgstr "Адрес аффилиата:"
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "Итого"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "Панель управления децентрализованными финансами"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "Незафиксированный PnL по всем открытым позициям"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "Свернуть"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "Бесшовная торговля"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "из вашего кошелька"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "Максимальная сумма превышена"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "Параметры получения недоступны. Повтор
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "Подробнее"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/zh-tw/messages.po
+++ b/src/locales/zh-tw/messages.po
@@ -1891,6 +1891,7 @@ msgstr "推廣夥伴地址："
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "全部"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "去中心化金融儀表板"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "所有未平倉倉位的待結算 PnL"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "收合"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "無縫交易"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "從您的錢包"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "超過最大數量"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "領取參數不可用。請幾秒後重試"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "閱讀詳情"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1891,6 +1891,7 @@ msgstr "推广者地址："
 #: src/pages/LeaderboardPage/components/LeaderboardContainer.tsx
 #: src/pages/Pools/PoolsTimeRangeFilter.tsx
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
+#: src/pages/Trade/components/OpenPositionPanel.tsx
 msgid "Total"
 msgstr "总计"
 
@@ -3307,6 +3308,10 @@ msgstr ""
 msgid "Decentralized finance dashboard"
 msgstr "去中心化金融仪表盘"
 
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index"
+msgstr ""
+
 #: src/pages/SyntheticsStats/SyntheticsStats.tsx
 msgid "Pending PnL from all open positions"
 msgstr "所有未平仓仓位的待结算 PnL"
@@ -3891,6 +3896,10 @@ msgstr ""
 #: src/components/SideNav/BottomMenuSection.tsx
 msgid "Collapse"
 msgstr "折叠"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Index Capacity"
+msgstr ""
 
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Banners"
@@ -5899,6 +5908,10 @@ msgstr "无缝交易"
 #: landing/src/pages/Home/HeroSection/HeroSection.tsx
 msgid "from your wallet"
 msgstr "从您的钱包"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Base Fee"
+msgstr ""
 
 #: src/components/Earn/Portfolio/RecommendedAssets/RecommendedAssets.tsx
 msgid "Explore more"
@@ -8262,6 +8275,10 @@ msgstr "超出最大金额"
 
 #: src/pages/Admin/AdminPage.tsx
 msgid "Trade OI is near cap (≥95%). Oracle price movements at TX time may trigger TradeCapExceeded."
+msgstr ""
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Skew Adjustment"
 msgstr ""
 
 #: src/pages/Hedge/HedgeDetailPage.tsx
@@ -11716,6 +11733,10 @@ msgstr "领取参数不可用。请在几秒后重试"
 #: src/pages/UiPage/BannerTest.tsx
 msgid "Read details"
 msgstr "查看详情"
+
+#: src/pages/Trade/components/OpenPositionPanel.tsx
+msgid "Estimated Fee"
+msgstr ""
 
 #: src/domain/vantage/vaults/vaultConfig.ts
 msgid "Senior"

--- a/src/pages/Portfolio/PortfolioPage.tsx
+++ b/src/pages/Portfolio/PortfolioPage.tsx
@@ -345,6 +345,19 @@ function SolvencySection({ items }: SolvencySectionProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Prism axis label helper (Issue #225/#227)
+// ---------------------------------------------------------------------------
+
+const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
+
+function getPrismAxisLabel(adapterAddress: string): string | null {
+  if (!adapterAddress || adapterAddress === ZERO_ADDR) return null;
+  const cfg = VAULT_CONFIGS.find((v) => v.adapterAddress?.toLowerCase() === adapterAddress.toLowerCase());
+  if (!cfg?.prismAxis) return null;
+  return { price: "Price", yield: "Yield", total: "Total" }[cfg.prismAxis] ?? null;
+}
+
+// ---------------------------------------------------------------------------
 // ADL Risk helpers
 // ---------------------------------------------------------------------------
 
@@ -559,9 +572,18 @@ function TradingSection({ positions, hasAccount }: TradingSectionProps) {
                   <div className="flex h-28 w-28 items-center justify-center rounded-full bg-slate-700 text-14 font-bold text-white">
                     {p.indexToken.slice(2, 4).toUpperCase()}
                   </div>
-                  <span className="text-13 font-medium text-white">
-                    {p.indexToken.slice(0, 6)}…{p.indexToken.slice(-4)}
-                  </span>
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-6">
+                      <span className="text-13 font-medium text-white">
+                        {p.indexToken.slice(0, 6)}…{p.indexToken.slice(-4)}
+                      </span>
+                      {getPrismAxisLabel(p.priceAdapter) && (
+                        <span className="bg-indigo-900/50 text-10 text-indigo-300 rounded-full px-6 py-1 font-medium">
+                          {getPrismAxisLabel(p.priceAdapter)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
                 </div>
                 {/* Side */}
                 <div className="text-right">

--- a/src/pages/Trade/TradePage.tsx
+++ b/src/pages/Trade/TradePage.tsx
@@ -37,8 +37,16 @@ const d = localhostDeployment.addresses as {
 };
 const USDC_ADDRESS = d.tokens?.USDC ?? "";
 
-// Vault configs that have a valid tokenAddress (tradeable markets)
-const TRADEABLE_VAULTS = VAULT_CONFIGS.filter((v) => v.tokenAddress && v.vaultAddress && v.assetType !== "stable");
+// Vault configs that have a valid tokenAddress (tradeable markets).
+// For Interest Prism vaults, only include the "price" axis as the representative market entry;
+// the axis tabs (Price / Yield / Total) are shown inside OpenPositionPanel.
+const TRADEABLE_VAULTS = VAULT_CONFIGS.filter(
+  (v) =>
+    v.tokenAddress &&
+    v.vaultAddress &&
+    v.assetType !== "stable" &&
+    (v.prismAxis === undefined || v.prismAxis === "price")
+);
 
 export default function TradePage() {
   const { account } = useWallet();
@@ -243,6 +251,7 @@ export default function TradePage() {
                     requests={requests}
                     onSuccess={() => setTimeout(refetch, 2000)}
                     noLiquidity={!hasLiquidity}
+                    vaultConfig={selectedVault}
                   />
                 )}
               </div>

--- a/src/pages/Trade/components/OpenPositionPanel.tsx
+++ b/src/pages/Trade/components/OpenPositionPanel.tsx
@@ -9,6 +9,9 @@
  *   - Slippage selector (0.1% / 0.3% / 0.5% / custom)
  *   - Bid/Ask spread display
  *   - Approve + Submit buttons with correct state management
+ *   - Index selector (Price / Yield / Total) for Interest Prism vaults (Issue #227)
+ *   - Skew Fee preview: Base Fee + Skew Adjustment = Total (Issue #225/#227)
+ *   - Per-adapter sub-limit capacity bar (Issue #225/#227)
  */
 
 import { t } from "@lingui/macro";
@@ -19,6 +22,7 @@ import type { UsePositionRequestsResult } from "domain/vantage/trade/usePosition
 import type { PositionRouterTradeResult } from "domain/vantage/trade/usePositionRouterTrade";
 import { DEFAULT_SLIPPAGE_BPS } from "domain/vantage/trade/usePositionRouterTrade";
 import type { SpreadData } from "domain/vantage/trade/useSpread";
+import { VAULT_CONFIGS, type VaultConfig } from "domain/vantage/vaults/vaultConfig";
 import { useChainId } from "lib/chains";
 import { helperToast } from "lib/helperToast";
 import { getProvider } from "lib/rpc";
@@ -39,6 +43,23 @@ const COLLATERAL_OPTIONS = [
 
 const SLIPPAGE_PRESETS = [10, 30, 50] as const; // bps
 
+// Minimal ABI for per-index skew reads (Issue #225)
+const SKEW_ABI = [
+  "function adapterLongOI(address) view returns (uint256)",
+  "function adapterShortOI(address) view returns (uint256)",
+  "function adapterMaxOI(address) view returns (uint256)",
+  "function skewFeeMultiplier(address) view returns (uint256)",
+  "function minFeeRateBps(address) view returns (uint256)",
+];
+
+type PrismAxis = "price" | "yield" | "total";
+
+const PRISM_AXIS_LABELS: Record<PrismAxis, string> = {
+  price: "Price",
+  yield: "Yield",
+  total: "Total",
+};
+
 type Props = {
   isLong: boolean;
   indexToken: string;
@@ -49,6 +70,8 @@ type Props = {
   onSuccess?: () => void;
   /** True when JuniorTrancheVault has no USDC — trades would revert on-chain. */
   noLiquidity?: boolean;
+  /** Full vault config for the selected market. Used to enable Prism axis selector. */
+  vaultConfig?: VaultConfig;
 };
 
 export function OpenPositionPanel({
@@ -60,6 +83,7 @@ export function OpenPositionPanel({
   requests,
   onSuccess,
   noLiquidity,
+  vaultConfig,
 }: Props) {
   const { account, signer } = useWallet();
   const { chainId } = useChainId();
@@ -75,7 +99,99 @@ export function OpenPositionPanel({
   const [isApproving, setIsApproving] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Dynamic OI cap: read from Vault + AssetRegistry
+  // ── Prism axis selector (Issue #227) ──────────────────────────────────────
+
+  const isPrismVault = Boolean(vaultConfig?.prismAxis);
+  const [selectedAxis, setSelectedAxis] = useState<PrismAxis>((vaultConfig?.prismAxis as PrismAxis) ?? "price");
+
+  // Sync selectedAxis when vaultConfig changes (e.g. user switches market)
+  useEffect(() => {
+    if (vaultConfig?.prismAxis) {
+      setSelectedAxis(vaultConfig.prismAxis as PrismAxis);
+    }
+  }, [vaultConfig?.prismAxis]);
+
+  // Resolve the active prism config based on the selected axis tab
+  const activePrismConfig = useMemo<VaultConfig | undefined>(() => {
+    if (!isPrismVault) return undefined;
+    return VAULT_CONFIGS.find((v) => v.prismAxis === selectedAxis);
+  }, [isPrismVault, selectedAxis]);
+
+  // Effective index token and adapter address for this trade
+  const activeIndexToken = activePrismConfig?.tokenAddress ?? indexToken;
+  const activeAdapterAddress =
+    activePrismConfig?.adapterAddress && activePrismConfig.adapterAddress !== ""
+      ? activePrismConfig.adapterAddress
+      : undefined;
+
+  // ── Skew Fee State (Issue #225/#227) ─────────────────────────────────────
+
+  type SkewData = {
+    longOI: bigint;
+    shortOI: bigint;
+    maxOI: bigint;
+    multiplier: bigint;
+    minFeeRate: bigint;
+    baseFee: bigint; // marginFeeBps from AssetRegistry
+  };
+  const [skewData, setSkewData] = useState<SkewData | null>(null);
+
+  useEffect(() => {
+    if (!activeAdapterAddress) {
+      setSkewData(null);
+      return;
+    }
+    const vaultAddr = getVantageContractAddress(chainId, "JuniorTrancheVault");
+    const registryAddr = getVantageContractAddress(chainId, "AssetRegistry");
+    const ZERO = "0x0000000000000000000000000000000000000000";
+    if (!vaultAddr || vaultAddr === ZERO || !registryAddr || registryAddr === ZERO) return;
+
+    const skewContract = new Contract(vaultAddr, SKEW_ABI, provider);
+    const registry = AssetRegistry__factory.connect(registryAddr, provider);
+
+    Promise.all([
+      skewContract.adapterLongOI(activeAdapterAddress) as Promise<bigint>,
+      skewContract.adapterShortOI(activeAdapterAddress) as Promise<bigint>,
+      skewContract.adapterMaxOI(activeAdapterAddress) as Promise<bigint>,
+      skewContract.skewFeeMultiplier(activeAdapterAddress) as Promise<bigint>,
+      skewContract.minFeeRateBps(activeAdapterAddress) as Promise<bigint>,
+      registry.getAssetRiskInfo(activeIndexToken).then((r) => r.marginFeeBps) as Promise<bigint>,
+    ])
+      .then(([longOI, shortOI, maxOI, multiplier, minFeeRate, baseFee]) => {
+        setSkewData({ longOI, shortOI, maxOI, multiplier, minFeeRate, baseFee });
+      })
+      .catch(() => setSkewData(null));
+  }, [activeAdapterAddress, activeIndexToken, chainId, provider]);
+
+  // Compute effective fee bps for current direction
+  const { skewBps, effectiveBps, isIncreasingSkew } = useMemo(() => {
+    if (!skewData || skewData.maxOI === 0n) {
+      return { skewBps: 0n, effectiveBps: skewData?.baseFee ?? 0n, isIncreasingSkew: false };
+    }
+    const { longOI, shortOI, maxOI, multiplier, minFeeRate, baseFee } = skewData;
+    const skew = longOI >= shortOI ? longOI - shortOI : shortOI - longOI;
+    const sBps = (multiplier * skew) / maxOI;
+    const increasing = (isLong && longOI >= shortOI) || (!isLong && shortOI >= longOI);
+    let eBps: bigint;
+    if (increasing) {
+      eBps = baseFee + sBps;
+    } else {
+      eBps = baseFee > sBps + minFeeRate ? baseFee - sBps : minFeeRate;
+    }
+    return { skewBps: sBps, effectiveBps: eBps, isIncreasingSkew: increasing };
+  }, [skewData, isLong]);
+
+  // Sub-limit utilization ratio (0–1)
+  const subLimitRatio = useMemo(() => {
+    if (!skewData || skewData.maxOI === 0n) return 0;
+    const totalOI = skewData.longOI + skewData.shortOI;
+    return Number((totalOI * 10_000n) / skewData.maxOI) / 10_000;
+  }, [skewData]);
+
+  const subLimitBarStyle = useMemo(() => ({ width: `${Math.min(subLimitRatio * 100, 100)}%` }), [subLimitRatio]);
+
+  // ── Dynamic OI cap: read from Vault + AssetRegistry ──────────────────────
+
   const [oiCapError, setOiCapError] = useState<string | null>(null);
 
   const collateralDecimals = useNativeEth ? 18 : 6;
@@ -186,13 +302,14 @@ export function OpenPositionPanel({
 
       const requestKey = await trade.createIncreasePosition({
         collateralToken,
-        indexToken,
+        indexToken: activeIndexToken,
         amountIn,
         sizeDelta,
         isLong,
         markPrice,
         slippageBps,
         useNativeEth,
+        priceAdapter: activeAdapterAddress,
       });
 
       if (requestKey) {
@@ -201,7 +318,7 @@ export function OpenPositionPanel({
           type: "increase",
           createdAtMs: now,
           expiresAtMs,
-          indexToken,
+          indexToken: activeIndexToken,
           isLong,
           sizeDelta,
         });
@@ -223,6 +340,28 @@ export function OpenPositionPanel({
     <div className="flex flex-col gap-12">
       {/* Spread display */}
       <SpreadBadge spread={spread} />
+
+      {/* ── Interest Prism Index Selector (Issue #227) ─────────────────────── */}
+      {isPrismVault && (
+        <div>
+          <div className="mb-6 text-12 text-slate-400">{t`Index`}</div>
+          <div className="flex gap-6">
+            {(["price", "yield", "total"] as PrismAxis[]).map((axis) => (
+              <button
+                key={axis}
+                onClick={() => setSelectedAxis(axis)}
+                className={`rounded-4 px-12 py-6 text-12 font-medium transition-colors ${
+                  selectedAxis === axis
+                    ? "bg-vantage-accent text-black"
+                    : "bg-vantage-input text-vantage-text-secondary hover:text-white"
+                }`}
+              >
+                {PRISM_AXIS_LABELS[axis]}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Collateral type toggle */}
       <div className="flex gap-8">
@@ -306,6 +445,44 @@ export function OpenPositionPanel({
               )
             ).toFixed(4)}
           </span>
+        </div>
+      )}
+
+      {/* ── Skew Fee Preview (Issue #225/#227) ──────────────────────────────── */}
+      {skewData && skewData.maxOI > 0n && (
+        <div className="rounded-4 border border-vantage-border bg-vantage-input/50 px-12 py-10 text-12">
+          <div className="text-slate-300 mb-8 font-medium">{t`Estimated Fee`}</div>
+          <div className="flex items-center justify-between text-slate-400">
+            <span>{t`Base Fee`}</span>
+            <span>{Number(skewData.baseFee) / 100}%</span>
+          </div>
+          <div className="mt-4 flex items-center justify-between">
+            <span className="text-slate-400">{t`Skew Adjustment`}</span>
+            <span className={isIncreasingSkew ? "text-red-400" : "text-green-400"}>
+              {isIncreasingSkew ? "+" : "−"}
+              {Number(skewBps) / 100}%
+            </span>
+          </div>
+          <div className="mt-6 flex items-center justify-between border-t border-vantage-border pt-6 font-semibold text-white">
+            <span>{t`Total`}</span>
+            <span>{Number(effectiveBps) / 100}%</span>
+          </div>
+
+          {/* Sub-limit capacity bar */}
+          <div className="mt-8">
+            <div className="mb-4 flex items-center justify-between text-11 text-slate-500">
+              <span>{t`Index Capacity`}</span>
+              <span>{(subLimitRatio * 100).toFixed(1)}%</span>
+            </div>
+            <div className="h-4 overflow-hidden rounded-full bg-slate-700">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  subLimitRatio > 0.9 ? "bg-red-500" : subLimitRatio > 0.7 ? "bg-amber-500" : "bg-green-500"
+                }`}
+                style={subLimitBarStyle}
+              />
+            </div>
+          </div>
         </div>
       )}
 

--- a/src/pages/Trade/components/UnifiedPositionList.tsx
+++ b/src/pages/Trade/components/UnifiedPositionList.tsx
@@ -17,11 +17,22 @@ import { useEffect, useRef } from "react";
 import type { VantagePosition } from "domain/vantage/positions/types";
 import { calcHealthBps, calcLiquidationPrice, formatVantageUsd } from "domain/vantage/positions/utils";
 import type { PositionRequest, UsePositionRequestsResult } from "domain/vantage/trade/usePositionRequests";
+import { VAULT_CONFIGS } from "domain/vantage/vaults/vaultConfig";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 function shortenAddr(addr: string) {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
+
+/** Returns the prism axis label for a given adapter address, or null if not a prism position. */
+function getPrismAxisLabel(adapterAddress: string): string | null {
+  if (!adapterAddress || adapterAddress === ZERO_ADDR) return null;
+  const cfg = VAULT_CONFIGS.find((v) => v.adapterAddress?.toLowerCase() === adapterAddress.toLowerCase());
+  if (!cfg?.prismAxis) return null;
+  return { price: "Price", yield: "Yield", total: "Total" }[cfg.prismAxis] ?? null;
 }
 
 function leverageLabel(size: bigint, collateral: bigint): string {
@@ -247,7 +258,14 @@ function ActiveRow({
     >
       {/* Market */}
       <div className="flex flex-col gap-2">
-        <span className="text-13 font-semibold text-white">{shortenAddr(pos.indexToken)}</span>
+        <div className="flex items-center gap-6">
+          <span className="text-13 font-semibold text-white">{shortenAddr(pos.indexToken)}</span>
+          {getPrismAxisLabel(pos.priceAdapter) && (
+            <span className="bg-indigo-900/50 text-10 text-indigo-300 rounded-full px-6 py-1 font-medium">
+              {getPrismAxisLabel(pos.priceAdapter)}
+            </span>
+          )}
+        </div>
         <span className="text-11 text-slate-500">{leverageLabel(pos.size, pos.collateral)}</span>
       </div>
 

--- a/src/vantage/abis/IVault.json
+++ b/src/vantage/abis/IVault.json
@@ -403,6 +403,42 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "juniorVault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "absorbFRDeficitFromSeniorYield",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "authorizedJuniorVault",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_account",
         "type": "address"
       },
@@ -456,6 +492,25 @@
   {
     "inputs": [],
     "name": "getAUM",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getAbsorbableYield",
     "outputs": [
       {
         "internalType": "uint256",
@@ -569,11 +624,93 @@
         "internalType": "uint256",
         "name": "_collateralDelta",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_convertOnADL",
+        "type": "bool"
       }
     ],
     "name": "increasePosition",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_collateralDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_priceAdapter",
+        "type": "address"
+      }
+    ],
+    "name": "increasePositionWithAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "juniorVault",
+        "type": "address"
+      }
+    ],
+    "name": "isJuniorCapReached",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -631,19 +768,6 @@
   {
     "inputs": [],
     "name": "lpManager",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "payoutHub",
     "outputs": [
       {
         "internalType": "address",
@@ -730,6 +854,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "juniorVault",
+        "type": "address"
+      }
+    ],
+    "name": "setAuthorizedJuniorVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/src/vantage/abis/PositionRouter.json
+++ b/src/vantage/abis/PositionRouter.json
@@ -352,6 +352,114 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_convertOnADL",
+        "type": "bool"
+      }
+    ],
+    "name": "createIncreasePositionFor",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestKey",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_priceAdapter",
+        "type": "address"
+      }
+    ],
+    "name": "createIncreasePositionWithAdapter",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestKey",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
@@ -540,6 +648,60 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_executionFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_convertOnADL",
+        "type": "bool"
+      }
+    ],
+    "name": "increasePositionETHFor",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestKey",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
@@ -599,8 +761,23 @@
       },
       {
         "internalType": "bool",
+        "name": "isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
         "name": "isNativeETH",
         "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "priceAdapter",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -634,6 +811,25 @@
       }
     ],
     "name": "isKeeper",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isRouter",
     "outputs": [
       {
         "internalType": "bool",
@@ -746,6 +942,24 @@
       }
     ],
     "name": "setIsKeeper",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isRouter",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsRouter",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/vantage/abis/Vault.json
+++ b/src/vantage/abis/Vault.json
@@ -19,6 +19,33 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "projected",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "AdapterSubLimitExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "account",
         "type": "address"
       }
@@ -72,6 +99,59 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "projected",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cap",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgeCapExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "HedgeDisabledError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "leverage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "threshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "HighLeverageLocked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsolventVault",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
         "name": "actual",
         "type": "uint256"
       },
@@ -82,6 +162,22 @@
       }
     ],
     "name": "InvalidLeverage",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "juniorAUM",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      }
+    ],
+    "name": "JuniorLiquidityInsufficient",
     "type": "error"
   },
   {
@@ -112,8 +208,14 @@
     "type": "error"
   },
   {
-    "inputs": [],
-    "name": "NoPendingPayoutHub",
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "NotAHedgePosition",
     "type": "error"
   },
   {
@@ -139,19 +241,39 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
-        "internalType": "address",
+        "internalType": "uint256",
+        "name": "dropAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "delay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "current",
-        "type": "address"
+        "type": "uint256"
       }
     ],
-    "name": "PayoutHubAlreadySet",
+    "name": "SoftDeleveragingNotReady",
     "type": "error"
   },
   {
     "inputs": [],
-    "name": "ReentrancyGuardReentrantCall",
+    "name": "SolvencyNotInDeficit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SolvencyStillInDeficit",
     "type": "error"
   },
   {
@@ -168,6 +290,22 @@
       }
     ],
     "name": "TimelockNotExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "projected",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cap",
+        "type": "uint256"
+      }
+    ],
+    "name": "TradeCapExceeded",
     "type": "error"
   },
   {
@@ -212,6 +350,18 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isHedge",
+        "type": "bool"
+      },
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "account",
         "type": "address"
@@ -254,6 +404,25 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "aum",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "AUMCacheUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "assetRegistry",
@@ -261,6 +430,38 @@
       }
     ],
     "name": "AssetRegistrySet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "hedgeCapBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tradeCapBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "AumCapsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "juniorVault",
+        "type": "address"
+      }
+    ],
+    "name": "AuthorizedJuniorVaultSet",
     "type": "event"
   },
   {
@@ -287,12 +488,56 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeUsd",
+        "type": "uint256"
+      }
+    ],
+    "name": "BorrowingFeeSettled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "registry",
         "type": "address"
       }
     ],
     "name": "ComplianceRegistrySet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "annualRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulative",
+        "type": "uint256"
+      }
+    ],
+    "name": "CumulativeBorrowingUpdated",
     "type": "event"
   },
   {
@@ -318,25 +563,6 @@
       }
     ],
     "name": "CumulativeFundingUpdated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "DebtSyncedWithHub",
     "type": "event"
   },
   {
@@ -404,6 +630,87 @@
       }
     ],
     "name": "DecreasePosition",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isHighLeverageLocked",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPremiumSurgeActive",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLPBoostActive",
+        "type": "bool"
+      }
+    ],
+    "name": "DefenseModeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "enum Vault.RevenueType",
+        "name": "rType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "seniorBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "juniorBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "protocolBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "DistributionConfigUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "frVolatilityFactorBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxDynamicBufferBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "slippageToleranceBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "DynamicBufferParamsUpdated",
     "type": "event"
   },
   {
@@ -510,6 +817,44 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shortCostRateWad",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "FRObservationRecorded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previous",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "next",
+        "type": "address"
+      }
+    ],
+    "name": "FeeRevenueStoreSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "token",
@@ -586,6 +931,143 @@
       {
         "indexed": true,
         "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingHedgedNotional",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgeADLTerminated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingHedgedNotional",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgeConverted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lowBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "highBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lowLeverageX",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "highLeverageX",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgePremiumParamsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "premiumUsd",
+        "type": "uint256"
+      }
+    ],
+    "name": "HedgePremiumSettled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "hedgeVault",
+        "type": "address"
+      }
+    ],
+    "name": "HedgeVaultSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
         "name": "key",
         "type": "bytes32"
       },
@@ -652,6 +1134,31 @@
       }
     ],
     "name": "KeeperSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "usdAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalBoostPoolUsd",
+        "type": "uint256"
+      }
+    ],
+    "name": "LPBoostDistributed",
     "type": "event"
   },
   {
@@ -739,6 +1246,25 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "bool",
+        "name": "isHedge",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newMax",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxLeverageUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "uint256",
         "name": "age",
         "type": "uint256"
@@ -817,49 +1343,23 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "oldHub",
+        "name": "vault",
         "type": "address"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "newHub",
-        "type": "address"
-      }
-    ],
-    "name": "PayoutHubChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newHub",
+        "name": "receiver",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "executableAt",
+        "name": "amount",
         "type": "uint256"
       }
     ],
-    "name": "PayoutHubProposed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "payoutHub",
-        "type": "address"
-      }
-    ],
-    "name": "PayoutHubSet",
+    "name": "PayoutSent",
     "type": "event"
   },
   {
@@ -984,6 +1484,31 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "bufferedYield",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalCost",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isDisabled",
+        "type": "bool"
+      }
+    ],
+    "name": "ProtocolSolvencyChecked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "token",
@@ -1072,6 +1597,55 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLong",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "RedemptionADLExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "uint8",
         "name": "level",
@@ -1079,6 +1653,68 @@
       }
     ],
     "name": "RequiredKYCLevelSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "ReserveFundWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "enum Vault.RevenueType",
+        "name": "rType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountUsd",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "seniorUsd",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "juniorUsd",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "protocolUsd",
+        "type": "uint256"
+      }
+    ],
+    "name": "RevenueAllocated",
     "type": "event"
   },
   {
@@ -1098,6 +1734,50 @@
       }
     ],
     "name": "RouterSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafetyBufferUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "SeniorYieldAbsorbed",
     "type": "event"
   },
   {
@@ -1173,6 +1853,106 @@
       }
     ],
     "name": "ShortfallSettled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulativeReduced",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingHedgedNotional",
+        "type": "uint256"
+      }
+    ],
+    "name": "SoftDeleveraged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "positionKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTotalHedgedNotional",
+        "type": "uint256"
+      }
+    ],
+    "name": "SoftLockRestored",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalCost",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalYield",
+        "type": "uint256"
+      }
+    ],
+    "name": "SolvencyDropRecorded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalCost",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalYield",
+        "type": "uint256"
+      }
+    ],
+    "name": "SolvencyRecovered",
     "type": "event"
   },
   {
@@ -1339,6 +2119,31 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "oldContrib",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newContrib",
+        "type": "uint256"
+      }
+    ],
+    "name": "YieldCacheRefreshed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "rwaAmount",
         "type": "uint256"
       },
@@ -1451,19 +2256,6 @@
   },
   {
     "inputs": [],
-    "name": "PAYOUT_HUB_TIMELOCK",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "PRICE_PRECISION",
     "outputs": [
       {
@@ -1502,15 +2294,31 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "acceptOwnership",
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "juniorVault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "absorbFRDeficitFromSeniorYield",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "acceptPayoutHub",
+    "name": "acceptOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1540,6 +2348,63 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "adapterLongOI",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "adapterMaxOI",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "adapterShortOI",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_account",
         "type": "address"
       },
@@ -1562,6 +2427,25 @@
     "name": "adlPosition",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowedAdapter",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1610,6 +2494,32 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "authorizedJuniorVault",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cachedStakedYieldUsdWad",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -1620,6 +2530,19 @@
     "name": "checkCompliance",
     "outputs": [],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      }
+    ],
+    "name": "checkProtocolSolvency",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1685,6 +2608,25 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "cumulativeBorrowingFactors",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1780,6 +2722,81 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "distributeLPBoost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum Vault.RevenueType",
+        "name": "rType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountUsd",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "distributeRevenue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum Vault.RevenueType",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "distributions",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "seniorBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "juniorBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "protocolBps",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "emergencyMode",
     "outputs": [
@@ -1790,6 +2807,39 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "executeHedgeADL",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1819,6 +2869,24 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32[]",
+        "name": "sortedKeys",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requiredReductionUsd",
+        "type": "uint256"
+      }
+    ],
+    "name": "executeSoftDeleveraging",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "",
         "type": "address"
@@ -1837,15 +2905,54 @@
   },
   {
     "inputs": [],
-    "name": "feeReservesLpShareBp",
+    "name": "feeRevenueStore",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "address",
         "name": "",
-        "type": "uint256"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "forceCloseForRedemption",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1885,6 +2992,32 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "frObservationInterval",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "frVolatilityFactorBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1928,6 +3061,72 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getAbsorbableYield",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllocationStatus",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "currentHedgeOI",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxHedgeOI",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "currentTradeOI",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxTradeOI",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      }
+    ],
+    "name": "getBorrowingFeeRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_indexToken",
         "type": "address"
       },
@@ -1957,6 +3156,34 @@
       {
         "internalType": "bool",
         "name": "hasProfit",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLiquidityStatus",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "juniorAUM",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netUPnL",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isCritical",
         "type": "bool"
       }
     ],
@@ -2049,6 +3276,38 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getPositionPriority",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRequiredBuffer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bufferBps",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "getTotalOI",
     "outputs": [
@@ -2085,6 +3344,129 @@
     "name": "harvestYield",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgeCapBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hedgeCollateralBalances",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgeMaxLeverage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgePremiumHighBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgePremiumHighLeverageX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgePremiumLowBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgePremiumLowLeverageX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hedgeVault",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "highLeverageLockThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -2139,11 +3521,141 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_collateralDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_convertOnADL",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_priceAdapter",
+        "type": "address"
+      }
+    ],
+    "name": "increasePositionWithAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isHedgeDisabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isHedgePosition",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isHighLeverageLocked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "juniorVault",
+        "type": "address"
+      }
+    ],
+    "name": "isJuniorCapReached",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
     ],
     "name": "isKeeper",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isLPBoostActive",
     "outputs": [
       {
         "internalType": "bool",
@@ -2168,6 +3680,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "isPremiumSurgeActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -2181,6 +3706,70 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isSoftLockedPosition",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastAUMUpdateTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "lastBorrowingTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastCachedAUM",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -2227,6 +3816,25 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "lastPremiumSettledAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "_account",
         "type": "address"
@@ -2258,6 +3866,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "lpBoostPool",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "lpManager",
     "outputs": [
@@ -2265,6 +3892,32 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxAUMCacheAge",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxDynamicBufferBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -2286,6 +3939,44 @@
   {
     "inputs": [],
     "name": "maxStalenessSpreadBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "minFeeRateBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "openedAt",
     "outputs": [
       {
         "internalType": "uint256",
@@ -2332,32 +4023,6 @@
   {
     "inputs": [],
     "name": "payoutBufferBps",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "payoutHub",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "payoutHubEarliestAccept",
     "outputs": [
       {
         "internalType": "uint256",
@@ -2430,19 +4095,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "pendingPayoutHub",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "address",
@@ -2461,6 +4113,44 @@
         "internalType": "uint64",
         "name": "executableAt",
         "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "positionAdapter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "positionSurgeBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -2510,6 +4200,11 @@
         "internalType": "int256",
         "name": "entryFundingRate",
         "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "entryBorrowingFactor",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -2542,19 +4237,6 @@
       }
     ],
     "name": "proposeExchangeRateChange",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_newHub",
-        "type": "address"
-      }
-    ],
-    "name": "proposePayoutHub",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2669,6 +4351,24 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      }
+    ],
+    "name": "recordHedgeDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
       },
       {
         "internalType": "address",
@@ -2677,6 +4377,19 @@
       }
     ],
     "name": "recordWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "refreshYieldCache",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2709,7 +4422,7 @@
         "type": "address"
       }
     ],
-    "name": "reservedAmounts",
+    "name": "reserveFund",
     "outputs": [
       {
         "internalType": "uint256",
@@ -2724,11 +4437,123 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "reservedAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "keys",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "restoreSoftDeleveraging",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "safetyBufferBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "setAdapterAllowed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxOI",
+        "type": "uint256"
+      }
+    ],
+    "name": "setAdapterMaxOI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_assetRegistry",
         "type": "address"
       }
     ],
     "name": "setAssetRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_hedgeCapBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tradeCapBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setAumCaps",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_juniorVault",
+        "type": "address"
+      }
+    ],
+    "name": "setAuthorizedJuniorVault",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2750,6 +4575,80 @@
     "inputs": [
       {
         "internalType": "bool",
+        "name": "_highLevLocked",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_premiumSurge",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_lpBoost",
+        "type": "bool"
+      }
+    ],
+    "name": "setDefenseMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum Vault.RevenueType",
+        "name": "rType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint16",
+        "name": "seniorBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "juniorBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "protocolBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "setDistributionConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_frVolatilityFactorBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxDynamicBufferBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_slippageToleranceBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDynamicBufferParams",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
         "name": "enabled",
         "type": "bool"
       }
@@ -2762,12 +4661,79 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "store",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeRevenueStore",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
-        "name": "_bps",
+        "name": "_seconds",
         "type": "uint256"
       }
     ],
-    "name": "setFeeReservesLpShareBp",
+    "name": "setFrObservationInterval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_lowBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_highBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_lowLeverageX",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_highLeverageX",
+        "type": "uint256"
+      }
+    ],
+    "name": "setHedgePremiumParams",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_hedgeVault",
+        "type": "address"
+      }
+    ],
+    "name": "setHedgeVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_threshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "setHighLeverageLockThreshold",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2806,6 +4772,24 @@
   {
     "inputs": [
       {
+        "internalType": "bool",
+        "name": "_isHedge",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_max",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxLeverage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_age",
         "type": "uint256"
@@ -2825,19 +4809,6 @@
       }
     ],
     "name": "setPayoutBufferBps",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_hub",
-        "type": "address"
-      }
-    ],
-    "name": "setPayoutHub",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -2890,6 +4861,55 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "_bps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSafetyBufferBps",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_multiplierBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minFeeBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSkewFeeConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_seconds",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSoftDeleveragingDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
         "name": "_rateBps",
         "type": "uint256"
       },
@@ -2900,6 +4920,19 @@
       }
     ],
     "name": "setStalenessPenalty",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_multiplierBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSurgePremiumMultiplier",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -3016,6 +5049,83 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "shouldConvertOnADL",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "skewFeeMultiplier",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "slippageToleranceBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "softDeleveragingDelay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "solvencyDropAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "stalenessPenaltyRateBps",
     "outputs": [
@@ -3029,21 +5139,16 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "token",
-        "type": "address"
-      },
+    "inputs": [],
+    "name": "surgePremiumMultiplierBps",
+    "outputs": [
       {
         "internalType": "uint256",
-        "name": "amount",
+        "name": "",
         "type": "uint256"
       }
     ],
-    "name": "syncDebtWithHub",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -3140,27 +5245,12 @@
   },
   {
     "inputs": [],
-    "name": "getLiquidityStatus",
+    "name": "totalGlobalOI",
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "totalBalance",
+        "name": "",
         "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "juniorAUM",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "netUPnL",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "isCritical",
-        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -3168,7 +5258,7 @@
   },
   {
     "inputs": [],
-    "name": "totalGlobalOI",
+    "name": "totalHedgedNotional",
     "outputs": [
       {
         "internalType": "uint256",
@@ -3269,6 +5359,32 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "tradeCapBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tradeMaxLeverage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -3302,6 +5418,26 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "updateAUMCache",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "updateCumulativeBorrowing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -3310,6 +5446,24 @@
       }
     ],
     "name": "updateCumulativeFunding",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "delta",
+        "type": "int256"
+      }
+    ],
+    "name": "updateHedgeBalance",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -3388,6 +5542,52 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawHedgeCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountUsd",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawReserveFund",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "yieldAccumulator",
     "outputs": [
@@ -3412,280 +5612,5 @@
     ],
     "stateMutability": "view",
     "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "shouldConvertOnADL",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_account",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_collateralToken",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_indexToken",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_isLong",
-        "type": "bool"
-      },
-      {
-        "internalType": "address",
-        "name": "_receiver",
-        "type": "address"
-      }
-    ],
-    "name": "executeHedgeADL",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "isHedgePosition",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "isSoftLockedPosition",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "positionKey",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "indexToken",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "size",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "remainingHedgedNotional",
-        "type": "uint256"
-      }
-    ],
-    "name": "HedgeADLTerminated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "positionKey",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "indexToken",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "size",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "remainingHedgedNotional",
-        "type": "uint256"
-      }
-    ],
-    "name": "HedgeConverted",
-    "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "isHedgeDisabled",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "safetyBufferBps",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "solvencyDropAt",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getRequiredBuffer",
-    "outputs": [{ "internalType": "uint256", "name": "bufferBps", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "isHighLeverageLocked",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "isPremiumSurgeActive",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "isLPBoostActive",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "name": "reserveFund",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "name": "lpBoostPool",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "name": "positionSurgeBps",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "_token", "type": "address" },
-      { "internalType": "uint256", "name": "_usdAmount", "type": "uint256" }
-    ],
-    "name": "distributeLPBoost",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bool", "name": "_highLevLocked", "type": "bool" },
-      { "internalType": "bool", "name": "_premiumSurge", "type": "bool" },
-      { "internalType": "bool", "name": "_lpBoost", "type": "bool" }
-    ],
-    "name": "setDefenseMode",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "token", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "usdAmount", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "totalBoostPoolUsd", "type": "uint256" }
-    ],
-    "name": "LPBoostDistributed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": false, "internalType": "bool", "name": "isHighLeverageLocked", "type": "bool" },
-      { "indexed": false, "internalType": "bool", "name": "isPremiumSurgeActive", "type": "bool" },
-      { "indexed": false, "internalType": "bool", "name": "isLPBoostActive", "type": "bool" }
-    ],
-    "name": "DefenseModeUpdated",
-    "type": "event"
   }
 ]


### PR DESCRIPTION
## 概要

Issue #227 のフロントエンド実装。Prism軸（Price / Yield / Total）のインデックスセレクターとスキューフィープレビューをトレードUIに追加。

## 変更内容

### `src/domain/vantage/vaults/vaultConfig.ts`
- `VaultConfig` に `adapterAddress?: string` を追加
- sUSDe_Price / sUSDe_Yield / sUSDe_Total の各設定に `adapterAddress`（`prismAdapters` デプロイJSONから）を追加

### `src/domain/vantage/trade/usePositionRouterTrade.ts`
- `IncreaseRequest` に `priceAdapter?: string` を追加
- `priceAdapter` が設定されている場合に `createIncreasePositionWithAdapter` を呼び出すブランチを追加

### `src/domain/vantage/positions/types.ts`
- `VantagePosition` に `priceAdapter: string` を追加（Prism以外は `address(0)`）

### `src/domain/vantage/positions/useVantagePositions.ts`
- `vault.positionAdapter(key)` をポジションごとにフェッチ

### `src/pages/Trade/components/OpenPositionPanel.tsx`
- Price / Yield / Total 軸セレクタータブを追加（`vaultConfig.prismAxis` がある場合）
- スキューフィープレビューブロック: Base Fee / Skew Adjustment（グリーン=リベート / レッド=ペナルティ）/ Total
- サブリミット容量プログレスバー

### `src/pages/Trade/TradePage.tsx`
- `TRADEABLE_VAULTS` フィルター: `prismAxis === undefined || prismAxis === "price"` のみ表示
- `vaultConfig={selectedVault}` を `OpenPositionPanel` に渡す

### `src/pages/Trade/components/UnifiedPositionList.tsx`
- `getPrismAxisLabel(adapterAddress)` ヘルパー
- アクティブポジション行にインジゴバッジを追加

### `src/pages/Portfolio/PortfolioPage.tsx`
- ポートフォリオページのAsset列にインジゴバッジを追加

## 含まれるコミット

- `feat(issue-221)`: sUSDe Interest Prism の vault configs 追加（Issue #227 の前提）
- `feat(issue-227)`: Index Selector + Skew Fee Display 本体

## 関連PR

- Solidity側: itchii-06/bcellar-monorepo#229

🤖 Generated with [Claude Code](https://claude.com/claude-code)